### PR TITLE
Changes package to com.revenuecat.purchases.react and fixes mainapplication

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary.rnpurchases">
+          package="com.revenuecat.purchases.react">
 
 </manifest>
   

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesConverters.kt
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesConverters.kt
@@ -1,4 +1,4 @@
-package com.reactlibrary.rnpurchases
+package com.revenuecat.purchases.react
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.rnpurchases;
+package com.revenuecat.purchases.react;
 
 import android.util.Log;
 
@@ -32,7 +32,7 @@ import java.util.Map;
 
 import kotlin.UninitializedPropertyAccessException;
 
-import static com.reactlibrary.rnpurchases.RNPurchasesConverters.convertMapToWriteableMap;
+import static com.revenuecat.purchases.react.RNPurchasesConverters.convertMapToWriteableMap;
 
 public class RNPurchasesModule extends ReactContextBaseJavaModule implements UpdatedPurchaserInfoListener {
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesPackage.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary.rnpurchases;
+package com.revenuecat.purchases.react;
 
 import androidx.annotation.NonNull;
 

--- a/example/android/app/src/main/java/com/revenuecat/purchases_sample/MainApplication.java
+++ b/example/android/app/src/main/java/com/revenuecat/purchases_sample/MainApplication.java
@@ -4,7 +4,7 @@ import android.app.Application;
 
 import com.facebook.react.ReactApplication;
 import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
-import com.reactlibrary.RNPurchasesPackage;
+import com.revenuecat.purchases.react.RNPurchasesPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;


### PR DESCRIPTION
Related to #114 

That PR forgot to change the reference in MainApplication. I also changed the package to ver `com.revenuecat.purchases.react` instead of `com.reactlibrary`