### PR TITLE
Fix error on cancelling purchase

### DIFF
--- a/examples/MagicWeather/src/components/PackageItem/index.js
+++ b/examples/MagicWeather/src/components/PackageItem/index.js
@@ -23,7 +23,7 @@ const PackageItem = ({ purchasePackage, setIsPurchasing }) => {
       }
     } catch (e) {
       if (!e.userCancelled) {
-        Alert.alert('Error purchasing package', e);
+        Alert.alert('Error purchasing package', e.message);
       }
     } finally {
       setIsPurchasing(false);


### PR DESCRIPTION
Cancelling a purchase causes an error as the whole Error object is passed as a description tot Alert.