### PR TITLE
Update invalidatePurchaserInfoCache docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -724,8 +724,13 @@ export default class Purchases {
     static getPaymentDiscount(product: PurchasesProduct, discount: PurchasesDiscount): Promise<PurchasesPaymentDiscount | undefined>;
     /**
      * Invalidates the cache for purchaser information.
-     * This is useful for cases where purchaser information might have been updated outside of the app, like if a
-     * promotional subscription is granted through the RevenueCat dashboard.
+     * 
+     * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * using the cache properly.
+     * 
+     * This is useful for cases where purchaser information might have been updated outside of the
+     * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
     static invalidatePurchaserInfoCache(): void;
     /**

--- a/index.js
+++ b/index.js
@@ -448,8 +448,13 @@ var Purchases = /** @class */ (function () {
     };
     /**
      * Invalidates the cache for purchaser information.
-     * This is useful for cases where purchaser information might have been updated outside of the app, like if a
-     * promotional subscription is granted through the RevenueCat dashboard.
+     * 
+     * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+     * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+     * using the cache properly.
+     * 
+     * This is useful for cases where purchaser information might have been updated outside of the
+     * app, like if a promotional subscription is granted through the RevenueCat dashboard.
      */
     Purchases.invalidatePurchaserInfoCache = function () {
         RNPurchases.invalidatePurchaserInfoCache();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1011,6 +1011,11 @@ export default class Purchases {
 
   /**
    * Invalidates the cache for purchaser information.
+   *
+   * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
+   * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
+   * using the cache properly.
+   *
    * This is useful for cases where purchaser information might have been updated outside of the app, like if a
    * promotional subscription is granted through the RevenueCat dashboard.
    */


### PR DESCRIPTION
Invalidating the cache is simultaneously an advanced technique and attractive to beginners who might think they need to invalidate the cache on every app launch, so I added a link to our docs that explains how to work with the cache in normal circumstances.

This will update both index.ts, index.d.ts, and index.js.

See RevenueCat/purchases-ios#223