### PR TITLE
Remove Podfile.locks when running `pods` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tslint": "tslint -c tslint.json 'src/*.ts'",
     "prepublish": "tsc",
     "example": "yarn --cwd examples/MagicWeather && yarn --cwd examples/purchaseTesterTypescript",
-    "pods": "(cd examples/MagicWeather && npx pod-install --quiet) && (cd examples/purchaseTesterTypescript && npx pod-install --quiet)",
+    "pods": "(cd examples/MagicWeather && rm -f ios/Podfile.lock && npx pod-install --quiet) && (cd examples/purchaseTesterTypescript && rm -f ios/Podfile.lock && npx pod-install --quiet)",
     "bootstrap": "yarn example && yarn && yarn pods"
   },
   "repository": {


### PR DESCRIPTION
I've noticed everytime we update the version of `PurchasesHybridCommon` running `npx pod-install --quiet` fails and asks to run `pod update PurchasesHybridCommon`. Since we are using the pod-install package we can't run `pod repo update` so I figured we could just remove the lockfile before running `npx pod-install`.

I know this is not ideal, but I would like `yarn bootstrap` to prepare everything correctly. Please note the lockfiles are not pushed to the repository