### PR TITLE
Adds an empty swift file and excludes PurchasesHybridCommon.framework

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |spec|
   spec.dependency   "React"
   spec.dependency   "PurchasesHybridCommon", "1.4.3"
   spec.static_framework = true
-  s.swift_version       = '5.0'
+  spec.swift_version    = '5.0'
 end

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -21,4 +21,5 @@ Pod::Spec.new do |spec|
   spec.dependency   "React"
   spec.dependency   "PurchasesHybridCommon", "1.4.3"
   spec.static_framework = true
+  s.swift_version       = '5.0'
 end

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.platform     = :ios, "9.0"
 
   spec.source       = { :git => "https://github.com/RevenueCat/react-native-purchases.git" }
-  spec.source_files = "ios/**/*.{h,m}"
+  spec.source_files = "ios/**/*.{h,m,swift}"
 
   # Ignore the downloaded Purchases.framework
   spec.exclude_files = "ios/Purchases.framework"

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -16,8 +16,10 @@ Pod::Spec.new do |spec|
   spec.source_files = "ios/**/*.{h,m,swift}"
 
   # Ignore the downloaded Purchases.framework
-  spec.exclude_files = "ios/Purchases.framework"
-  spec.exclude_files = "ios/PurchasesHybridCommon.framework"
+  spec.exclude_files = [
+    "ios/Purchases.framework",
+    "ios/PurchasesHybridCommon.framework"
+  ]
 
   spec.dependency   "React"
   spec.dependency   "PurchasesHybridCommon", "1.4.3"

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |spec|
 
   # Ignore the downloaded Purchases.framework
   spec.exclude_files = "ios/Purchases.framework"
+  spec.exclude_files = "ios/PurchasesHybridCommon.framework"
 
   spec.dependency   "React"
   spec.dependency   "PurchasesHybridCommon", "1.4.3"

--- a/ios/PurchasesPlugin.swift
+++ b/ios/PurchasesPlugin.swift
@@ -1,0 +1,9 @@
+//
+//  PurchasesPlugin.swift
+//  RNPurchases
+//
+//  Created by César de la Vega  on 10/6/20.
+//  Copyright © 2020 Facebook. All rights reserved.
+//
+
+import Foundation

--- a/ios/RNPurchases-Bridging-Header.h
+++ b/ios/RNPurchases-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/ios/RNPurchases.xcodeproj/project.pbxproj
+++ b/ios/RNPurchases.xcodeproj/project.pbxproj
@@ -7,8 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		35D0736B20AD0F740012EB8C /* Purchases.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35D0736A20AD0F740012EB8C /* Purchases.framework */; };
+		3552B97D252CF5900098008A /* PurchasesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3552B97C252CF5900098008A /* PurchasesPlugin.swift */; };
 		35BFF4DC247DDAD3008B64DA /* PurchasesHybridCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35BFF4DB247DDAD3008B64DA /* PurchasesHybridCommon.framework */; };
+		35D0736B20AD0F740012EB8C /* Purchases.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35D0736A20AD0F740012EB8C /* Purchases.framework */; };
 		B3E7B58A1CC2AC0600A0062D /* RNPurchases.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNPurchases.m */; };
 /* End PBXBuildFile section */
 
@@ -26,8 +27,10 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNPurchases.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPurchases.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		35D0736A20AD0F740012EB8C /* Purchases.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Purchases.framework; sourceTree = SOURCE_ROOT; };
+		3552B97B252CF5900098008A /* RNPurchases-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNPurchases-Bridging-Header.h"; sourceTree = "<group>"; };
+		3552B97C252CF5900098008A /* PurchasesPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesPlugin.swift; sourceTree = "<group>"; };
 		35BFF4DB247DDAD3008B64DA /* PurchasesHybridCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PurchasesHybridCommon.framework; sourceTree = "<group>"; };
+		35D0736A20AD0F740012EB8C /* Purchases.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Purchases.framework; sourceTree = SOURCE_ROOT; };
 		B3E7B5881CC2AC0600A0062D /* RNPurchases.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPurchases.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNPurchases.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPurchases.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -63,12 +66,14 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				3552B97C252CF5900098008A /* PurchasesPlugin.swift */,
 				35D0736A20AD0F740012EB8C /* Purchases.framework */,
 				35BFF4DB247DDAD3008B64DA /* PurchasesHybridCommon.framework */,
 				B3E7B5881CC2AC0600A0062D /* RNPurchases.h */,
 				B3E7B5891CC2AC0600A0062D /* RNPurchases.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				35493AC8202D4BCD004DFA39 /* Frameworks */,
+				3552B97B252CF5900098008A /* RNPurchases-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -103,6 +108,7 @@
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 1200;
 					};
 				};
 			};
@@ -131,6 +137,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNPurchases.m in Sources */,
+				3552B97D252CF5900098008A /* PurchasesPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -221,6 +228,7 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -231,16 +239,21 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPurchases;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "RNPurchases-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -251,10 +264,13 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPurchases;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "RNPurchases-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- Adds `"ios/PurchasesHybridCommon.framework"` to the list of excluded files to avoid duplicated symbols errors
- Adds an empty swift file to the plugin and specifies the Swift Version in the podspec. I haven't seen this fixing the build errors in React Native 0.61.5 (possibly in more versions), but I don't think it hurts.
- Looks like the app won't compile until a swift file is added to the iOS project. In React Native 0.63.3 everything works fine.