### PR TITLE
Fix version comment for AdServices if not supported

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -160,7 +160,7 @@ RCT_EXPORT_METHOD(enableAdServicesAttributionTokenCollection)
     if (@available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)) {
         [RCCommonFunctionality enableAdServicesAttributionTokenCollection];
     } else {
-        NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collection, but it's only available on iOS 14.0 or greater.");
+        NSLog(@"[Purchases] Warning: tried to enable AdServices attribution token collection, but it's only available on iOS 14.3 or greater or macOS 11.1 or greater.");
     }
 }
 


### PR DESCRIPTION
- Fixes comment that mentioned only supported in iOS 14.0 and above when its iOS 14.3+ and macOS 11.1+
