### PR TITLE
Fix unzip issue in framework download script

### DIFF
--- a/scripts/download-purchases-framework.sh
+++ b/scripts/download-purchases-framework.sh
@@ -25,9 +25,7 @@ if [ -d ./Purchases.framework ]; then
 fi
 
 curl -sSL $URL > temp.zip
-unzip -o temp.zip -d temp
-mv temp/Purchases.framework ./Purchases.framework
-rm -r temp
+unzip -o temp.zip
 rm temp.zip
 
 if ! [ -d ./Purchases.framework ]; then


### PR DESCRIPTION
Environment:
BusyBox v1.28.4 (2018-05-30 10:45:57 UTC) multi-call binary.

ERROR:
unzip: can't change directory to 'temp': No such file or directory