### PR TITLE
Update to gen2 circleCI machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,8 @@ jobs:
   ios:
     executor:
       name: rn/macos
-      xcode_version: 12.5.0
+      resource_class: macos.x86.medium.gen2
+      xcode_version: 13.2.0
     steps:
       - checkout
       - rn/ios_simulator_start:


### PR DESCRIPTION
Updates to use [new executor type](https://circleci.com/docs/2.0/executor-types/#using-macos).

I also upgraded Xcode to 13.2.0

| Before | After |
|--------|------|
| <img width="526" alt="Screen Shot 2022-01-03 at 3 14 56 PM" src="https://user-images.githubusercontent.com/664544/147940853-c74f3a5a-8479-48bf-9762-decd316fffd1.png"> | <img width="642" alt="Screen Shot 2022-01-03 at 3 13 52 PM" src="https://user-images.githubusercontent.com/664544/147940716-91d273bf-f205-496d-8895-222343b76d4e.png"> |
| <img width="402" alt="Screen Shot 2022-01-03 at 3 08 09 PM" src="https://user-images.githubusercontent.com/664544/147940165-f46e51cc-926e-4f13-bd5c-85fef9c658f3.png"> | <img width="408" alt="Screen Shot 2022-01-03 at 3 13 21 PM" src="https://user-images.githubusercontent.com/664544/147940675-81d90c85-d1e1-4ad3-b348-21783d172f33.png"> |

