### PR TITLE
Switch to main before preparing next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,6 @@ jobs:
       - revenuecat/trust-github-key
       - revenuecat/setup-git-credentials
       - run:
-          name: Switching to main branch
-          command: git checkout main
-      - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
 
@@ -158,9 +155,11 @@ workflows:
       - make-release:
           <<: *release-tags
       - prepare-next-version:
-          <<: *release-tags
-          requires:
-            - make-release
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              only: main
       - docs-deploy:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,8 +158,8 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-            # branches:
-              # only: main
+            branches:
+              only: main
       - docs-deploy:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,8 +158,8 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-            branches:
-              only: main
+            # branches:
+              # only: main
       - docs-deploy:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ aliases:
         ignore: /.*/
       branches:
         only: /^release\/.*/
+  only-main-branch: &only-main-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: main
 
 commands:
   install-dependencies:
@@ -155,11 +161,7 @@ workflows:
       - make-release:
           <<: *release-tags
       - prepare-next-version:
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              only: main
+          <<: *only-main-branch
       - docs-deploy:
           <<: *release-tags
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
       - revenuecat/trust-github-key
       - revenuecat/setup-git-credentials
       - run:
+          name: Switching to main branch
+          command: git checkout main
+      - run:
           name: Prepare next version
           command: bundle exec fastlane prepare_next_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 562dbc8d71bba33ec58b5c999d15e4c39b09bc7f
+  revision: 1269f49ad16be4fc7b38ff8b75e17f819f6af6c8
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 


### PR DESCRIPTION
We noticed how `prepare-next-version` is created from the release branches, which are then squashed and merged to `main`. This makes the snapshot bump branches to also have the commits from the merged release branch.

I added a step in the `prepare-next-version` job to switch to `main`. Alternatively, we could do this branch change in the fastlane plugin, but I wonder if we want to give the flexibility to execute the lane from any branch. Let me know what you think, I am open to move it there too.