### PR TITLE
`Purchases.setUp`: added `usesStoreKit2IfAvailable`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -353,14 +353,15 @@ describe("Purchases", () => {
     const Purchases = require("../dist/index").default;
 
     Purchases.setup("key", "user");
-
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false);
 
     Purchases.setup("key", "user", true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false);
 
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined);
+    Purchases.setup("key", "user", true, "suite name", true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true);
 
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(2);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(3);
   })
 
   it("cancelled purchaseProduct sets userCancelled in the error", () => {
@@ -582,7 +583,7 @@ describe("Purchases", () => {
 
     Purchases.setup("key", "user", false, "suitename");
 
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suitename");
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suitename", false);
   })
 
   describe("invalidate customer info cache", () => {

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -78,7 +78,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     @ReactMethod
     public void setupPurchases(String apiKey, @Nullable String appUserID,
-                               boolean observerMode, @Nullable String userDefaultsSuiteName) {
+                               boolean observerMode, @Nullable String userDefaultsSuiteName,
+                                @Nullable Boolean usesStoreKit2IfAvailable) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         CommonKt.configure(reactContext, apiKey, appUserID, observerMode, platformInfo);
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(this);

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -81,6 +81,7 @@ async function checkSetup() {
   const aString: string = "";
   const userID: string | null = "";
   const observerMode: boolean = false;
+  const usesStoreKit2IfAvailable: boolean = true;
   const userDefaultsSuiteName: string = "";
 
   Purchases.setup(
@@ -93,6 +94,13 @@ async function checkSetup() {
     userID,
     observerMode,
     userDefaultsSuiteName
+  );
+  Purchases.setup(
+    aString,
+    userID,
+    observerMode,
+    userDefaultsSuiteName,
+    usesStoreKit2IfAvailable
   );
 
   await Purchases.setProxyURL(aString);

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -37,14 +37,15 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                   appUserID:(nullable NSString *)appUserID
                   observerMode:(BOOL)observerMode
-                  userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName) {
+                  userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName
+                  usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable) {
     RCPurchases *purchases = [RCPurchases configureWithAPIKey:apiKey
                                                   appUserID:appUserID
                                                observerMode:observerMode
                                       userDefaultsSuiteName:userDefaultsSuiteName
                                              platformFlavor:self.platformFlavor
                                       platformFlavorVersion:self.platformFlavorVersion
-                                     usesStoreKit2IfAvailable:NO
+                                     usesStoreKit2IfAvailable:usesStoreKit2IfAvailable
                                           dangerousSettings:nil];
     purchases.delegate = self;
 }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -181,8 +181,8 @@ export default class Purchases {
      * Sets up Purchases with your API key and an app user id.
      * @param {String} apiKey RevenueCat API Key. Needs to be a String
      * @param {String?} appUserID An optional unique id for identifying the user. Needs to be a string.
-     * @param {boolean?} observerMode An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
-     * @param {boolean?} usesStoreKit2IfAvailable An optional boolean. iOS-only. Set this to TRUE to enable StoreKit2 on compatible devices.
+     * @param {boolean} [observerMode=false] An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
+     * @param {boolean} [usesStoreKit2IfAvailable=false] An optional boolean. iOS-only. Set this to TRUE to enable StoreKit2 on compatible devices.
      * @param {String?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.
      * Default is null, which will make the SDK use standardUserDefaults.

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -182,6 +182,7 @@ export default class Purchases {
      * @param {String} apiKey RevenueCat API Key. Needs to be a String
      * @param {String?} appUserID An optional unique id for identifying the user. Needs to be a string.
      * @param {boolean?} observerMode An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
+     * @param {boolean?} usesStoreKit2IfAvailable An optional boolean. iOS-only. Set this to TRUE to enable StoreKit2 on compatible devices.
      * @param {String?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.
      * Default is null, which will make the SDK use standardUserDefaults.
@@ -190,7 +191,8 @@ export default class Purchases {
         apiKey: string,
         appUserID?: string | null,
         observerMode: boolean = false,
-        userDefaultsSuiteName?: string
+        userDefaultsSuiteName?: string,
+        usesStoreKit2IfAvailable: boolean = false
     ): void {
         if (appUserID !== null && typeof appUserID !== "undefined" && typeof appUserID !== "string") {
             throw new Error("appUserID needs to be a string");
@@ -199,7 +201,8 @@ export default class Purchases {
             apiKey,
             appUserID,
             observerMode,
-            userDefaultsSuiteName
+            userDefaultsSuiteName,
+            usesStoreKit2IfAvailable
         );
     }
 


### PR DESCRIPTION
 Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/170 (this won't compile until we point to PHC with that update).

Also depends on #361.