### PR TITLE
`docs-deploy`: specify xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
   docs-deploy:
     executor:
       name: rn/macos
+      xcode_version: 13.2.0
     steps:
       - checkout
       - install-dependencies


### PR DESCRIPTION
Should fix https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/1168/workflows/f3c95ce5-cf1c-4aad-ab49-728142637090/jobs/3689
Without this it was using a version that's no longer there (12.4.0).