### PR TITLE
Setup local testing for PurchaseTester Typescript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
           pod_install_directory: examples/purchaseTester/ios
       - rn/pod_install:
           pod_install_directory: examples/purchaseTesterTypescript/ios
+      - rn/yarn_install:
+          cache_folder: ~/.cache/yarn
       - rn/ios_build:
           build_configuration: Release
           device: iPhone 11 Pro

--- a/examples/purchaseTesterTypescript/android/settings.gradle
+++ b/examples/purchaseTesterTypescript/android/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'PurchaseTester'
+
 include ':react-native-purchases'
-project(':react-native-purchases').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-purchases/android')
+project(':react-native-purchases').projectDir = new File(rootProject.projectDir, '../../../android')
+
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -50,7 +50,10 @@ const HomeScreen: React.FC<Props> = ({
     // currently passing fetchData to components and screens
     // so everything can be refreshed
     Purchases.addPurchaserInfoUpdateListener(fetchData);
-    fetchData();
+
+    // Oddly the cleanest way to call an async function
+    // from a non-asyn function
+    setTimeout(fetchData, 1)
   }, []);
 
   // Gets purchaser info, app user id, if user is anonymous, and offerings

--- a/examples/purchaseTesterTypescript/ios/Podfile
+++ b/examples/purchaseTesterTypescript/ios/Podfile
@@ -4,9 +4,6 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, '11.0'
 
 target 'PurchaseTester' do
-  # Pods for ReactNativeSample
-  pod 'RNPurchases', :path => '../../../'
-  
   config = use_native_modules!
 
   use_react_native!(

--- a/examples/purchaseTesterTypescript/ios/Podfile.lock
+++ b/examples/purchaseTesterTypescript/ios/Podfile.lock
@@ -408,7 +408,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNPurchases (from `../../../`)
+  - RNPurchases (from `../../..`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
@@ -494,7 +494,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNPurchases:
-    :path: "../../../"
+    :path: "../../.."
   RNScreens:
     :path: "../node_modules/react-native-screens"
   Yoga:
@@ -552,6 +552,6 @@ SPEC CHECKSUMS:
   Yoga: e7dc4e71caba6472ff48ad7d234389b91dadc280
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 33ed4a8d19e916379fff8d32a64e33f1b80d7738
+PODFILE CHECKSUM: cd6af7a9d5d8dd302a106b9b100d159909f7f592
 
 COCOAPODS: 1.11.2

--- a/examples/purchaseTesterTypescript/metro.config.js
+++ b/examples/purchaseTesterTypescript/metro.config.js
@@ -5,13 +5,28 @@
  * @format
  */
 
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    }),
-  },
-};
+ const packagePath = require('path').resolve('../../');
+ 
+ module.exports = {
+   resolver: {
+     nodeModulesPaths: [packagePath], // replace 'react-native-purchases` in the package.json
+     resolverMainFields: ['source', 'react-native', 'main'], // will first look the source then main
+     // source is needed for 'react-native-purchases`
+     // main is needed for node_module deps
+     // BUT we also need to make sure `npm install` is run in the `react-native-purchases` directory
+   },
+
+   watchFolders: [
+     packagePath // metro will update when something is changed
+   ],
+ 
+   transformer: {
+     getTransformOptions: async () => ({
+       transform: {
+         experimentalImportSupport: false,
+         inlineRequires: true,
+       },
+     }),
+   },
+ };
+ 

--- a/examples/purchaseTesterTypescript/metro.config.js
+++ b/examples/purchaseTesterTypescript/metro.config.js
@@ -5,19 +5,27 @@
  * @format
  */
 
- const packagePath = require('path').resolve('../../');
+// IMPORTANT
+// Make sure `npm install` is run in this refernced package's directory
+// This package will be looking for node_modules in its own directory
+const packagePath = require('path').resolve('../../');
  
  module.exports = {
    resolver: {
-     nodeModulesPaths: [packagePath], // replace 'react-native-purchases` in the package.json
+     // Tells metro to look at for `react-native-purchases`
+     // This fixes issues with referencing file in package.json which 
+     // creates a symlink and metro can't handle symlinks
+     nodeModulesPaths: [packagePath], 
+
+     // Tells metro to first look in the package.json's source,then react-native then main
+     // This is needed so that metro uses the 'source' for `react-native-purchases` and
+     // not the 'dist'
      resolverMainFields: ['source', 'react-native', 'main'], // will first look the source then main
-     // source is needed for 'react-native-purchases`
-     // main is needed for node_module deps
-     // BUT we also need to make sure `npm install` is run in the `react-native-purchases` directory
    },
 
+   // Metro will automatically update when something is changed in this path
    watchFolders: [
-     packagePath // metro will update when something is changed
+     packagePath
    ],
  
    transformer: {

--- a/examples/purchaseTesterTypescript/metro.config.js
+++ b/examples/purchaseTesterTypescript/metro.config.js
@@ -6,7 +6,7 @@
  */
 
 // IMPORTANT
-// Make sure `npm install` is run in this refernced package's directory
+// Make sure `npm install` is run in this referenced package's directory
 // This package will be looking for node_modules in its own directory
 const packagePath = require('path').resolve('../../');
  

--- a/examples/purchaseTesterTypescript/package.json
+++ b/examples/purchaseTesterTypescript/package.json
@@ -15,7 +15,6 @@
     "@react-navigation/native-stack": "^6.2.5",
     "react": "17.0.2",
     "react-native": "0.66.4",
-    "react-native-purchases": "^4.5.0",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.1"
   },

--- a/examples/purchaseTesterTypescript/react-native.config.js
+++ b/examples/purchaseTesterTypescript/react-native.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    dependencies: {
+        'react-native-purchases': {
+            root: require('path').resolve("../../../")
+        },
+    },
+};

--- a/examples/purchaseTesterTypescript/react-native.config.js
+++ b/examples/purchaseTesterTypescript/react-native.config.js
@@ -1,5 +1,8 @@
 module.exports = {
     dependencies: {
+        // This is used for auto linking because `react-native link <dep>` will
+        // soon be deprecated 
+        // This is essentiallly an auto linking definition for local dependencies
         'react-native-purchases': {
             root: require('path').resolve("../../../")
         },


### PR DESCRIPTION
Follow up to https://github.com/RevenueCat/react-native-purchases/pull/320

## Motivation
Use local repo for `react-native-purchases` instead of pointing to published version to use for local development

## Description
- New `react-native.config.js` to define local decency for auto linking
- Updated `metro.config.js ` to:
  - Look at the root `package.json` with `nodeModulesPath` and `watchFolders`
  - Set `resolverMainFields` to look at `source` so `react-native-purchases` doesn't use the compiled `dist` 
- Updated `.circleci/config.yml`
  - Need to run `yarn install` (or `npm install`) in the root directory because this as local dependency needs its own `node_modules`