### PR TITLE
Move prepare_next_version job to different workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,12 +160,17 @@ workflows:
           <<: *release-branches
       - make-release:
           <<: *release-tags
-      - prepare-next-version:
-          <<: *only-main-branch
       - docs-deploy:
           <<: *release-tags
           requires:
             - make-release
+  snapshot-bump:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    jobs:
+      - prepare-next-version:
+          <<: *only-main-branch
   danger:
     when:
       not:


### PR DESCRIPTION
Followup to https://github.com/RevenueCat/react-native-purchases/pull/432 to move the `prepare_next_version` job to a different workflow, since it won't be directly linked to the deploy workflow anymore.
