### PR TITLE
CircleCI: fixed `Podfile.lock` caching issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,10 @@ jobs:
       - rn/yarn_install:
           yarn_install_directory: examples/purchaseTesterTypescript
           cache_folder: ~/.cache/yarn
-      - rn/pod_install:
-          pod_install_directory: examples/purchaseTesterTypescript/ios
+      - run:
+          name: "Install example dependencies"
+          command: |
+            cd examples/purchaseTesterTypescript/ios && pod install --repo-update && cd -
       - rn/yarn_install:
           cache_folder: ~/.cache/yarn
       - rn/ios_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           yarn_install_directory: examples/purchaseTesterTypescript
           cache_folder: ~/.cache/yarn
       - run:
-          name: "Install example dependencies"
+          name: Install example dependencies
           command: |
             cd examples/purchaseTesterTypescript/ios && pod install --repo-update && cd -
       - rn/yarn_install:


### PR DESCRIPTION
Fixes [CSDK-332].

See https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/1078/workflows/802f3ff0-15d6-4390-b67e-0ba8768c1996/jobs/3418/parallel-runs/0/steps/0-108

We use the `react-native-community/react-native` orb which relies on the existence of `Podfile.lock` files, but we removed those on https://github.com/RevenueCat/react-native-purchases/pull/355

[CSDK-332]: https://revenuecats.atlassian.net/browse/CSDK-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ