### PR TITLE
Use receivedUpdatedCustomerInfo instead of didReceiveUpdatedCustomerInfo

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -314,7 +314,7 @@ RCT_REMAP_METHOD(isConfigured,
 
 #pragma mark -
 #pragma mark Delegate Methods
-- (void)purchases:(RCPurchases *)purchases didReceiveUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
+- (void)purchases:(RCPurchases *)purchases receivedUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {
     [self sendEventWithName:RNPurchasesCustomerInfoUpdatedEvent body:customerInfo.dictionary];
 }
 


### PR DESCRIPTION
### A description about what and why you are contributing, even if it's trivial.
It seems like the react native `addCustomerInfoUpdateListener` never gets called. Looking at the code it seems like at some point the iOS code changed to using receivedUpdatedCustomerInfo for the delegate instead of didReceiveUpdatedCustomerInfo. This is kind of obscured because you have to trace it through the hybrid shared project. I believe this should fix it though. Related PR which is a good place to start when trying to track down the initial change https://github.com/RevenueCat/purchases-ios/pull/1836

### The issue number(s) or PR number(s) in the description if you are contributing in response to those.
Here is a thread and someone else saying they ran into this error: https://community.revenuecat.com/sdks-51/addcustomerinfoupdatelistener-is-never-called-2073

### If applicable, unit tests.
  There were previously no tests, it would be nice for this to be typesafe but I assume there is some reason it is not and so didn't spend much time trying.
