### PR TITLE
Create unzip folder before extracting.

### DIFF
--- a/scripts/download-purchases-framework.sh
+++ b/scripts/download-purchases-framework.sh
@@ -25,6 +25,8 @@ if [ -d ./Purchases.framework ]; then
 fi
 
 curl -sSL $URL > temp.zip
+# In some cases the temp folder can not be created by unzip, https://github.com/RevenueCat/react-native-purchases/issues/26
+mkdir -p temp
 unzip -o temp.zip -d temp
 mv temp/Purchases.framework ./Purchases.framework
 rm -r temp


### PR DESCRIPTION
For some reason unzip fails when installing on bitbucket pipelines. 

Creating the `temp` folder before unzipping resolves the problem.

#26 