### PR TITLE
Release 5.0.0 Beta 2

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,4 @@
-## 5.0.0-beta.1
+## 5.0.0-beta.2
 
 ⚠️⚠️ This is a pre-release version. ⚠️⚠️
 
@@ -9,9 +9,11 @@ This version of the SDK automatically uses StoreKit 2 APIs under the hood only f
 New types that wrap native types from Apple, Google and Amazon, and we cleaned up the naming of other types and methods for a more consistent experience. 
 
 ### Removed APIs
+- `setUp` has been removed in favor of `configure`
 - `identify` and `createAlias` have been removed in favor of `logIn`.
 - `reset` has been removed in favor of `logOut`.
 - `addAttributionData` has been removed in favor of `set<NetworkID> methods`.
+- `PurchasesStoreProduct`: removed `intro_price_string`, `intro_price_period`, `intro_price_cycles`, `intro_price_period_unit`, `intro_price_period_number_of_units` in favor of new `introPrice: PurchasesIntroPrice`.
 
 ### Renamed APIs
 
@@ -19,6 +21,8 @@ New types that wrap native types from Apple, Google and Amazon, and we cleaned u
 | :-: | :-: |
 | `PurchaserInfo` | `CustomerInfo` |
 | `PurchasesProduct` | `PurchasesStoreProduct` |
+| `PurchasesStoreProductProduct.price_string` | `PurchasesStoreProductProduct.priceString` |
+| `PurchasesStoreProductProduct.currency_code` | `PurchasesStoreProductProduct.currencyCode` |
 | `PurchasesTransaction` | `PurchasesStoreTransaction` |
 | `PurchasesDiscount` | `PurchasesStoreProductDiscount` |
 | `PurchasesPaymentDiscount` | `PurchasesPromotionalOffer` |
@@ -27,7 +31,6 @@ New types that wrap native types from Apple, Google and Amazon, and we cleaned u
 | `Purchases.invalidatePurchaserInfoCache` | `Purchases.invalidateCustomerInfoCache` |
 | `Purchases.addPurchaserInfoUpdateListener` | `Purchases.addCustomerInfoUpdateListener` |
 | `Purchases.removePurchaserInfoUpdateListener` | `Purchases.removeCustomerInfoUpdateListener` |
-| `PurchasesStoreProduct.introPrice` | `PurchasesStoreProduct.intro_price` |
 
 ### Known issues:
 - Amazon support currently doesn't work correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
-## 5.0.0-beta.1
+## 5.0.0-beta.2
+
+## 5.0.0-beta.2
+
+⚠️⚠️ This is a pre-release version. ⚠️⚠️
+
+#### StoreKit 2 support
+This version of the SDK automatically uses StoreKit 2 APIs under the hood only for APIs that the RevenueCat team has determined work better than StoreKit 1.
+
+#### New types and cleaned up naming
+New types that wrap native types from Apple, Google and Amazon, and we cleaned up the naming of other types and methods for a more consistent experience. 
+
+### Removed APIs
+- `setUp` has been removed in favor of `configure`
+- `identify` and `createAlias` have been removed in favor of `logIn`.
+- `reset` has been removed in favor of `logOut`.
+- `addAttributionData` has been removed in favor of `set<NetworkID> methods`.
+- `PurchasesStoreProduct`: removed `intro_price_string`, `intro_price_period`, `intro_price_cycles`, `intro_price_period_unit`, `intro_price_period_number_of_units` in favor of new `introPrice: PurchasesIntroPrice`.
+
+### Renamed APIs
+
+| 4.x | 5.0.0 |
+| :-: | :-: |
+| `PurchaserInfo` | `CustomerInfo` |
+| `PurchasesProduct` | `PurchasesStoreProduct` |
+| `PurchasesStoreProductProduct.price_string` | `PurchasesStoreProductProduct.priceString` |
+| `PurchasesStoreProductProduct.currency_code` | `PurchasesStoreProductProduct.currencyCode` |
+| `PurchasesTransaction` | `PurchasesStoreTransaction` |
+| `PurchasesDiscount` | `PurchasesStoreProductDiscount` |
+| `PurchasesPaymentDiscount` | `PurchasesPromotionalOffer` |
+| `Purchases.restoreTransactions` | `Purchases.restorePurchases` |
+| `Purchases.getPaymentDiscount` | `Purchases.getPromotionalOffer` |
+| `Purchases.invalidatePurchaserInfoCache` | `Purchases.invalidateCustomerInfoCache` |
+| `Purchases.addPurchaserInfoUpdateListener` | `Purchases.addCustomerInfoUpdateListener` |
+| `Purchases.removePurchaserInfoUpdateListener` | `Purchases.removeCustomerInfoUpdateListener` |
+## 5.0.0-beta.2
 
 ⚠️⚠️ This is a pre-release version. ⚠️⚠️
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 5.0.0-beta.2
 
-## 5.0.0-beta.2
-
 ⚠️⚠️ This is a pre-release version. ⚠️⚠️
 
 #### StoreKit 2 support
@@ -33,7 +31,8 @@ New types that wrap native types from Apple, Google and Amazon, and we cleaned u
 | `Purchases.invalidatePurchaserInfoCache` | `Purchases.invalidateCustomerInfoCache` |
 | `Purchases.addPurchaserInfoUpdateListener` | `Purchases.addCustomerInfoUpdateListener` |
 | `Purchases.removePurchaserInfoUpdateListener` | `Purchases.removeCustomerInfoUpdateListener` |
-## 5.0.0-beta.2
+
+## 5.0.0-beta.1
 
 ⚠️⚠️ This is a pre-release version. ⚠️⚠️
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
         versionCode 1
-        versionName '5.0.0-beta.1'
+        versionName '5.0.0-beta.2'
     }
 
     buildTypes {

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -336,7 +336,7 @@ readyForPromotedProduct:(RCStoreProduct *)product
 }
 
 - (NSString *)platformFlavorVersion {
-    return @"5.0.0-beta.1";
+    return @"5.0.0-beta.2";
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-purchases",
   "title": "React Native Purchases",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "description": "React Native in-app purchases and subscriptions made easy. Supports iOS and Android. ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/docs/index.html
+++ b/scripts/docs/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/react-native-purchases-docs/5.0.0-beta.1/" />
+	<meta http-equiv="refresh" content="0; url=https://revenuecat.github.io/react-native-purchases-docs/5.0.0-beta.2/" />
 </head>
 <body>
 </body>


### PR DESCRIPTION
## 5.0.0-beta.2

⚠️⚠️ This is a pre-release version. ⚠️⚠️

#### StoreKit 2 support
This version of the SDK automatically uses StoreKit 2 APIs under the hood only for APIs that the RevenueCat team has determined work better than StoreKit 1.

#### New types and cleaned up naming
New types that wrap native types from Apple, Google and Amazon, and we cleaned up the naming of other types and methods for a more consistent experience.

### Removed APIs
- `setUp` has been removed in favor of `configure`
- `identify` and `createAlias` have been removed in favor of `logIn`.
- `reset` has been removed in favor of `logOut`.
- `addAttributionData` has been removed in favor of `set<NetworkID> methods`.
- `PurchasesStoreProduct`: removed `intro_price_string`, `intro_price_period`, `intro_price_cycles`, `intro_price_period_unit`, `intro_price_period_number_of_units` in favor of new `introPrice: PurchasesIntroPrice`.

### Renamed APIs

| 4.x | 5.0.0 |
| :-: | :-: |
| `PurchaserInfo` | `CustomerInfo` |
| `PurchasesProduct` | `PurchasesStoreProduct` |
| `PurchasesStoreProductProduct.price_string` | `PurchasesStoreProductProduct.priceString` |
| `PurchasesStoreProductProduct.currency_code` | `PurchasesStoreProductProduct.currencyCode` |
| `PurchasesTransaction` | `PurchasesStoreTransaction` |
| `PurchasesDiscount` | `PurchasesStoreProductDiscount` |
| `PurchasesPaymentDiscount` | `PurchasesPromotionalOffer` |
| `Purchases.restoreTransactions` | `Purchases.restorePurchases` |
| `Purchases.getPaymentDiscount` | `Purchases.getPromotionalOffer` |
| `Purchases.invalidatePurchaserInfoCache` | `Purchases.invalidateCustomerInfoCache` |
| `Purchases.addPurchaserInfoUpdateListener` | `Purchases.addCustomerInfoUpdateListener` |
| `Purchases.removePurchaserInfoUpdateListener` | `Purchases.removeCustomerInfoUpdateListener` |

### Known issues:
- Amazon support currently doesn't work correctly.