### PR TITLE
Update willRenew comment - will be false for lifetime

### DIFF
--- a/src/purchaserInfo.ts
+++ b/src/purchaserInfo.ts
@@ -12,7 +12,6 @@ export interface PurchasesEntitlementInfo {
     readonly isActive: boolean;
     /**
      * True if the underlying subscription is set to renew at the end of the billing period (expirationDate).
-     * Will always be True if entitlement is for lifetime access.
      */
     readonly willRenew: boolean;
     /**


### PR DESCRIPTION
### Motivation
Inspired by https://github.com/RevenueCat/purchases-flutter/issues/361

### Description
The comment for entitlement's `willRenew` was wrong. Lifteime purchases will return `false`

