### PR TITLE
Export MakePurchaseResult

### DIFF
--- a/dist/purchases.d.ts
+++ b/dist/purchases.d.ts
@@ -8,7 +8,7 @@ import { PRORATION_MODE, PACKAGE_TYPE, INTRO_ELIGIBILITY_STATUS, PurchasesOfferi
  */
 export declare type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
 export declare type ShouldPurchasePromoProductListener = (deferredPurchase: () => Promise<MakePurchaseResult>) => void;
-declare type MakePurchaseResult = {
+export declare type MakePurchaseResult = {
     productIdentifier: string;
     purchaserInfo: PurchaserInfo;
 };
@@ -578,4 +578,3 @@ export default class Purchases {
     static isConfigured(): Promise<boolean>;
     private static throwIfNotConfigured;
 }
-export {};

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -26,7 +26,7 @@ const eventEmitter = new NativeEventEmitter(RNPurchases);
  */
 export type PurchaserInfoUpdateListener = (purchaserInfo: PurchaserInfo) => void;
 export type ShouldPurchasePromoProductListener = (deferredPurchase: () => Promise<MakePurchaseResult>) => void;
-type MakePurchaseResult = { productIdentifier: string; purchaserInfo: PurchaserInfo; };
+export type MakePurchaseResult = { productIdentifier: string; purchaserInfo: PurchaserInfo; };
 
 let purchaserInfoUpdateListeners: PurchaserInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] = [];


### PR DESCRIPTION
Export MakePurchaseResult

See https://github.com/RevenueCat/react-native-purchases/issues/350 for customer issue reporting that this type wasn't exported
