### PR TITLE
Finished version 5.0 renames

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -94,19 +94,19 @@ describe("Purchases", () => {
     expect(listener).toHaveBeenCalledTimes(0);
   });
 
-  it("calling setup with something other than string throws exception", () => {
+  it("calling configure with something other than string throws exception", () => {
     const Purchases = require("../dist/index").default;
 
     expect(() => {
-      Purchases.setup("api_key", 123)
+      Purchases.configure("api_key", 123)
     }).toThrowError();
 
     expect(() => {
-      Purchases.setup("api_key")
+      Purchases.configure("api_key")
     }).not.toThrowError();
 
     expect(() => {
-      Purchases.setup("api_key", "123a")
+      Purchases.configure("api_key", "123a")
     }).not.toThrowError();
 
 
@@ -349,16 +349,16 @@ describe("Purchases", () => {
     expect(customerInfo).toEqual(customerInfoStub);
   })
 
-  it("setup works", async () => {
+  it("configure works", async () => {
     const Purchases = require("../dist/index").default;
 
-    Purchases.setup("key", "user");
+    Purchases.configure("key", "user");
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false);
 
-    Purchases.setup("key", "user", true);
+    Purchases.configure("key", "user", true);
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false);
 
-    Purchases.setup("key", "user", true, "suite name", true);
+    Purchases.configure("key", "user", true, "suite name", true);
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true);
 
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(3);
@@ -578,10 +578,10 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(0);
   });
 
-  it("calling setup with a userDefaultsSuiteName", () => {
+  it("calling configure with a userDefaultsSuiteName", () => {
     const Purchases = require("../dist/index").default;
 
-    Purchases.setup("key", "user", false, "suitename");
+    Purchases.configure("key", "user", false, "suitename");
 
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suitename", false);
   })
@@ -753,7 +753,7 @@ describe("Purchases", () => {
 
       // This functions should skip the test since they not required an instance of Purchases
       const excludedFunctionNames = [
-        "setup",
+        "configure",
         "setSimulatesAskToBuyInSandbox",
         "addCustomerInfoUpdateListener",
         "removeCustomerInfoUpdateListener",

--- a/apitesters/customerInfo.ts
+++ b/apitesters/customerInfo.ts
@@ -3,7 +3,7 @@ import {
   CustomerInfo,
   PurchasesEntitlementInfo,
   PurchasesEntitlementInfos,
-  PurchasesTransaction
+  PurchasesStoreTransaction
 } from "../src";
 
 function checkLoginResult(result: LogInResult) {
@@ -24,7 +24,7 @@ function checkCustomerInfo(info: CustomerInfo) {
   const originalApplicationVersion: string | null = info.originalApplicationVersion;
   const originalPurchaseDate: string | null = info.originalPurchaseDate;
   const managementURL: string | null = info.managementURL;
-  const nonSubscriptionTransactions: PurchasesTransaction[] = info.nonSubscriptionTransactions;
+  const nonSubscriptionTransactions: PurchasesStoreTransaction[] = info.nonSubscriptionTransactions;
 }
 
 function checkEntitlementInfos(infos: PurchasesEntitlementInfos) {
@@ -47,7 +47,7 @@ function checkEntitlementInfo(info: PurchasesEntitlementInfo) {
   const billingIssueDetectedAt: string | null = info.billingIssueDetectedAt;
 }
 
-function checkTransaction(transaction: PurchasesTransaction) {
+function checkTransaction(transaction: PurchasesStoreTransaction) {
   const revenueCatId: string = transaction.revenueCatId;
   const productId: string = transaction.productId;
   const purchaseDate: string = transaction.purchaseDate;

--- a/apitesters/enums.ts
+++ b/apitesters/enums.ts
@@ -1,22 +1,10 @@
 import {
-  ATTRIBUTION_NETWORK,
   BILLING_FEATURE,
   PURCHASE_TYPE,
   PACKAGE_TYPE,
   INTRO_ELIGIBILITY_STATUS,
   PRORATION_MODE
 } from '../dist';
-
-function checkAttributionNetwork(network: ATTRIBUTION_NETWORK): boolean {
-    switch (network) {
-        case ATTRIBUTION_NETWORK.APPLE_SEARCH_ADS: return true;
-        case ATTRIBUTION_NETWORK.ADJUST: return true;
-        case ATTRIBUTION_NETWORK.APPSFLYER: return true;
-        case ATTRIBUTION_NETWORK.BRANCH: return true;
-        case ATTRIBUTION_NETWORK.TENJIN: return true;
-        case ATTRIBUTION_NETWORK.FACEBOOK: return true;
-    }
-}
 
 function checkPurchaseType(type: PURCHASE_TYPE): boolean {
     switch (type) {

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -2,14 +2,14 @@ import {
   INTRO_ELIGIBILITY_STATUS,
   IntroEligibility,
   PACKAGE_TYPE, PRORATION_MODE,
-  PurchasesDiscount,
+  PurchasesStoreProductDiscount,
   PurchasesIntroPrice,
   PurchasesOffering, PurchasesOfferings,
   PurchasesPackage, PurchasesPromotionalOffer,
-  PurchasesProduct, UpgradeInfo
+  PurchasesStoreProduct, UpgradeInfo
 } from "../dist";
 
-function checkProduct(product: PurchasesProduct) {
+function checkProduct(product: PurchasesStoreProduct) {
   const identifier: string = product.identifier;
   const description: string = product.description;
   const title: string = product.title;
@@ -17,10 +17,10 @@ function checkProduct(product: PurchasesProduct) {
   const priceString: string = product.price_string;
   const currencyCode: string = product.currency_code;
   const introPrice: PurchasesIntroPrice | null = product.introPrice;
-  const discounts: PurchasesDiscount[] | null = product.discounts;
+  const discounts: PurchasesStoreProductDiscount[] | null = product.discounts;
 }
 
-function checkDiscount(discount: PurchasesDiscount) {
+function checkDiscount(discount: PurchasesStoreProductDiscount) {
   const identifier: string = discount.identifier;
   const price: number = discount.price;
   const priceString: string = discount.priceString;
@@ -42,7 +42,7 @@ function checkIntroPrice(introPrice: PurchasesIntroPrice) {
 function checkPackage(pack: PurchasesPackage) {
   const identifier: string = pack.identifier;
   const packageType: PACKAGE_TYPE = pack.packageType;
-  const product: PurchasesProduct = pack.product;
+  const product: PurchasesStoreProduct = pack.product;
   const offeringIdentifier: string = pack.offeringIdentifier;
 }
 

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -16,7 +16,7 @@ function checkProduct(product: PurchasesStoreProduct) {
   const price: number = product.price;
   const priceString: string = product.price_string;
   const currencyCode: string = product.currency_code;
-  const introPrice: PurchasesIntroPrice | null = product.introPrice;
+  const introPrice: PurchasesIntroPrice | null = product.intro_price;
   const discounts: PurchasesStoreProductDiscount[] | null = product.discounts;
 }
 

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -84,18 +84,18 @@ async function checkSetup() {
   const usesStoreKit2IfAvailable: boolean = true;
   const userDefaultsSuiteName: string = "";
 
-  Purchases.setup(
+  Purchases.configure(
     aString,
     userID,
     observerMode
   );
-  Purchases.setup(
+  Purchases.configure(
     aString,
     userID,
     observerMode,
     userDefaultsSuiteName
   );
-  Purchases.setup(
+  Purchases.configure(
     aString,
     userID,
     observerMode,

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -3,10 +3,10 @@ import {
   PurchasesOfferings,
   PurchasesPackage,
   PurchasesPromotionalOffer,
-  PurchasesProduct,
+  PurchasesStoreProduct,
   UpgradeInfo,
   MakePurchaseResult,
-  PURCHASE_TYPE, PurchasesDiscount, BILLING_FEATURE, IntroEligibility,
+  PURCHASE_TYPE, PurchasesStoreProductDiscount, BILLING_FEATURE, IntroEligibility,
   LogInResult, ShouldPurchasePromoProductListener, CustomerInfoUpdateListener
 } from '../dist';
 
@@ -16,7 +16,7 @@ async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
 
   const offerings: PurchasesOfferings = await Purchases.getOfferings();
-  const products: PurchasesProduct[] = await Purchases.getProducts(
+  const products: PurchasesStoreProduct[] = await Purchases.getProducts(
     productIds,
     PURCHASE_TYPE.INAPP
   );
@@ -34,8 +34,8 @@ async function checkUsers(purchases: Purchases) {
 }
 
 async function checkPurchasing(purchases: Purchases,
-                               product: PurchasesProduct,
-                               discount: PurchasesDiscount,
+                               product: PurchasesStoreProduct,
+                               discount: PurchasesStoreProductDiscount,
                                paymentDiscount: PurchasesPromotionalOffer,
                                pack: PurchasesPackage) {
   const productId: string = ""

--- a/src/customerInfo.ts
+++ b/src/customerInfo.ts
@@ -132,7 +132,7 @@ export interface CustomerInfo {
      */
     readonly managementURL: string | null;
 
-    readonly nonSubscriptionTransactions: PurchasesTransaction[];
+    readonly nonSubscriptionTransactions: PurchasesStoreTransaction[];
 }
 
 /**
@@ -140,7 +140,7 @@ export interface CustomerInfo {
  * non-subscription purchases
  */
 
-export interface PurchasesTransaction {
+export interface PurchasesStoreTransaction {
     /**
      * RevenueCat Id associated to the transaction.
      */

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -63,7 +63,7 @@ export enum INTRO_ELIGIBILITY_STATUS {
 }
 
 
-export interface PurchasesProduct {
+export interface PurchasesStoreProduct {
     /**
      * Product Id.
      */
@@ -131,10 +131,10 @@ export interface PurchasesProduct {
     /**
      * Collection of discount offers for a product. Null for Android.
      */
-    readonly discounts: PurchasesDiscount[] | null;
+    readonly discounts: PurchasesStoreProductDiscount[] | null;
 }
 
-export interface PurchasesDiscount {
+export interface PurchasesStoreProductDiscount {
     /**
      * Identifier of the discount.
      */
@@ -208,7 +208,7 @@ export interface PurchasesPackage {
     /**
      * Product assigned to this package.
      */
-    readonly product: PurchasesProduct;
+    readonly product: PurchasesStoreProduct;
     /**
      * Offering this package belongs to.
      */

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -89,45 +89,9 @@ export interface PurchasesStoreProduct {
      */
     readonly currency_code: string;
     /**
-     * @deprecated, use introPrice instead.
-     *
-     * Introductory price of a subscription in the local currency.
-     */
-    readonly intro_price: number | null;
-    /**
-     * @deprecated, use introPrice instead.
-     *
-     * Formatted introductory price of a subscription, including its currency sign, such as €3.99.
-     */
-    readonly intro_price_string: string | null;
-    /**
-     * @deprecated, use introPrice instead.
-     *
-     * Billing period of the introductory price, specified in ISO 8601 format.
-     */
-    readonly intro_price_period: string | null;
-    /**
-     * @deprecated, use introPrice instead.
-     *
-     * Number of subscription billing periods for which the user will be given the introductory price, such as 3.
-     */
-    readonly intro_price_cycles: number | null;
-    /**
-     * @deprecated, use introPrice instead.
-     *
-     * Unit for the billing period of the introductory price, can be DAY, WEEK, MONTH or YEAR.
-     */
-    readonly intro_price_period_unit: string | null;
-    /**
-     * @deprecated, use introPrice instead.
-     *
-     * Number of units for the billing period of the introductory price.
-     */
-    readonly intro_price_period_number_of_units: number | null;
-    /**
      * Introductory price.
      */
-    readonly introPrice: PurchasesIntroPrice | null;
+    readonly intro_price: PurchasesIntroPrice | null;
     /**
      * Collection of discount offers for a product. Null for Android.
      */

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -6,12 +6,12 @@ import {
     PACKAGE_TYPE,
     INTRO_ELIGIBILITY_STATUS,
     PurchasesOfferings,
-    PurchasesProduct,
+    PurchasesStoreProduct,
     UpgradeInfo,
     PurchasesPromotionalOffer,
     PurchasesPackage,
     IntroEligibility,
-    PurchasesDiscount
+    PurchasesStoreProductDiscount
 } from "./offerings";
 
 import { Platform } from "react-native";
@@ -46,15 +46,6 @@ eventEmitter.addListener(
         );
     }
 );
-
-export enum ATTRIBUTION_NETWORK {
-    APPLE_SEARCH_ADS = 0,
-    ADJUST = 1,
-    APPSFLYER = 2,
-    BRANCH = 3,
-    TENJIN = 4,
-    FACEBOOK = 5,
-}
 
 export enum PURCHASE_TYPE {
     /**
@@ -115,22 +106,6 @@ export interface LogInResult {
 }
 
 export default class Purchases {
-    /**
-     * Enum for attribution networks
-     * @readonly
-     * @enum {number}
-     */
-    public static ATTRIBUTION_NETWORK = ATTRIBUTION_NETWORK;
-
-    /**
-     * @deprecated use ATTRIBUTION_NETWORK instead
-     *
-     * Enum for attribution networks
-     * @readonly
-     * @enum {number}
-     */
-    public static ATTRIBUTION_NETWORKS = ATTRIBUTION_NETWORK;
-
     /**
      * Supported SKU types.
      * @readonly
@@ -321,7 +296,7 @@ export default class Purchases {
      * Fetch the product info
      * @param {String[]} productIdentifiers Array of product identifiers
      * @param {String} type Optional type of products to fetch, can be inapp or subs. Subs by default
-     * @returns {Promise<PurchasesProduct[]>} A promise containing an array of products. The promise will be rejected
+     * @returns {Promise<PurchasesStoreProduct[]>} A promise containing an array of products. The promise will be rejected
      * if the products are not properly configured in RevenueCat or if there is another error retrieving them.
      * Rejections return an error code, and a userInfo object with more information. The promise will also be rejected
      * if setup has not been called yet.
@@ -329,7 +304,7 @@ export default class Purchases {
     public static async getProducts(
         productIdentifiers: string[],
         type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
-    ): Promise<PurchasesProduct[]> {
+    ): Promise<PurchasesStoreProduct[]> {
         await Purchases.throwIfNotConfigured();
         return RNPurchases.getProductInfo(productIdentifiers, type);
     }
@@ -366,7 +341,7 @@ export default class Purchases {
     /**
      * iOS only. Purchase a product applying a given discount.
      *
-     * @param {PurchasesProduct} product The product you want to purchase
+     * @param {PurchasesStoreProduct} product The product you want to purchase
      * @param {PurchasesPromotionalOffer} discount Discount to apply to this package. Retrieve this discount using getPromotionalOffer.
      * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
      * a customer info object and a product identifier. Rejections return an error code,
@@ -374,7 +349,7 @@ export default class Purchases {
      * rejected if setup has not been called yet.
      */
     public static async purchaseDiscountedProduct(
-        product: PurchasesProduct,
+        product: PurchasesStoreProduct,
         discount: PurchasesPromotionalOffer
     ): Promise<MakePurchaseResult> {
         await Purchases.throwIfNotConfigured();
@@ -632,8 +607,8 @@ export default class Purchases {
      * called yet or if there's an error getting the payment discount.
      */
     public static async getPromotionalOffer(
-        product: PurchasesProduct,
-        discount: PurchasesDiscount
+        product: PurchasesStoreProduct,
+        discount: PurchasesStoreProductDiscount
     ): Promise<PurchasesPromotionalOffer | undefined> {
         await Purchases.throwIfNotConfigured();
         if (Platform.OS === "android") {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -471,55 +471,6 @@ export default class Purchases {
     }
 
     /**
-     * @deprecated, use logIn instead.
-     * This function will alias two appUserIDs together.
-     * @param {String} newAppUserID The new appUserID that should be linked to the currently identified appUserID.
-     * Needs to be a string.
-     * @returns {Promise<CustomerInfo>} A promise of a customer info object. Rejections return an error code, and a
-     * userInfo object with more information. The promise will be rejected if setup has not been called yet or if
-     * there's an issue creating the alias.
-     */
-    public static async createAlias(newAppUserID: string): Promise<CustomerInfo> {
-        await Purchases.throwIfNotConfigured();
-        // noinspection SuspiciousTypeOfGuard
-        if (typeof newAppUserID !== "string") {
-            throw new Error("newAppUserID needs to be a string");
-        }
-        return RNPurchases.createAlias(newAppUserID);
-    }
-
-    /**
-     * @deprecated, use logIn instead.
-     * This function will identify the current user with an appUserID. Typically this would be used after a logout to
-     * identify a new user without calling configure
-     * @param {String} newAppUserID The appUserID that should be linked to the currently user
-     * @returns {Promise<CustomerInfo>} A promise of a customer info object. Rejections return an error code, and an
-     * userInfo object with more information. The promise will be rejected if setup has not been called yet or if
-     * there's an issue identifying the user.
-     */
-    public static async identify(newAppUserID: string): Promise<CustomerInfo> {
-        await Purchases.throwIfNotConfigured();
-        // noinspection SuspiciousTypeOfGuard
-        if (typeof newAppUserID !== "string") {
-            throw new Error("newAppUserID needs to be a string");
-        }
-        return RNPurchases.identify(newAppUserID);
-    }
-
-    /**
-     * @deprecated, use logOut instead.
-     * Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the
-     *  cache.
-     * @returns {Promise<CustomerInfo>} A promise of a customer info object. Rejections return an error code, and an
-     * userInfo object with more information. The promise will be rejected if setup has not been called yet or if
-     * there's an issue resetting the user.
-     */
-    public static async reset(): Promise<CustomerInfo> {
-        await Purchases.throwIfNotConfigured();
-        return RNPurchases.reset();
-    }
-
-    /**
      * Enables/Disables debugs logs
      * @param {boolean} enabled Enable or not debug logs
      */

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -162,7 +162,7 @@ export default class Purchases {
      * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.
      * Default is null, which will make the SDK use standardUserDefaults.
      */
-    public static setup(
+    public static configure(
         apiKey: string,
         appUserID?: string | null,
         observerMode: boolean = false,


### PR DESCRIPTION
### Changes:
- Renamed `PurchasesStoreTransaction`
- Renamed `PurchasesStoreProduct`
- Renamed `PurchasesStoreProductDiscount`
- Removed deprecated `identify`/`reset`/`createAlias`
- Renamed `setUp` to `configure`
- Removed no loner needed `ATTRIBUTION_NETWORK`
- Removed deprecated `intro_price` properties in favor of the new one

For [CSDK-182].
See also https://github.com/RevenueCat/purchases-hybrid-common/pull/147

[CSDK-182]: https://revenuecats.atlassian.net/browse/CSDK-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ