### PR TITLE
Fix `PurchasesEntitlementInfo.store` type

### DIFF
--- a/src/purchaserInfo.ts
+++ b/src/purchaserInfo.ts
@@ -33,10 +33,9 @@ export interface PurchasesEntitlementInfo {
      */
     readonly expirationDate: string | null;
     /**
-     * The store where this entitlement was unlocked from. Either: appStore, macAppStore, playStore, stripe,
-     * promotional, unknownStore
+     * The store where this entitlement was unlocked from.
      */
-    readonly store: string;
+    readonly store: "PLAY_STORE" | "APP_STORE" | "STRIPE" | "MAC_APP_STORE" | "PROMOTIONAL";
     /**
      * The product identifier that unlocked this entitlement
      */


### PR DESCRIPTION
Remove the misleading comment and improve the type of `PurchasesEntitlementInfo.store`

## Issue
#295 

## Additional information
The list of values are from https://docs.revenuecat.com/docs/webhooks