### PR TITLE
Fix types of getAppUserId

### DIFF
--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -448,9 +448,9 @@ export default class Purchases {
 
     /**
      * Get the appUserID
-     * @returns {string} The app user id in a promise
+     * @returns {Promise<string>} The app user id in a promise
      */
-    public static getAppUserID(): string {
+    public static getAppUserID(): Promise<string> {
         return RNPurchases.getAppUserID();
     }
 


### PR DESCRIPTION
Similar to `isAnonymous` (fixed in https://github.com/RevenueCat/react-native-purchases/pull/302 ), the returned type of `getAppUserId` is incorrect and should be a `Promise<string>` instead of a `string`
