### PR TITLE
Update Hybrid Common 4.1.0 and add AdServices

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |spec|
   ]
 
   spec.dependency   "React-Core"
-  spec.dependency   "PurchasesHybridCommon", '4.0.0'
+  spec.dependency   "PurchasesHybridCommon", '4.1.0'
   spec.swift_version    = '5.0'
 end

--- a/apitesters/attributes.ts
+++ b/apitesters/attributes.ts
@@ -24,4 +24,5 @@ async function checkAttributes(purchases: Purchases) {
 
   await Purchases.collectDeviceIdentifiers();
   await Purchases.setAutomaticAppleSearchAdsAttributionCollection(true);
+  await Purchases.enableAdServicesAttributionTokenCollection();
 }

--- a/examples/purchaseTesterTypescript/App.tsx
+++ b/examples/purchaseTesterTypescript/App.tsx
@@ -39,6 +39,8 @@ const App = () => {
     } else {
       Purchases.configure({apiKey: APIKeys.apple});
     }
+
+    Purchases.enableAdServicesAttributionTokenCollection();
   }, []);
 
   return !hasKeys() ? (

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -160,7 +160,7 @@ RCT_EXPORT_METHOD(enableAdServicesAttributionTokenCollection)
     if (@available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)) {
         [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
     } else {
-        NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collction, but it's only available on iOS 14.0 or greater.");
+        NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collection, but it's only available on iOS 14.0 or greater.");
     }
 }
 

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -157,7 +157,7 @@ RCT_EXPORT_METHOD(setAutomaticAppleSearchAdsAttributionCollection:(BOOL)automati
 
 RCT_EXPORT_METHOD(enableAdServicesAttributionTokenCollection)
 {
-    if (@available(iOS 14.0, macOS 11.1, macCatalyst 14.3, *)) {
+    if (@available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)) {
         [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
     } else {
         NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collction, but it's only available on iOS 14.0 or greater.");

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -157,7 +157,11 @@ RCT_EXPORT_METHOD(setAutomaticAppleSearchAdsAttributionCollection:(BOOL)automati
 
 RCT_EXPORT_METHOD(enableAdServicesAttributionTokenCollection)
 {
-    [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
+    if (@available(iOS 14.0, macOS 11.1, macCatalyst 14.3, *)) {
+        [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
+    } else {
+        NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collction, but it's only available on iOS 14.0 or greater.");
+    }
 }
 
 RCT_REMAP_METHOD(isAnonymous,

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -155,6 +155,11 @@ RCT_EXPORT_METHOD(setAutomaticAppleSearchAdsAttributionCollection:(BOOL)automati
     [RCCommonFunctionality setAutomaticAppleSearchAdsAttributionCollection:automaticAppleSearchAdsAttributionCollection];
 }
 
+RCT_EXPORT_METHOD(enableAdServicesAttributionTokenCollection)
+{
+    [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
+}
+
 RCT_REMAP_METHOD(isAnonymous,
                  isAnonymousWithResolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -544,6 +544,7 @@ export default class Purchases {
      */
     public static async enableAdServicesAttributionTokenCollection(): Promise<void> {
         if (Platform.OS === "ios") {
+            await Purchases.throwIfNotConfigured();
             RNPurchases.enableAdServicesAttributionTokenCollection();
         }
     }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -525,6 +525,7 @@ export default class Purchases {
     }
 
     /**
+     * @deprecated, use enableAdServicesAttributionTokenCollection instead.
      * Enable automatic collection of Apple Search Ad attribution. Disabled by default
      * @param {boolean} enabled Enable or not automatic apple search ads attribution collection
      * @returns {Promise<void>} The promise will be rejected if setup has not been called yet.
@@ -534,6 +535,16 @@ export default class Purchases {
     ): Promise<void> {
         if (Platform.OS === "ios") {
             RNPurchases.setAutomaticAppleSearchAdsAttributionCollection(enabled);
+        }
+    }
+
+    /**
+     * Enable automatic collection of Apple Search Ad attribution. Disabled by default
+     * @returns {Promise<void>} The promise will be rejected if setup has not been called yet.
+     */
+    public static async enableAdServicesAttributionTokenCollection(): Promise<void> {
+        if (Platform.OS === "ios") {
+            RNPurchases.enableAdServicesAttributionTokenCollection();
         }
     }
 

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -539,7 +539,7 @@ export default class Purchases {
     }
 
     /**
-     * Enable automatic collection of Apple Search Ad attribution. Disabled by default
+     * Enable automatic collection of Apple Search Ad attribution on iOS. Disabled by default
      * @returns {Promise<void>} The promise will be rejected if setup has not been called yet.
      */
     public static async enableAdServicesAttributionTokenCollection(): Promise<void> {


### PR DESCRIPTION
- Updated Hybrid Common to `4.1.0`
- Adds new `enableAdServicesAttributionTokenCollection` method
  - Will essentially be a no-op on non-iOS platforms
- Updated typescript purchase tester example to call `Purchases.enableAdServicesAttributionTokenCollection`