### PR TITLE
remove build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,6 @@ def getExtOrIntegerDefault(name) {
 
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
-    buildToolsVersion getExtOrDefault('buildToolsVersion')
 
     defaultConfig {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')


### PR DESCRIPTION
Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.
