### PR TITLE
Add podspec

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -15,6 +15,9 @@ Pod::Spec.new do |spec|
   spec.source       = { :git => "https://github.com/RevenueCat/react-native-purchases.git" }
   spec.source_files = "ios/**/*.{h,m}"
 
+  # Ignore the downloaded Purchases.framework
+  spec.exclude_files = "ios/Purchases.framework"
+
   spec.dependency   "React"
   spec.dependency   "Purchases"
 end

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |spec|
+  spec.name         = "RNPurchases"
+  spec.summary      = "Cross-platform subscriptions framework for ReactNative"
+  spec.version      = package['version']
+
+  spec.authors      = package['author']
+  spec.homepage     = "https://github.com/RevenueCat/react-native-purchases"
+  spec.license      = package['license']
+  spec.platform     = :ios, "9.0"
+
+  spec.source       = { :git => "https://github.com/RevenueCat/react-native-purchases.git" }
+  spec.source_files = "ios/**/*.{h,m}"
+
+  spec.dependency   "React"
+  spec.dependency   "Purchases"
+end

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -2,7 +2,6 @@
 #import "RNPurchases.h"
 
 @import StoreKit;
-@import Purchases;
 
 #import "RCPurchaserInfo+RNPurchases.h"
 #import "RCEntitlement+RNPurchases.h"


### PR DESCRIPTION
Hi,

I added a podspec so the lib can be used with RN projects using CocoaPods to manage their dependencies.

People already using CocoaPods and running `react-native link react-native-purchases` will see it directly added to their `Podfile`.

I removed an `@import` statement which caused the CocoaPods build to fail. I believe it shouldn't break normal users not using CocoaPods, since `RNPurchases.h` already does `#import <Purchases/RCPurchases.h>` but let me know if it causes an issue. I haven't tested that scenario myself.

Cheers,