### PR TITLE
Intro pricing in iOS

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNPurchasesMath.java
+++ b/android/src/main/java/com/reactlibrary/RNPurchasesMath.java
@@ -1,0 +1,39 @@
+package com.reactlibrary;
+
+// The functionality of this class has been extracted from Java 8 Math class
+class RNPurchasesMath {
+    /**
+     * Returns the sum of its arguments,
+     * throwing an exception if the result overflows an {@code int}.
+     *
+     * @param x the first value
+     * @param y the second value
+     * @return the result
+     * @throws ArithmeticException if the result overflows an int
+     */
+    static int addExact(int x, int y) {
+        int r = x + y;
+        // HD 2-12 Overflow if both arguments have the opposite sign of the result
+        if (((x ^ r) & (y ^ r)) < 0) {
+            throw new ArithmeticException("integer overflow");
+        }
+        return r;
+    }
+
+    /**
+     * Returns the sum of its arguments,
+     * throwing an exception if the result overflows a {@code long}.
+     *
+     * @param x the first value
+     * @param y the second value
+     * @return the result
+     * @throws ArithmeticException if the result overflows a long
+     */
+    static int multiplyExact(int x, int y) {
+        long r = (long)x * (long)y;
+        if ((int)r != r) {
+            throw new ArithmeticException("integer overflow");
+        }
+        return (int)r;
+    }
+}

--- a/android/src/main/java/com/reactlibrary/RNPurchasesModule.java
+++ b/android/src/main/java/com/reactlibrary/RNPurchasesModule.java
@@ -102,10 +102,24 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
         }
         map.putString("intro_price_string", detail.getIntroductoryPrice());
         map.putString("intro_price_period", detail.getIntroductoryPricePeriod());
+        if (detail.getIntroductoryPricePeriod() != null && !detail.getIntroductoryPricePeriod().isEmpty()) {
+            RNPurchasesPeriod period = RNPurchasesPeriod.parse(detail.getIntroductoryPricePeriod());
+            if (period.years > 0) {
+                map.putString("intro_price_period_unit", "YEAR");
+                map.putInt("intro_price_period_number_of_units", period.years);
+            } else if (period.months > 0) {
+                map.putString("intro_price_period_unit", "MONTH");
+                map.putInt("intro_price_period_number_of_units", period.months);
+            } else if (period.days > 0) {
+                map.putString("intro_price_period_unit", "DAY");
+                map.putInt("intro_price_period_number_of_units", period.days);
+            }
+        } else {
+            map.putString("intro_price_period_unit", "");
+            map.putString("intro_price_period_number_of_units", "");
+        }
         map.putString("intro_price_cycles", detail.getIntroductoryPriceCycles());
-
         map.putString("currency_code", detail.getPriceCurrencyCode());
-
         return map;
     }
 

--- a/android/src/main/java/com/reactlibrary/RNPurchasesPeriod.java
+++ b/android/src/main/java/com/reactlibrary/RNPurchasesPeriod.java
@@ -1,0 +1,107 @@
+package com.reactlibrary;
+
+import androidx.annotation.NonNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+// The functionality of this class has been extracted from Java 8 time package
+class RNPurchasesPeriod {
+    final int years;
+    final int months;
+    final int days;
+
+    private RNPurchasesPeriod(int years, int months, int days) {
+        this.years = years;
+        this.months = months;
+        this.days = days;
+    }
+
+    private static final RNPurchasesPeriod ZERO = new RNPurchasesPeriod(0, 0, 0);
+
+    private static final Pattern PATTERN =
+            Pattern.compile("([-+]?)P(?:([-+]?[0-9]+)Y)?(?:([-+]?[0-9]+)M)?(?:([-+]?[0-9]+)W)?(?:([-+]?[0-9]+)D)?", Pattern.CASE_INSENSITIVE);
+
+    private static RNPurchasesPeriod create(int years, int months, int days) {
+        if ((years | months | days) == 0) {
+            return ZERO;
+        }
+        return new RNPurchasesPeriod(years, months, days);
+    }
+
+    /**
+     * Obtains a {@code Period} from a text string such as {@code PnYnMnD}.
+     * <p>
+     * This will parse the string produced by {@code toString()} which is
+     * based on the ISO-8601 period formats {@code PnYnMnD} and {@code PnW}.
+     * <p>
+     * The string starts with an optional sign, denoted by the ASCII negative
+     * or positive symbol. If negative, the whole period is negated.
+     * The ASCII letter "P" is next in upper or lower case.
+     * There are then four sections, each consisting of a number and a suffix.
+     * At least one of the four sections must be present.
+     * The sections have suffixes in ASCII of "Y", "M", "W" and "D" for
+     * years, months, weeks and days, accepted in upper or lower case.
+     * The suffixes must occur in order.
+     * The number part of each section must consist of ASCII digits.
+     * The number may be prefixed by the ASCII negative or positive symbol.
+     * The number must parse to an {@code int}.
+     * <p>
+     * The leading plus/minus sign, and negative values for other units are
+     * not part of the ISO-8601 standard. In addition, ISO-8601 does not
+     * permit mixing between the {@code PnYnMnD} and {@code PnW} formats.
+     * Any week-based input is multiplied by 7 and treated as a number of days.
+     * <p>
+     * For example, the following are valid inputs:
+     * <pre>
+     *   "P2Y"             -- Period.ofYears(2)
+     *   "P3M"             -- Period.ofMonths(3)
+     *   "P4W"             -- Period.ofWeeks(4)
+     *   "P5D"             -- Period.ofDays(5)
+     *   "P1Y2M3D"         -- Period.of(1, 2, 3)
+     *   "P1Y2M3W4D"       -- Period.of(1, 2, 25)
+     *   "P-1Y2M"          -- Period.of(-1, 2, 0)
+     *   "-P1Y2M"          -- Period.of(-1, -2, 0)
+     * </pre>
+     *
+     * @param text  the text to parse, not null
+     * @return the parsed period, not null
+     * @throws RuntimeException if the text cannot be parsed to a period
+     */
+    static RNPurchasesPeriod parse(@NonNull CharSequence text) {
+        Matcher matcher = PATTERN.matcher(text);
+        if (matcher.matches()) {
+            int negate = ("-".equals(matcher.group(1)) ? -1 : 1);
+            String yearMatch = matcher.group(2);
+            String monthMatch = matcher.group(3);
+            String weekMatch = matcher.group(4);
+            String dayMatch = matcher.group(5);
+            if (yearMatch != null || monthMatch != null || dayMatch != null || weekMatch != null) {
+                try {
+                    int years = parseNumber(text, yearMatch, negate);
+                    int months = parseNumber(text, monthMatch, negate);
+                    int weeks = parseNumber(text, weekMatch, negate);
+                    int days = parseNumber(text, dayMatch, negate);
+                    days = RNPurchasesMath.addExact(days, RNPurchasesMath.multiplyExact(weeks, 7));
+                    return create(years, months, days);
+                } catch (NumberFormatException ex) {
+                    throw new RuntimeException("Text cannot be parsed to a Period: " + text, ex);
+                }
+            }
+        }
+        throw new RuntimeException("Text cannot be parsed to a Period: " + text);
+    }
+
+    private static int parseNumber(CharSequence text, String str, int negate) {
+        if (str == null) {
+            return 0;
+        }
+        int val = Integer.parseInt(str);
+        try {
+            return RNPurchasesMath.multiplyExact(val, negate);
+        } catch (ArithmeticException ex) {
+            throw new RuntimeException("Text cannot be parsed to a Period: " + text, ex);
+        }
+    }
+
+}

--- a/ios/SKProduct+RNPurchases.m
+++ b/ios/SKProduct+RNPurchases.m
@@ -23,15 +23,46 @@
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     formatter.numberStyle = NSNumberFormatterCurrencyStyle;
     formatter.locale = self.priceLocale;
-    NSDictionary *d = @{
+    NSMutableDictionary *d = [NSMutableDictionary dictionaryWithDictionary:@{
                         @"identifier": self.productIdentifier ?: @"",
                         @"description": self.localizedDescription ?: @"",
                         @"title": self.localizedTitle ?: @"",
                         @"price": @(self.price.floatValue),
                         @"price_string": [formatter stringFromNumber:self.price],
                         @"currency_code": (self.rc_currencyCode) ? self.rc_currencyCode : [NSNull null]
-                        };
+                        }];
+    
+    if (@available(iOS 11.2, *)) {
+        d[@"intro_price"] = @(self.introductoryPrice.price.floatValue) ?: @"";
+        if (self.introductoryPrice.price) {
+            d[@"intro_price_string"] = [formatter stringFromNumber:self.introductoryPrice.price];
+        } else {
+            d[@"intro_price_string"] = @"";
+        }
+        d[@"intro_price_period"] = [self normalizeSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod] ?: @"";
+        d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods) ?: @"";
+    } else {
+        d[@"intro_price"] = @"";
+        d[@"intro_price_string"] = @"";
+        d[@"intro_price_period"] = @"";
+        d[@"intro_price_cycles"] = @"";
+    }
+    
     return d;
+}
+
+- (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
+    switch (subscriptionPeriod.unit)
+    {
+        case SKProductPeriodUnitDay:
+            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"D"];;
+        case SKProductPeriodUnitWeek:
+            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"W"];;
+        case SKProductPeriodUnitMonth:
+            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"M"];;
+        case SKProductPeriodUnitYear:
+            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"Y"];;
+    }
 }
 
 @end

--- a/ios/SKProduct+RNPurchases.m
+++ b/ios/SKProduct+RNPurchases.m
@@ -32,28 +32,32 @@
                         @"currency_code": (self.rc_currencyCode) ? self.rc_currencyCode : [NSNull null]
                         }];
     
+    
     if (@available(iOS 11.2, *)) {
-        d[@"intro_price"] = @(self.introductoryPrice.price.floatValue) ?: @"";
-        if (self.introductoryPrice.price) {
-            d[@"intro_price_string"] = [formatter stringFromNumber:self.introductoryPrice.price];
-        } else {
-            d[@"intro_price_string"] = @"";
+        if (self.introductoryPrice) {
+            d[@"intro_price"] = @(self.introductoryPrice.price.floatValue) ?: @"";
+            if (self.introductoryPrice.price) {
+                d[@"intro_price_string"] = [formatter stringFromNumber:self.introductoryPrice.price];
+            } else {
+                d[@"intro_price_string"] = @"";
+            }
+            d[@"intro_price_period"] = [self normalizeSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod] ?: @"";
+            d[@"intro_price_period_unit"] = [self normalizeSubscriptionPeriodUnit:self.introductoryPrice.subscriptionPeriod.unit] ?: @"";
+            d[@"intro_price_period_number_of_units"] = @(self.introductoryPrice.subscriptionPeriod.numberOfUnits) ?: @"";
+            d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods) ?: @"";
+            return d;
         }
-        d[@"intro_price_period"] = [self normalizeSubscriptionPeriod:self.introductoryPrice.subscriptionPeriod] ?: @"";
-        d[@"intro_price_cycles"] = @(self.introductoryPrice.numberOfPeriods) ?: @"";
-    } else {
-        d[@"intro_price"] = @"";
-        d[@"intro_price_string"] = @"";
-        d[@"intro_price_period"] = @"";
-        d[@"intro_price_cycles"] = @"";
     }
+    d[@"intro_price"] = @"";
+    d[@"intro_price_string"] = @"";
+    d[@"intro_price_period"] = @"";
+    d[@"intro_price_cycles"] = @"";
     
     return d;
 }
 
 - (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
-    switch (subscriptionPeriod.unit)
-    {
+    switch (subscriptionPeriod.unit) {
         case SKProductPeriodUnitDay:
             return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"D"];;
         case SKProductPeriodUnitWeek:
@@ -62,6 +66,19 @@
             return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"M"];;
         case SKProductPeriodUnitYear:
             return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"Y"];;
+    }
+}
+
+- (NSString *)normalizeSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){
+    switch (subscriptionPeriodUnit) {
+        case SKProductPeriodUnitDay:
+            return @"DAY";
+        case SKProductPeriodUnitWeek:
+            return @"WEEK";
+        case SKProductPeriodUnitMonth:
+            return @"MONTH";
+        case SKProductPeriodUnitYear:
+            return @"YEAR";
     }
 }
 

--- a/ios/SKProduct+RNPurchases.m
+++ b/ios/SKProduct+RNPurchases.m
@@ -57,16 +57,18 @@
 }
 
 - (NSString *)normalizeSubscriptionPeriod:(SKProductSubscriptionPeriod *)subscriptionPeriod API_AVAILABLE(ios(11.2)){
+    NSString *unit;
     switch (subscriptionPeriod.unit) {
         case SKProductPeriodUnitDay:
-            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"D"];;
+            unit = @"D";
         case SKProductPeriodUnitWeek:
-            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"W"];;
+            unit = @"W";
         case SKProductPeriodUnitMonth:
-            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"M"];;
+            unit = @"M";
         case SKProductPeriodUnitYear:
-            return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), @"Y"];;
+            unit = @"Y";
     }
+    return [NSString stringWithFormat:@"%@%@%@", @"P", @(subscriptionPeriod.numberOfUnits), unit];
 }
 
 - (NSString *)normalizeSubscriptionPeriodUnit:(SKProductPeriodUnit)subscriptionPeriodUnit API_AVAILABLE(ios(11.2)){


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/react-native-purchases/issues/49

We have been sending introductory pricing for Android for a while, back we needed to add support to iOS. 

Android's `intro_price_period` returns the period in ISO8601 format (https://developer.android.com/reference/com/android/billingclient/api/SkuDetails.html#getintroductorypriceperiod) so we need to return the same format for iOS. To make things easier we also return `intro_price_period_unit` and a `intro_price_period_number_of_units`. For parsing ISO8601 to unit and number of units I have used the Java 8 implementation (cannot use Java 8 because our Android min version is 16).

