### PR TITLE
Updated main and MagicWeather README to match purchases-ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Or view our React Native sample app:
 The minimum React Native version this SDK requires is `0.64`.
 
 ## SDK Reference
-Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).
+Our full SDK reference [can be found here](https://revenuecat.github.io/react-native-purchases-docs/).
 
 ## Contributing
 Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ The minimum React Native version this SDK requires is `0.64`.
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/react-native-purchases-docs/).
 
-## Contributing
-Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).
-
 ---
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
+<h3 align="center">😻 In-App Subscriptions Made Easy 😻</h3>
 
-<p align="center">
-  <img src="https://uploads-ssl.webflow.com/5e2613cf294dc30503dcefb7/5e752025f8c3a31d56a51408_logo_red%20(1).svg" width="350" alt="RevenueCat"/>
-<br>
-React Native in-app subscriptions made easy
-</p>
+[![License](https://img.shields.io/cocoapods/l/RevenueCat.svg?style=flat)](http://cocoapods.org/pods/RevenueCat)
 
-# What is react-native-purchases?
+RevenueCat is a powerful, reliable, and free to use in-app purchase server with cross-platform support. Our open-source framework provides a backend and a wrapper around StoreKit and Google Play Billing to make implementing in-app purchases and subscriptions easy. 
 
-React Native Purchases is a client for the [RevenueCat](https://www.revenuecat.com/) subscription and purchase tracking system. It is an open source framework that provides a wrapper around `StoreKit`, `Google Play Billing` and the RevenueCat backend to make implementing in-app purchases in `React Native` easy.
+Whether you are building a new app or already have millions of customers, you can use RevenueCat to:
 
-## Features
+  * Fetch products, make purchases, and check subscription status with our [native SDKs](https://docs.revenuecat.com/docs/installation). 
+  * Host and [configure products](https://docs.revenuecat.com/docs/entitlements) remotely from our dashboard. 
+  * Analyze the most important metrics for your app business [in one place](https://docs.revenuecat.com/docs/charts).
+  * See customer transaction histories, chart lifetime value, and [grant promotional subscriptions](https://docs.revenuecat.com/docs/customers).
+  * Get notified of real-time events through [webhooks](https://docs.revenuecat.com/docs/webhooks).
+  * Send enriched purchase events to analytics and attribution tools with our easy integrations.
+
+Sign up to [get started for free](https://app.revenuecat.com/signup).
+
+## React Native Purchases
+
+React Native Purchases is the client for the [RevenueCat](https://www.revenuecat.com/) subscription and purchase tracking system. It is an open source framework that provides a wrapper around `StoreKit`, `Google Play Billing` and the RevenueCat backend to make implementing in-app purchases in `React Native` easy.
+
+## Migrating from Purchases v3
+- See our [Migration guide](https://revenuecat-docs.netlify.app/documentation/revenuecat/v4_api_migration_guide)
+
+## RevenueCat SDK Features
 |   | RevenueCat |
 | --- | --- |
 ✅ | Server-side receipt validation
@@ -21,29 +34,53 @@ React Native Purchases is a client for the [RevenueCat](https://www.revenuecat.c
 💯 | Well maintained - [frequent releases](https://github.com/RevenueCat/purchases-ios/releases)  
 📮 | Great support - [Help Center](https://revenuecat.zendesk.com) 
 
+## Getting Started
+For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).
+
+Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to install the SDK.
+
+Or view our React Native sample app:
+- [MagicWeather](examples/MagicWeather)
+
 ## Requirements
 
 The minimum React Native version this SDK requires is `0.64`.
+
+## SDK Reference
+Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).
+
+## Contributing
+Contributions are always welcome! To learn how you can contribute, please see the [Contributing Guide](./Contributing/CONTRIBUTING.md).
+
+---
 
 ## Installation
 
 ExpoKit projects of version 33 or higher can successfully use react-native-purchases. If you haven't upgraded, you can follow [the instructions here to upgrade](https://docs.expo.io/versions/latest/expokit/expokit/#upgrading-expokit). 
 
-If you're planning on ejecting from Expo, upgrade your expo version _first_, THEN eject. It'll save you a whole lot of hassle.
+> ❗️ If you're planning on ejecting from Expo, upgrade your expo version _first_, THEN eject. It'll save you a whole lot of hassle. ❗️
 
-### Add the library to the project
+### 1. Add the library to the project
 
-`$ npm install react-native-purchases --save`
+```
+$ npm install react-native-purchases --save
+```
+
 or
-`$ yarn add react-native-purchases`
 
-### Link library to the project
+```
+$ yarn add react-native-purchases
+```
 
-`$ react-native link react-native-purchases`
+### 2. Link library to the project
+
+```
+$ react-native link react-native-purchases
+```
 
 ### Additional iOS Setup
 
-#### If your project uses Cocoapods
+### If your project uses Cocoapods
 If your project already uses Cocoapods to install iOS dependencies, common in ExpoKit projects, linking the library should have added it to the podfile. If it hasn't, add the following to your project's podfile to reference the library from your node_modules folder:
 
 ```ruby
@@ -53,35 +90,27 @@ pod 'RNPurchases', :path => '../node_modules/react-native-purchases'
 
 In your `ios` folder, run `pod install`. If you've just upgraded ExpoKit, you might need to upgrade cocoapods to the newest version: `sudo gem install cocoapods`. 
 
-#### Migrating from manual installation (if your project doesn't use CocoapodsCreate)
+### Migrating from manual installation (if your project doesn't use CocoapodsCreate)
 
-##### Remove the Framework Reference from your project
+### Remove the Framework Reference from your project
 
 1. Remove `Purchases.framework` and `PurchasesHybridCommon.framework` from the libraries section of the project. 
 
-##### Remove iOS Frameworks to Embedded Binaries
+### Remove iOS Frameworks to Embedded Binaries
 1. In Xcode, in project manager, select your app target.
 1. Select the general tab
 1. Look for `Purchases.framework` and `PurchasesHybridCommon.framework` in the Embedded Binaries section and remove them.
 
 Remove `$(PROJECT_DIR)/../node_modules/react-native-purchases/ios` from Framework Search paths in build settings
 
-##### Remove Strip Frameworks Phase
+### Remove Strip Frameworks Phase
 During the old manual installation instructions, now deprecated, we indicated to add a build phase to strip fat frameworks. 
 1. In Xcode, in project manager, select your app target.
 2. Open the `Build Phases` tab
 3. Remove the added `Strip Frameworks` phase
 4. Clean `Derived Data` 
 
-##### Link static library
+### Link static library
 The `react-native link` command should have added the `libRNPurchases.a` library to the _Linked Frameworks and Libraries_ section of your app target. If it hasn't add it like this:
 
 ![](https://media.giphy.com/media/U2MMgrdYlkRhEcy80J/giphy.gif)
-
-## Getting Started
-
-Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to use the SDK
-
-## SDK Reference
-Our full SDK reference [can be found here](https://revenuecat.github.io/react-native-purchases-docs).
-

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ react-native link react-native-purchases
 
 ### Additional iOS Setup
 
-### If your project uses Cocoapods
+#### If your project uses Cocoapods
 If your project already uses Cocoapods to install iOS dependencies, common in ExpoKit projects, linking the library should have added it to the podfile. If it hasn't, add the following to your project's podfile to reference the library from your node_modules folder:
 
 ```ruby
@@ -87,27 +87,27 @@ pod 'RNPurchases', :path => '../node_modules/react-native-purchases'
 
 In your `ios` folder, run `pod install`. If you've just upgraded ExpoKit, you might need to upgrade cocoapods to the newest version: `sudo gem install cocoapods`. 
 
-### Migrating from manual installation (if your project doesn't use CocoapodsCreate)
+#### Migrating from manual installation (if your project doesn't use CocoapodsCreate)
 
-### Remove the Framework Reference from your project
+##### Remove the Framework Reference from your project
 
 1. Remove `Purchases.framework` and `PurchasesHybridCommon.framework` from the libraries section of the project. 
 
-### Remove iOS Frameworks to Embedded Binaries
+##### Remove iOS Frameworks to Embedded Binaries
 1. In Xcode, in project manager, select your app target.
 1. Select the general tab
 1. Look for `Purchases.framework` and `PurchasesHybridCommon.framework` in the Embedded Binaries section and remove them.
 
 Remove `$(PROJECT_DIR)/../node_modules/react-native-purchases/ios` from Framework Search paths in build settings
 
-### Remove Strip Frameworks Phase
+##### Remove Strip Frameworks Phase
 During the old manual installation instructions, now deprecated, we indicated to add a build phase to strip fat frameworks. 
 1. In Xcode, in project manager, select your app target.
 2. Open the `Build Phases` tab
 3. Remove the added `Strip Frameworks` phase
 4. Clean `Derived Data` 
 
-### Link static library
+##### Link static library
 The `react-native link` command should have added the `libRNPurchases.a` library to the _Linked Frameworks and Libraries_ section of your app target. If it hasn't add it like this:
 
 ![](https://media.giphy.com/media/U2MMgrdYlkRhEcy80J/giphy.gif)

--- a/examples/MagicWeather/README.md
+++ b/examples/MagicWeather/README.md
@@ -15,13 +15,84 @@ See minimum react-native version requirements for RevenueCat's *Purchases* SDK [
 
 ## Features
 
-This sample demonstrates:
+| Feature                          | Sample Project Location                   |
+| -------------------------------- | ----------------------------------------- |
+| 🕹 Configuring the *Purchases* SDK  | [App.js](App.js#L17) |
+| 💰 Building a basic paywall         | [src/screens/PaywallScreen/index.js](src/screens/PaywallScreen/index.js) |
+| 🔐 Checking subscription status     | [src/screens/WeatherScreen/index.js](src/screens/WeatherScreen/index.js#L30) |
+| 🤑 Restoring transactions           | [src/components/RestorePurchasesButton/index.js](src/components/RestorePurchasesButton/index.js) |
+| 👥 Identifying the user             | [src/components/LoginForm/index.js](src/components/LoginForm/index.js) |
+| 🚪 Logging out the user             | [src/components/LogoutButton/index.js](src/components/LogoutButton/index.js) |
 
-- How to [configure](App.js#L17) an instance of *Purchases*
-- How to display product prices and names, and how to build a basic [paywall](src/screens/PaywallScreen/index.js)
-- How to check [subscription status](src/screens/WeatherScreen/index.js#L30)
-- How to [restore transactions](src/components/RestorePurchasesButton/index.js)
-- How to [identify](src/components/LoginForm/index.js) users and how to [logout](src/components/LogoutButton/index.js)
+## Setup & Run
+
+### Prerequisites
+- Be sure to have an an [Apple Developer Account](https://developer.apple.com/account/) or [Google Play Console Account](https://play.google.com/console/developers).
+- Be sure to set up at least one subscription on the [App Store](https://docs.revenuecat.com/docs/apple-app-store) or [Play Store](https://docs.revenuecat.com/docs/google-play-store) and link it to RevenueCat:
+    - Add the [product](https://docs.revenuecat.com/docs/entitlements#products) (e.g. `rc_3999_1y`) to RevenueCat's dashboard. It should match the product ID on the App/Play Store.
+    - Attach the product to an [entitlement](https://docs.revenuecat.com/docs/entitlements#creating-an-entitlement), e.g. `premium`.
+    - Attach the product to a [package](https://docs.revenuecat.com/docs/entitlements#adding-packages) (e.g. `Annual`) inside an [offering](https://docs.revenuecat.com/docs/entitlements#creating-an-offering) (e.g. `sale` or `default`).
+- Get your [API key](https://docs.revenuecat.com/docs/authentication#obtaining-api-keys) from your RevenueCat project.
+
+### Steps to Run
+1. Download or clone this repository
+    > git clone https://github.com/RevenueCat/react-native-purchases.git
+
+2. Ensure you have [node package manager (npm)](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed on your machine.
+
+3. Navigate into the `MagicWeather` directory and install the dependencies using npm
+
+    ```
+    cd react-native-purchases/examples/MagicWeather
+    npm install
+    ```
+
+4. Navigate into the `ios` directory and install the pod file.
+
+    ```
+    cd ios
+    pod install
+    ```
+
+5. Open the `Xcode project` file (ios/MagicWeatherReactNative.xcodeproj) and match the `bundle ID` to your App Store package in App Store Connect and RevenueCat.
+    
+    <img src="https://i.imgur.com/1z32GRo.png" alt="General tab in Xcode" width="250px" />
+
+6. Open the `build.gradle` file (android/app/build.gradle#L134) and match `applicationId` to your Google Play package in Google Play Console and RevenueCat.
+    
+    <img src="https://i.imgur.com/oZIAvOc.png" alt="Build Gradle with applicationId" width="250px" />
+
+7. Open `Constants/index.js` (src/constants/index.js): 
+    - Replace the value for `API_KEY` with the API key from your RevenueCat project.
+    - Replace the value for `entitlementID` with the entitlement ID of your product in RevenueCat's dashboard.
+    - Comment out the error directives.
+
+    <img src="https://i.imgur.com/x1bvUTJ.png" alt="Constants/index.js file" width="250px" />
+
+8. Run the app on a simulator or physical device.
+
+```
+npm run ios
+```
+
+or
+
+```
+npm run android
+```
+
+
+### Example Flow: Purchasing a Subscription
+
+1. On the home page, select **Change the Weather**.
+2. On the prompted payment sheet, select the product listed.
+3. On the next modal, select **Subscribe**.
+4. On the next modal, sign in with your Sandbox User ID.
+5. On the next modal, select **Ok**.
+6. Return to the home page and select **Change the Weather** to see the weather change!
+
+#### Purchase Flow Demo (`iOS` version)
+<img src="https://i.imgur.com/SSbRLhr.gif" width="220px" />
 
 ## Support
 

--- a/examples/MagicWeather/README.md
+++ b/examples/MagicWeather/README.md
@@ -19,7 +19,7 @@ See minimum react-native version requirements for RevenueCat's *Purchases* SDK [
 | -------------------------------- | ----------------------------------------- |
 | 🕹 Configuring the *Purchases* SDK  | [App.js](App.js#L17) |
 | 💰 Building a basic paywall         | [src/screens/PaywallScreen/index.js](src/screens/PaywallScreen/index.js) |
-| 🔐 Checking subscription status     | [src/screens/WeatherScreen/index.js](src/screens/WeatherScreen/index.js#L30) |
+| 🔐 Checking subscription status     | [src/screens/WeatherScreen/index.js](src/screens/WeatherScreen/index.js) |
 | 🤑 Restoring transactions           | [src/components/RestorePurchasesButton/index.js](src/components/RestorePurchasesButton/index.js) |
 | 👥 Identifying the user             | [src/components/LoginForm/index.js](src/components/LoginForm/index.js) |
 | 🚪 Logging out the user             | [src/components/LogoutButton/index.js](src/components/LogoutButton/index.js) |


### PR DESCRIPTION
The main README has been updated to match the purchases-ios version. This includes changes to the banner and RevenueCat description at the top and some miscellaneous sections (e.g., SDK Reference, Contributing). The "Installation" section related to React Native has been preserved.

The MagicWeather example app README has been updated to match the purchases-ios version, with instructions for both iOS and Android integration, and screenshots.

Thank you for contributing to react-native-purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [ x ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.
