### PR TITLE
adds more exempt labels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,6 +16,9 @@ exemptLabels:
   - enhancement
   - next-release
   - investigating
+  - pinned
+  - you can do this!
+  - triaged
 
 # Set to true to ignore issues in a project (defaults to false)
 #exemptProjects: false


### PR DESCRIPTION
### Motivation
Our stalebot needs a few more labels to be sure we aren’t automatically closing issues that shouldn’t be closed.

### Description
New exempt labels are:
- pinned
- you can do this!
- triaged
