### PR TITLE
Exports interfaces and types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ declare enum INTRO_ELIGIBILITY_STATUS {
 /**
  * The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
-interface PurchasesEntitlementInfo {
+export interface PurchasesEntitlementInfo {
     /**
      * The entitlement identifier configured in the RevenueCat dashboard
      */
@@ -155,7 +155,7 @@ interface PurchasesEntitlementInfo {
 /**
  * Contains all the entitlements associated to the user.
  */
-interface PurchasesEntitlementInfos {
+export interface PurchasesEntitlementInfos {
     /**
      * Map of all EntitlementInfo (`PurchasesEntitlementInfo`) objects (active and inactive) keyed by entitlement identifier.
      */
@@ -169,7 +169,7 @@ interface PurchasesEntitlementInfos {
         [key: string]: PurchasesEntitlementInfo;
     };
 }
-interface PurchaserInfo {
+export interface PurchaserInfo {
     /**
      * Entitlements attached to this purchaser info
      */
@@ -221,7 +221,7 @@ interface PurchaserInfo {
      */
     readonly originalApplicationVersion: string | null;
 }
-interface PurchasesProduct {
+export interface PurchasesProduct {
     /**
      * Product Id.
      */
@@ -275,7 +275,7 @@ interface PurchasesProduct {
  * Contains information about the product available for the user to purchase.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesPackage {
+export interface PurchasesPackage {
     /**
      * Unique identifier for this package. Can be one a predefined package type or a custom one.
      */
@@ -297,7 +297,7 @@ interface PurchasesPackage {
  * An offering is a collection of Packages (`PurchasesPackage`) available for the user to purchase.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesOffering {
+export interface PurchasesOffering {
     /**
      * Unique identifier defined in RevenueCat dashboard.
      */
@@ -343,7 +343,7 @@ interface PurchasesOffering {
  * Contains all the offerings configured in RevenueCat dashboard.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesOfferings {
+export interface PurchasesOfferings {
     /**
      * Map of all Offerings [PurchasesOffering] objects keyed by their identifier.
      */
@@ -355,10 +355,16 @@ interface PurchasesOfferings {
      */
     readonly current: PurchasesOffering | null;
 }
+export interface PurchasesError {
+    code: number;
+    message: string;
+    readableErrorCode: string;
+    underlyingErrorMessage: string;
+}
 /**
  * Holds the information used when upgrading from another sku. For Android use only.
  */
-interface UpgradeInfo {
+export interface UpgradeInfo {
     /**
      * The oldSKU to upgrade from.
      */
@@ -371,7 +377,7 @@ interface UpgradeInfo {
 /**
  * Holds the introductory price status
  */
-interface IntroEligibility {
+export interface IntroEligibility {
     /**
      * The introductory price eligibility status
      */
@@ -386,8 +392,8 @@ interface IntroEligibility {
  * @callback PurchaserInfoUpdateListener
  * @param {Object} purchaserInfo Object containing info for the purchaser
  */
-declare type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
-declare type ShouldPurchasePromoProductListener = (deferredPurchase: () => MakePurchasePromise) => void;
+export declare type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
+export declare type ShouldPurchasePromoProductListener = (deferredPurchase: () => MakePurchasePromise) => void;
 declare type MakePurchasePromise = Promise<{
     productIdentifier: string;
     purchaserInfo: PurchaserInfo;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "3.0.4",
   "description": "",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "tsc",
     "preinstall": "node build.js",
@@ -11,7 +12,8 @@
     "demo.ios": "cd example; react-native run-ios",
     "demo.android": "cd example; react-native run-android",
     "setup.example": "rm -rf node_modules;rm -rf example/node_modules;yarn install; yarn link; cd example; yarn link react-native-purchases; yarn; cd ..;",
-    "tslint": "tslint -c tslint.json 'src/*.ts'"
+    "tslint": "tslint -c tslint.json 'src/*.ts'",
+    "prepublish": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ enum INTRO_ELIGIBILITY_STATUS {
 /**
  * The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
-interface PurchasesEntitlementInfo {
+export interface PurchasesEntitlementInfo {
   /**
    * The entitlement identifier configured in the RevenueCat dashboard
    */
@@ -182,7 +182,7 @@ interface PurchasesEntitlementInfo {
 /**
  * Contains all the entitlements associated to the user.
  */
-interface PurchasesEntitlementInfos {
+export interface PurchasesEntitlementInfos {
   /**
    * Map of all EntitlementInfo (`PurchasesEntitlementInfo`) objects (active and inactive) keyed by entitlement identifier.
    */
@@ -193,7 +193,7 @@ interface PurchasesEntitlementInfos {
   readonly active: { [key: string]: PurchasesEntitlementInfo };
 }
 
-interface PurchaserInfo {
+export interface PurchaserInfo {
   /**
    * Entitlements attached to this purchaser info
    */
@@ -242,7 +242,7 @@ interface PurchaserInfo {
   readonly originalApplicationVersion: string | null;
 }
 
-interface PurchasesProduct {
+export interface PurchasesProduct {
   /**
    * Product Id.
    */
@@ -297,7 +297,7 @@ interface PurchasesProduct {
  * Contains information about the product available for the user to purchase.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesPackage {
+export interface PurchasesPackage {
   /**
    * Unique identifier for this package. Can be one a predefined package type or a custom one.
    */
@@ -320,7 +320,7 @@ interface PurchasesPackage {
  * An offering is a collection of Packages (`PurchasesPackage`) available for the user to purchase.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesOffering {
+export interface PurchasesOffering {
   /**
    * Unique identifier defined in RevenueCat dashboard.
    */
@@ -367,7 +367,7 @@ interface PurchasesOffering {
  * Contains all the offerings configured in RevenueCat dashboard.
  * For more info see https://docs.revenuecat.com/docs/entitlements
  */
-interface PurchasesOfferings {
+export interface PurchasesOfferings {
   /**
    * Map of all Offerings [PurchasesOffering] objects keyed by their identifier.
    */
@@ -378,7 +378,7 @@ interface PurchasesOfferings {
   readonly current: PurchasesOffering | null;
 }
 
-interface PurchasesError {
+export interface PurchasesError {
   code: number;
   message: string;
   readableErrorCode: string;
@@ -388,7 +388,7 @@ interface PurchasesError {
 /**
  * Holds the information used when upgrading from another sku. For Android use only.
  */
-interface UpgradeInfo {
+export interface UpgradeInfo {
   /**
    * The oldSKU to upgrade from.
    */
@@ -402,7 +402,7 @@ interface UpgradeInfo {
 /**
  * Holds the introductory price status
  */
-interface IntroEligibility {
+export interface IntroEligibility {
   /**
    * The introductory price eligibility status
    */
@@ -418,8 +418,8 @@ interface IntroEligibility {
  * @callback PurchaserInfoUpdateListener
  * @param {Object} purchaserInfo Object containing info for the purchaser
  */
-type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
-type ShouldPurchasePromoProductListener = (deferredPurchase: () => MakePurchasePromise) => void;
+export type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
+export type ShouldPurchasePromoProductListener = (deferredPurchase: () => MakePurchasePromise) => void;
 type MakePurchasePromise = Promise<{ productIdentifier: string; purchaserInfo: PurchaserInfo; }>;
 
 let purchaserInfoUpdateListeners: PurchaserInfoUpdateListener[] = [];


### PR DESCRIPTION
Related https://github.com/RevenueCat/react-native-purchases/issues/72

We were not exporting the interfaces and types so they were not available for import. Also added types to the package.json, although it's not necessary since it's in the default location. Also added a prepublish to make sure we call `tsc` before publishing 