### PR TITLE
Fix Expo SDK 44 compatibility

### DIFF
--- a/ios/RNPurchases.h
+++ b/ios/RNPurchases.h
@@ -3,11 +3,7 @@
 //  Copyright © 2019 RevenueCat. All rights reserved.
 //
 
-#if __has_include("RCTEventEmitter.h")
-#import "RCTEventEmitter.h"
-#else
 #import <React/RCTEventEmitter.h>
-#endif
 
 #import <Purchases/RCPurchases.h>
 #import <PurchasesHybridCommon/PurchasesHybridCommon.h>


### PR DESCRIPTION
# Issue

The current version of react-native-purchases does not build in a Expo SDK 44 project because of duplicate symbols.

```
› Compiling react-native-purchases Pods/RNPurchases » PurchasesPlugin.swift

❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:14:1)

  12 |  * events to be observed by JS.
  13 |  */
> 14 | @interface RCTEventEmitter : NSObject <RCTBridgeModule, RCTInvalidating>
     | ^ duplicate interface definition for class 'RCTEventEmitter'
  15 | 
  16 | @property (nonatomic, weak) RCTBridge *bridge;
  17 | @property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;


❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:16:40)

  14 | @interface RCTEventEmitter : NSObject <RCTBridgeModule, RCTInvalidating>
  15 | 
> 16 | @property (nonatomic, weak) RCTBridge *bridge;
     |                                        ^ property has a previous declaration
  17 | @property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;
  18 | @property (nonatomic, weak) RCTViewRegistry *viewRegistry_DEPRECATED;
  19 | 


❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:17:48)

  15 | 
  16 | @property (nonatomic, weak) RCTBridge *bridge;
> 17 | @property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;
     |                                                ^ property has a previous declaration
  18 | @property (nonatomic, weak) RCTViewRegistry *viewRegistry_DEPRECATED;
  19 | 
  20 | - (instancetype)initWithDisabledObservation;


❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/React-Core/React/RCTEventEmitter.h:18:46)

  16 | @property (nonatomic, weak) RCTBridge *bridge;
  17 | @property (nonatomic, weak) RCTModuleRegistry *moduleRegistry;
> 18 | @property (nonatomic, weak) RCTViewRegistry *viewRegistry_DEPRECATED;
     |                                              ^ property has a previous declaration
  19 | 
  20 | - (instancetype)initWithDisabledObservation;
  21 | 


❌  (/Users/yonom/Documents/GitHub/app/ios/Pods/Headers/Public/RNPurchases/RNPurchases.h:15:26)

  13 | #import <PurchasesHybridCommon/PurchasesHybridCommon.h>
  14 | 
> 15 | @interface RNPurchases : RCTEventEmitter <RCTBridgeModule>
     |                          ^ definition of 'RCTEventEmitter' must be imported from module 'React.RCTEventEmitter' before it is required
  16 | 
  17 | @end
  18 | 

```

# Why

Expo SDK 44 requires importing react headers with `#import <React/*.h>` due to swift compatibility reasons. 

For more information: https://github.com/expo/expo/issues/15622#issuecomment-997141629

# Fix

Remove the usage of `#import "RCTEventEmitter.h"`
