### PR TITLE
Started APITesters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
           name: Tests
           command: yarn test
       - run:
+          name: API Tests
+          command: yarn tsc -p apitesters
+      - run:
           name: Linter
           command: yarn run tslint
   android:

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -1,0 +1,21 @@
+import {PurchasesOfferings, PurchasesProduct, UpgradeInfo} from '../dist';
+import Purchases from '../dist/purchases';
+import {PURCHASE_TYPE} from '../src';
+
+async function checkPurchases(purchases: Purchases) {
+  const productId: string = ""
+  const productIds: string[] = [productId];
+  const upgradeInfo: UpgradeInfo | null = null;
+
+  const offerings: PurchasesOfferings = await Purchases.getOfferings();
+  const products: PurchasesProduct[] = await Purchases.getProducts(
+    productIds,
+    PURCHASE_TYPE.INAPP
+  );
+
+  await Purchases.purchaseProduct(
+    productId,
+    upgradeInfo,
+    PURCHASE_TYPE.INAPP
+  );
+}

--- a/apitesters/tsconfig.json
+++ b/apitesters/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noEmit": true // We don't actually need to output anything
+  },
+  "include": ["./*"],
+}


### PR DESCRIPTION
For [CSDK-143].

This relies on TypeScript compilation to detect type issues. A separate `tsconfig.json` inherits from the parent one to compile only these files.

`noUnusedLocals` and `noUnusedParameters` are set to `false` to ignore errors due to all these values being unused in the testers.

This PR only adds the main setup. See #360 for the rest of testers.

[CSDK-143]: https://revenuecats.atlassian.net/browse/CSDK-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ