### PR TITLE
Upgrade cocoapods-download to 1.6.3 for security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       public_suffix
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.4.0)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)


### PR DESCRIPTION
We have a [security alert](https://github.com/RevenueCat/react-native-purchases/security/dependabot/3) due to a version of cocoapods-downloader. I've upgrade it in the Gemfile.lock to a safest one. I've found that the new version is inside the Cocoapods range as you can see [here](https://github.com/CocoaPods/CocoaPods/blob/1.10.2/Gemfile.lock#L117)

In the version 1.11.3 fo Cocoapods [they've updated to 1.5.1](https://github.com/CocoaPods/CocoaPods/blob/b544eb356238d90684d109333e728703226af9f6/Gemfile.lock#L58-L63) but is still affected by the issue