### PR TITLE
Scripts for increasing versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ examples/purchaseTester/.vscode/
 #
 examples/purchaseTester/ios/Pods
 examples/purchaseTester/ios/test_output
+
+**/*.bck

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,10 @@
-1. Update to the latest SDK versions in `scripts/build.js`, `RNPurchases.podspec` and `android/build.gradle`.
+1. Run `./scripts/update-hybrid-common.sh x.x.x` to update to the latest SDK versions in `scripts/build.js`, `RNPurchases.podspec` and `android/build.gradle`.
 1. Update versions in VERSIONS.md.
-1. Update version in `package.json`.
-1. Update `platformFlavorVersion` in `RNPurchases.m`.
-1. Update versionName in `android/build.gradle`.
+1. Run `./scripts/prepare-for-release.sh x.x.x` to update version in `package.json`, `platformFlavorVersion` in `RNPurchases.m` and versionName in `android/build.gradle`.
 1. Add an entry to CHANGELOG.md
 1. Run `npm run build`
 1. `git commit -am "Preparing for version x.y.z"`
 1. `git tag x.y.z`
-1. `git push origin master && git push --tags`
+1. `git push origin --tags`
 1. Create a new release in github and upload
 1. `npm publish`

--- a/scripts/prepare-for-release.sh
+++ b/scripts/prepare-for-release.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+PREVIOUS_VERSION=$(awk -F\" '/"version":/ {print $4}' package.json)
+NEW_VERSION=$1
+
+sed -i.bck "s/$PREVIOUS_VERSION/$NEW_VERSION/" package.json
+sed -i.bck "s/$PREVIOUS_VERSION/$NEW_VERSION/" ios/RNPurchases.m
+sed -i.bck "s/$PREVIOUS_VERSION/$NEW_VERSION/" android/build.gradle
+
+yarn example
+pushd examples/purchaseTester
+npx pod-install
+popd

--- a/scripts/update-hybrid-common.sh
+++ b/scripts/update-hybrid-common.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+PREVIOUS_VERSION=$(cat RNPurchases.podspec | grep '"PurchasesHybridCommon", ' | awk '{print($3)}' | sed "s/'//g")
+PREVIOUS_IOS_POD_VERSION=$(cat examples/purchaseTester/ios/Podfile.lock | grep ' Purchases (=' | awk '{print($4)}' | sed "s/)//g")
+
+NEW_VERSION=$1
+
+echo "Updating from $PREVIOUS_VERSION"
+
+sed -i.bck "s/$PREVIOUS_VERSION/$NEW_VERSION/" RNPurchases.podspec
+sed -i.bck "s/$PREVIOUS_VERSION/$NEW_VERSION/" android/build.gradle
+
+yarn example
+pushd examples/purchaseTester/ios
+pod update PurchasesHybridCommon
+popd
+
+NEW_IOS_POD_VERSION=$(cat examples/purchaseTester/ios/Podfile.lock | grep ' Purchases (=' | awk '{print($4)}' | sed "s/)//g")
+echo "Updating Purchases from $PREVIOUS_IOS_POD_VERSION to $NEW_IOS_POD_VERSION"
+
+sed -i.bck "s/download-purchases-framework.sh $PREVIOUS_IOS_POD_VERSION/download-purchases-framework.sh $NEW_IOS_POD_VERSION/" scripts/build.js
+sed -i.bck "s/download-purchases-common.sh $PREVIOUS_VERSION/download-purchases-common.sh $NEW_VERSION/" scripts/build.js


### PR DESCRIPTION
We've had a couple instances where we didn't increase the versions numbers correctly. I created a couple scripts for increasing purchases-hybrid-common version and to increase the version number of the plugin when preparing a new release.