### PR TITLE
Fix missing parameter in purchaseProduct

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -193,12 +193,12 @@ describe("Purchases", () => {
 
     Purchases.makePurchase("onemonth_freetrial");
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", null, "subs");
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", null, "subs", null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     Purchases.makePurchase("onemonth_freetrial", "viejo", Purchases.PURCHASE_TYPE.INAPP);
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial",{ oldSKU: "viejo" }, Purchases.PURCHASE_TYPE.INAPP);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial",{ oldSKU: "viejo" }, Purchases.PURCHASE_TYPE.INAPP, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -212,14 +212,14 @@ describe("Purchases", () => {
 
     Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs");
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
     }, Purchases.PURCHASE_TYPE.INAPP)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", { oldSKU: "viejo" }, Purchases.PURCHASE_TYPE.INAPP);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", { oldSKU: "viejo" }, Purchases.PURCHASE_TYPE.INAPP, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     Purchases.purchaseProduct("onemonth_freetrial", {
@@ -227,7 +227,7 @@ describe("Purchases", () => {
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
     }, Purchases.PURCHASE_TYPE.INAPP)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", { oldSKU: "viejo", prorationMode: Purchases.PRORATION_MODE.DEFERRED}, Purchases.PURCHASE_TYPE.INAPP);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", { oldSKU: "viejo", prorationMode: Purchases.PRORATION_MODE.DEFERRED}, Purchases.PURCHASE_TYPE.INAPP, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -113,6 +113,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     public void purchaseProduct(final String productIdentifier,
                                 @Nullable final ReadableMap upgradeInfo,
                                 final String type,
+                                @Nullable final String discountTimestamp,
                                 final Promise promise) {
         CommonKt.purchaseProduct(
                 getCurrentActivity(),

--- a/example/app/screens/UpsellScreen.js
+++ b/example/app/screens/UpsellScreen.js
@@ -84,9 +84,9 @@ export default class UpsellScreen extends React.Component {
               <Button
                 color="#f2545b"
                 onPress={async () => {
-                  const product = this.state.offerings.current.annual.product.identifier;
+                  const aPackage = this.state.offerings.current.monthly;
                   try {
-                    const purchaseMade = await Purchases.purchaseProduct(product);
+                    const purchaseMade = await Purchases.purchasePackage(aPackage, {oldSKU: "old", prorationMode: Purchases.PRORATION_MODE.DEFERRED}, Purchases.PURCHASE_TYPE.SUBS);
                     checkIfPro(purchaseMade.purchaserInfo, this.props.navigation);
                   } catch (e) {
                     if (!e.userCancelled) {

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ var Purchases = /** @class */ (function () {
      */
     Purchases.purchaseProduct = function (productIdentifier, upgradeInfo, type) {
         if (type === void 0) { type = PURCHASE_TYPE.SUBS; }
-        return RNPurchases.purchaseProduct(productIdentifier, upgradeInfo, type).catch(function (error) {
+        return RNPurchases.purchaseProduct(productIdentifier, upgradeInfo, type, null).catch(function (error) {
             error.userCancelled = error.code === "1";
             throw error;
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -779,7 +779,8 @@ export default class Purchases {
     return RNPurchases.purchaseProduct(
       productIdentifier,
       upgradeInfo,
-      type
+      type,
+      null
     ).catch((error: any) => {
       error.userCancelled = error.code === "1";
       throw error;


### PR DESCRIPTION
There was a missing parameter when calling `RNPurchases.purchaseProduct`. Android was working because it was also missing it.

I reverted the example back and removed the discount stuff to keep it simple
