### PR TITLE
Specify branch for deployment dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,8 +172,10 @@ workflows:
       - make-release:
           <<: *release-tags
       - prepare-next-version:
+          <<: *release-tags
           requires:
             - make-release
       - docs-deploy:
+          <<: *release-tags
           requires:
             - make-release


### PR DESCRIPTION
On the latest release tag, the docs deploy and prepare-next-version jobs didn't execute. I added a specification for those 2 jobs to run only on release-tags and that seems to fix the issue.