### PR TITLE
Fix crash on iOS < 10 as NSISO8601DateFormatter is unavailable there

### DIFF
--- a/ios/RCPurchaserInfo+RNPurchases.m
+++ b/ios/RCPurchaserInfo+RNPurchases.m
@@ -8,21 +8,18 @@
 
 #import "RCPurchaserInfo+RNPurchases.h"
 
-static id formatter;
+static NSDateFormatter *formatter;
 static dispatch_once_t onceToken;
 
 static NSString * stringFromDate(NSDate *date)
 {
     dispatch_once(&onceToken, ^{
-        if (@available(iOS 10.0, *)) {
-            formatter = [NSISO8601DateFormatter new];
-        } else {
-            NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-            dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
-            dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
-            dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
-            formatter = dateFormatter;
-        }
+        // Here we're not using NSISO8601DateFormatter as we need to support iOS < 10
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        dateFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"GMT"];
+        dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
+        dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        formatter = dateFormatter;
     });
 
     return [formatter stringFromDate:date];


### PR DESCRIPTION
Hi,

I got crashes on iOS 9.

I tracked it down to the use of `NSISO8601DateFormatter` which is only available starting iOS 10.
This lead to trying to insert nil strings in the dictionary and causing the actual crash.

Let me know what you think.