### PR TITLE
A fix for the duplicate interfaces error

### DIFF
--- a/ios/RNPurchases.h
+++ b/ios/RNPurchases.h
@@ -3,12 +3,8 @@
 //  Copyright © 2019 RevenueCat. All rights reserved.
 //
 
-#if __has_include("RCTEventEmitter.h")
-#import "RCTEventEmitter.h"
-#else
+#import <React/RCTAppState.h>
 #import <React/RCTEventEmitter.h>
-#endif
-
 #import <Purchases/RCPurchases.h>
 #import <PurchasesHybridCommon/PurchasesHybridCommon.h>
 


### PR DESCRIPTION
**Why I'm contributing**
We're having issues with RNPurchases + newer Expo versions (>41) using expo modules. This is a problem for us, but also for large part of the user base for this package since most of the React Native landscape is utilizing Expo when building their apps (it's the de facto standard and also the reccomended way from RN per Dec' 2021).

The ios build fails due to `duplicate interface definition for class 'RCTEventEmitter'´. The change suggested fixed in this PR fixes this error and the app builds successfully, but I'm not an iOS dev, and there might be side-effects to my fix that I'm not aware of.

An issue exists for this, but it has been closed a while ago: #160 