### PR TITLE
Renamed `restoreTransactions` to `restorePurchases`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -257,14 +257,14 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(2);
   });
 
-  it("restoreTransactions works", async () => {
+  it("restorePurchases works", async () => {
     const Purchases = require("../dist/index").default;
 
-    NativeModules.RNPurchases.restoreTransactions.mockResolvedValueOnce(customerInfoStub);
+    NativeModules.RNPurchases.restorePurchases.mockResolvedValueOnce(customerInfoStub);
 
-    const customerInfo = await Purchases.restoreTransactions();
+    const customerInfo = await Purchases.restorePurchases();
 
-    expect(NativeModules.RNPurchases.restoreTransactions).toBeCalledTimes(1);
+    expect(NativeModules.RNPurchases.restorePurchases).toBeCalledTimes(1);
     expect(customerInfo).toEqual(customerInfoStub);
   })
 

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -21,7 +21,7 @@ async function checkPurchases(purchases: Purchases) {
     PURCHASE_TYPE.INAPP
   );
 
-  const customerInfo: CustomerInfo = await Purchases.restoreTransactions();
+  const customerInfo: CustomerInfo = await Purchases.restorePurchases();
 }
 
 async function checkUsers(purchases: Purchases) {

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -103,8 +103,8 @@ RCT_REMAP_METHOD(purchasePackage,
                            completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
 }
 
-RCT_REMAP_METHOD(restoreTransactions,
-                 restoreTransactionsWithResolve:(RCTPromiseResolveBlock)resolve
+RCT_REMAP_METHOD(restorePurchases,
+                 restorePurchasesWithResolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality restorePurchasesWithCompletionBlock:[self getResponseCompletionBlockWithResolve:resolve
                                                                                                     reject:reject]];

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -678,7 +678,7 @@ NativeModules.RNPurchases = {
   getOfferings: jest.fn(),
   getProductInfo: jest.fn(),
   makePurchase: jest.fn(),
-  restoreTransactions: jest.fn(),
+  restorePurchases: jest.fn(),
   getAppUserID: jest.fn(),
   setDebugLogsEnabled: jest.fn(),
   getCustomerInfo: jest.fn(),

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -431,9 +431,9 @@ export default class Purchases {
      * @returns {Promise<CustomerInfo>} A promise of a customer info object. Rejections return an error code, and an
      * userInfo object with more information. The promise will be also be rejected if setup has not been called yet.
      */
-    public static async restoreTransactions(): Promise<CustomerInfo> {
+    public static async restorePurchases(): Promise<CustomerInfo> {
         await Purchases.throwIfNotConfigured();
-        return RNPurchases.restoreTransactions();
+        return RNPurchases.restorePurchases();
     }
 
     /**


### PR DESCRIPTION
Fixes #388 and [SDKONCALL-74]

[SDKONCALL-74]: https://revenuecats.atlassian.net/browse/SDKONCALL-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ