### PR TITLE
Fixes purchaseDiscountedPackage/purchaseDiscountedProduct

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -579,7 +579,7 @@ describe("Purchases", () => {
 
     Purchases.purchaseDiscountedProduct(aProduct, paymentDiscountStub)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, paymentDiscountStub.timestamp);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, paymentDiscountStub.timestamp.toString());
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 
@@ -621,7 +621,7 @@ describe("Purchases", () => {
       aPackage.identifier,
       aPackage.offeringIdentifier,
       null,
-      paymentDiscountStub.timestamp
+      paymentDiscountStub.timestamp.toString()
     );
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isUTCDateStringFuture = exports.INTRO_ELIGIBILITY_STATUS = exports.PACKAGE_TYPE = exports.PRORATION_MODE = exports.PURCHASE_TYPE = exports.ATTRIBUTION_NETWORK = void 0;
 // @ts-ignore
 var react_native_1 = require("react-native");
 var RNPurchases = react_native_1.NativeModules.RNPurchases;
@@ -292,7 +293,7 @@ var Purchases = /** @class */ (function () {
         if (typeof discount === "undefined" || discount == null) {
             throw new Error("A discount is required");
         }
-        return RNPurchases.purchaseProduct(product.identifier, null, null, discount.timestamp).catch(function (error) {
+        return RNPurchases.purchaseProduct(product.identifier, null, null, discount.timestamp.toString()).catch(function (error) {
             error.userCancelled = error.code === "1";
             throw error;
         });
@@ -326,7 +327,7 @@ var Purchases = /** @class */ (function () {
         if (typeof discount === "undefined" || discount == null) {
             throw new Error("A discount is required");
         }
-        return RNPurchases.purchasePackage(aPackage.identifier, aPackage.offeringIdentifier, null, discount.timestamp).catch(function (error) {
+        return RNPurchases.purchasePackage(aPackage.identifier, aPackage.offeringIdentifier, null, discount.timestamp.toString()).catch(function (error) {
             error.userCancelled = error.code === "1";
             throw error;
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -828,7 +828,7 @@ export default class Purchases {
       product.identifier,
       null,
       null,
-      discount.timestamp
+      discount.timestamp.toString()
     ).catch((error: any) => {
       error.userCancelled = error.code === "1";
       throw error;
@@ -880,7 +880,7 @@ export default class Purchases {
       aPackage.identifier,
       aPackage.offeringIdentifier,
       null,
-      discount.timestamp
+      discount.timestamp.toString()
     ).catch((error: any) => {
       error.userCancelled = error.code === "1";
       throw error;


### PR DESCRIPTION
We were passing a number instead of the expected string. The common files expect a string so I figured the easiest would be to just convert it in the JS level since we can't have nullable Integers as parameters in the React Native module.

https://github.com/RevenueCat/react-native-purchases/blob/develop/ios/RNPurchases.m#L111 