### PR TITLE
`README`: updated minimum RN version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ React Native Purchases is a client for the [RevenueCat](https://www.revenuecat.c
 
 ## Requirements
 
-The minimum React Native version this SDK requires is `0.58`.
+The minimum React Native version this SDK requires is `0.64`.
 
 ## Installation
 


### PR DESCRIPTION
Looks like this was out of sync with [`package.json`](https://github.com/RevenueCat/react-native-purchases/blob/2b3825cc7625bbfdb8522082fe3579612f5cf763/package.json#L69).