### PR TITLE
Removes usage of BuildConfig

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -40,6 +40,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     private static final String PURCHASER_INFO_UPDATED = "Purchases-PurchaserInfoUpdated";
     public static final String PLATFORM_NAME = "react-native";
+    public static final String PLUGIN_VERSION = "3.3.2";
 
     private final ReactApplicationContext reactContext;
 
@@ -67,7 +68,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     public void setupPurchases(String apiKey, @Nullable String appUserID,
                                boolean observerMode, @Nullable String userDefaultsSuiteName,
                                final Promise promise) {
-        PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, BuildConfig.VERSION_NAME);
+        PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         CommonKt.configure(reactContext, apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedPurchaserInfoListener(this);
         promise.resolve(null);


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/react-native-purchases/issues/170

Looks like something changed in Android plugin 4.1.0 that we can't access BuildConfig. 

I figured the easiest would be to just hardcode the version directly, like we do in other plugins.