### PR TITLE
Adds missing addListener and removeListeners functions to RNPurchasesModule.java

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -68,6 +68,16 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
+    public void addListener(String eventName) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+      // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
     public void setupPurchases(String apiKey, @Nullable String appUserID,
                                boolean observerMode, @Nullable String userDefaultsSuiteName) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);


### PR DESCRIPTION
Fix for https://github.com/RevenueCat/react-native-purchases/issues/309 by adding new required functions to `RNPurchasesModule.java`. 

Same fix was implemented in https://github.com/react-native-webrtc/react-native-webrtc/pull/1072 and it follows the official documentation https://reactnative.dev/docs/native-modules-android#sending-events-to-javascript.

I tested it with this branch https://github.com/RevenueCat/react-native-purchases/pull/338 and it fixes the warning and the listener still works.

[CF-370]

[CF-370]: https://revenuecats.atlassian.net/browse/CF-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ