### PR TITLE
fix: xCode 12 compatibility

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |spec|
     "ios/PurchasesHybridCommon.framework"
   ]
 
-  spec.dependency   "React"
+  spec.dependency   "React-Core"
   spec.dependency   "PurchasesHybridCommon", '1.4.5'
   spec.swift_version    = '5.0'
 end


### PR DESCRIPTION
Xcode 12 fails to build when using use_frameworks! in the Podfile. See: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116