### PR TITLE
Fixed `fastlane update_hybrid_common`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -103,6 +103,7 @@ lane :build_hybrid_example do |options|
     sh("yarn example")
   end
   Dir.chdir(File.expand_path("examples/purchaseTesterTypescript/ios", get_root_folder)) do
+    sh("pod install --repo-update")
     sh("pod update PurchasesHybridCommon --repo-update")
   end
 end


### PR DESCRIPTION
After #355, `Podfile.lock` isn't in the repo anymore, so `pod update` without it doesn't work.