### PR TITLE
Add beginRefundRequest APIs for iOS 15+

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,16 +1,21 @@
 const {NativeModules, NativeEventEmitter, Platform} = require("react-native");
+const { UnsupportedPlatformError } = require("../dist/errors");
+const { REFUND_REQUEST_STATUS } = require("../dist/purchases");
 
 const nativeEmitter = new NativeEventEmitter();
 
 describe("Purchases", () => {
+  var Purchases;
+
   beforeEach(() => {
     jest.resetAllMocks();
     NativeModules.RNPurchases.isConfigured.mockResolvedValue(true);
+
+    Purchases = require("../dist/index").default;
   });
 
   it("addCustomerInfoUpdateListener correctly saves listeners", () => {
     const listener = jest.fn();
-    const Purchases = require("../dist/index").default;
 
     Purchases.addCustomerInfoUpdateListener(listener);
 
@@ -20,7 +25,6 @@ describe("Purchases", () => {
   });
 
   it("removeCustomerInfoUpdateListener correctly removes a listener", () => {
-    const Purchases = require("../dist/index").default;
     const listener = jest.fn();
     Purchases.addCustomerInfoUpdateListener(listener);
     Purchases.removeCustomerInfoUpdateListener(listener);
@@ -37,7 +41,6 @@ describe("Purchases", () => {
 
   it("addShouldPurchasePromoProductListener correctly saves listeners", () => {
     const listener = jest.fn();
-    const Purchases = require("../dist/index").default;
 
     Purchases.addShouldPurchasePromoProductListener(listener);
 
@@ -54,8 +57,6 @@ describe("Purchases", () => {
     const listener = deferredPurchase => {
       this.deferredPurchase = deferredPurchase;
     };
-
-    const Purchases = require("../dist/index").default;
 
     Purchases.addShouldPurchasePromoProductListener(listener);
 
@@ -78,7 +79,6 @@ describe("Purchases", () => {
   });
 
   it("removeShouldPurchasePromoProductListener correctly removes a listener", () => {
-    const Purchases = require("../dist/index").default;
     const listener = jest.fn();
     Purchases.addShouldPurchasePromoProductListener(listener);
     Purchases.removeShouldPurchasePromoProductListener(listener);
@@ -95,8 +95,6 @@ describe("Purchases", () => {
   });
 
   it("calling configure without an object throws exception", () => {
-    const Purchases = require("../dist/index").default;
-
     expect(() => {
       Purchases.configure("api_key")
     }).toThrowError("Invalid API key. It must be called with an Object: configure({apiKey: \"key\"})");
@@ -109,8 +107,6 @@ describe("Purchases", () => {
   });
 
   it("calling configure with invalid user ID type throws exception", () => {
-    const Purchases = require("../dist/index").default;
-
     expect(() => {
       Purchases.configure({apiKey: "api_key", appUserID: 123})
     }).toThrowError();
@@ -128,8 +124,6 @@ describe("Purchases", () => {
   })
 
   it("allowing sharing store account works", async () => {
-    const Purchases = require("../dist/index").default;
-
     await Purchases.setAllowSharingStoreAccount(true)
 
     expect(NativeModules.RNPurchases.setAllowSharingStoreAccount).toBeCalledWith(true);
@@ -137,8 +131,6 @@ describe("Purchases", () => {
   })
 
   it("disallowing sharing store account works", async () => {
-    const Purchases = require("../dist/index").default;
-
     await Purchases.setAllowSharingStoreAccount(false)
 
     expect(NativeModules.RNPurchases.setAllowSharingStoreAccount).toBeCalledWith(false);
@@ -146,8 +138,6 @@ describe("Purchases", () => {
   })
 
   it("get offerings works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.getOfferings.mockResolvedValueOnce(offeringsStub);
 
     const offerings = await Purchases.getOfferings();
@@ -157,8 +147,6 @@ describe("Purchases", () => {
   })
 
   it("getProducts works and gets subs by default", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.getProductInfo.mockResolvedValueOnce(productsStub);
 
     let products = await Purchases.getProducts("onemonth_freetrial");
@@ -178,8 +166,6 @@ describe("Purchases", () => {
 
 
   it("purchaseProduct works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchaseProduct.mockResolvedValue({
       purchasedProductIdentifier: "123",
       customerInfo: customerInfoStub
@@ -207,8 +193,6 @@ describe("Purchases", () => {
   });
 
   it("purchasePackage works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
       purchasedProductIdentifier: "123",
       customerInfo: customerInfoStub
@@ -262,8 +246,6 @@ describe("Purchases", () => {
   });
 
   it("restorePurchases works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.restorePurchases.mockResolvedValueOnce(customerInfoStub);
 
     const customerInfo = await Purchases.restorePurchases();
@@ -273,8 +255,6 @@ describe("Purchases", () => {
   })
 
   it("getAppUserID works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.getAppUserID.mockResolvedValueOnce("123");
 
     const appUserID = await Purchases.getAppUserID()
@@ -284,8 +264,6 @@ describe("Purchases", () => {
   })
 
   describe("when calling logIn", () => {
-    const Purchases = require("../dist/index").default;
-
     it("throws an error if the appUserID is not a string", () => {
       expect(async () => {
         await Purchases.logIn(123)
@@ -317,7 +295,6 @@ describe("Purchases", () => {
   });
 
   describe("when calling logOut", () => {
-    const Purchases = require("../dist/index").default;
     it("correctly passes the call to the native module and returns the value", async () => {
       NativeModules.RNPurchases.logOut.mockResolvedValueOnce(customerInfoStub);
 
@@ -329,8 +306,6 @@ describe("Purchases", () => {
   });
 
   it("setDebugLogsEnabled works", () => {
-    const Purchases = require("../dist/index").default;
-
     Purchases.setDebugLogsEnabled(true)
 
     expect(NativeModules.RNPurchases.setDebugLogsEnabled).toBeCalledWith(true);
@@ -343,8 +318,6 @@ describe("Purchases", () => {
   })
 
   it("getCustomerInfo works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.getCustomerInfo.mockResolvedValueOnce(customerInfoStub);
 
     const customerInfo = await Purchases.getCustomerInfo();
@@ -354,8 +327,6 @@ describe("Purchases", () => {
   })
 
   it("configure works", async () => {
-    const Purchases = require("../dist/index").default;
-
     Purchases.configure({apiKey: "key", appUserID: "user"});
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false);
 
@@ -372,8 +343,6 @@ describe("Purchases", () => {
   })
 
   it("cancelled purchaseProduct sets userCancelled in the error", () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchaseProduct.mockRejectedValueOnce({
       code: "1",
       message: "User cancelled",
@@ -391,8 +360,6 @@ describe("Purchases", () => {
   });
 
   it("cancelled purchasePackage sets userCancelled in the error", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchasePackage.mockRejectedValueOnce({
       code: "1",
       message: "User cancelled",
@@ -412,8 +379,6 @@ describe("Purchases", () => {
   });
 
   it("successful purchase works", () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchaseProduct.mockResolvedValueOnce({
       purchasedProductIdentifier: "123",
       customerInfo: customerInfoStub
@@ -426,8 +391,6 @@ describe("Purchases", () => {
   })
 
   it("syncpurchases works for android", async () => {
-    const Purchases = require("../dist/index").default;
-
     Platform.OS = "android";
 
     await Purchases.syncPurchases();
@@ -436,8 +399,6 @@ describe("Purchases", () => {
   })
 
   it("syncpurchases works for ios", async () => {
-    const Purchases = require("../dist/index").default;
-
     Platform.OS = "ios";
 
     await Purchases.syncPurchases();
@@ -447,8 +408,6 @@ describe("Purchases", () => {
 
 
   it("finishTransactions works", async () => {
-    const Purchases = require("../dist/index").default;
-
     await Purchases.setFinishTransactions(true);
     expect(NativeModules.RNPurchases.setFinishTransactions).toBeCalledWith(true);
 
@@ -459,16 +418,12 @@ describe("Purchases", () => {
   })
 
   it("checkTrialOrIntroductoryPriceEligibility works", async () => {
-    const Purchases = require("../dist/index").default;
-
     await Purchases.checkTrialOrIntroductoryPriceEligibility(["monthly"])
 
     expect(NativeModules.RNPurchases.checkTrialOrIntroductoryPriceEligibility).toBeCalledWith(["monthly"]);
   })
 
   it("getPromotionalOffer works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.getPromotionalOffer.mockResolvedValue(promotionalOfferStub);
 
     const aProduct = {
@@ -483,8 +438,6 @@ describe("Purchases", () => {
   });
 
   it("getPromotionalOffer returns undefined for Android", async () => {
-    const Purchases = require("../dist/index").default;
-
     Platform.OS = "android";
 
     let promotionalOffer = await Purchases.getPromotionalOffer(productStub, discountStub);
@@ -494,7 +447,6 @@ describe("Purchases", () => {
   });
 
   it("getPromotionalOffer throws error when null discount", () => {
-    const Purchases = require("../dist/index").default;
     Platform.OS = "ios";
 
     expect(async () => {
@@ -509,8 +461,6 @@ describe("Purchases", () => {
   });
 
   it("purchaseDiscountedProduct works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchaseProduct.mockResolvedValue({
       purchasedProductIdentifier: "123",
       customerInfo: customerInfoStub
@@ -528,8 +478,6 @@ describe("Purchases", () => {
   });
 
   it("purchaseDiscountedProduct throws if null or undefined discount", () => {
-    const Purchases = require("../dist/index").default;
-
     expect(async () => {
       Purchases.purchaseDiscountedProduct(productStub, null)
     }).rejects.toThrow();
@@ -542,8 +490,6 @@ describe("Purchases", () => {
   });
 
   it("purchaseDiscountedPackage works", async () => {
-    const Purchases = require("../dist/index").default;
-
     NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
       purchasedProductIdentifier: "123",
       customerInfo: customerInfoStub
@@ -572,8 +518,6 @@ describe("Purchases", () => {
   });
 
   it("purchaseDiscountedPackage throws if null or undefined discount", () => {
-    const Purchases = require("../dist/index").default;
-
     expect(async () => {
       await Purchases.purchaseDiscountedPackage(packagestub, null)
     }).rejects.toThrow();
@@ -588,7 +532,6 @@ describe("Purchases", () => {
   describe("invalidate customer info cache", () => {
     describe("when invalidateCustomerInfoCache is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
         await Purchases.invalidateCustomerInfoCache();
 
         expect(NativeModules.RNPurchases.invalidateCustomerInfoCache).toBeCalledTimes(1);
@@ -599,7 +542,6 @@ describe("Purchases", () => {
   describe("setAttributes", () => {
     describe("when setAttributes is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
         const attributes = { band: "AirBourne", song: "Back in the game" }
 
         await Purchases.setAttributes(attributes);
@@ -613,7 +555,6 @@ describe("Purchases", () => {
   describe("setEmail", () => {
     describe("when setEmail is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
         const email = "garfield@revenuecat.com";
 
         await Purchases.setEmail(email);
@@ -627,7 +568,6 @@ describe("Purchases", () => {
   describe("setPhoneNumber", () => {
     describe("when setPhoneNumber is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
         const phoneNumber = "+123456789";
 
         await Purchases.setPhoneNumber(phoneNumber);
@@ -641,7 +581,6 @@ describe("Purchases", () => {
   describe("setDisplayName", () => {
     describe("when setDisplayName is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
         const displayName = "Garfield";
 
         await Purchases.setDisplayName(displayName);
@@ -655,8 +594,6 @@ describe("Purchases", () => {
   describe("setPushToken", () => {
     describe("when setPushToken is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
-
         const pushToken = "65a1ds56adsgh6954asd";
 
         await Purchases.setPushToken(pushToken);
@@ -670,8 +607,6 @@ describe("Purchases", () => {
   describe("canMakePayments", () => {
     describe("when no parameters are passed", () => {
       it("calls Purchases with empty list", () => {
-        const Purchases = require("../dist/index").default;
-
         Purchases.canMakePayments();
 
         expect(NativeModules.RNPurchases.canMakePayments).toBeCalledTimes(1);
@@ -680,8 +615,6 @@ describe("Purchases", () => {
     });
     describe("when empty list is passed", () => {
       it("calls Purchases with empty list", () => {
-        const Purchases = require("../dist/index").default;
-
         Purchases.canMakePayments([]);
 
         expect(NativeModules.RNPurchases.canMakePayments).toBeCalledTimes(1);
@@ -690,8 +623,6 @@ describe("Purchases", () => {
     });
     describe("when list of parameters are passed", () => {
       it("calls Purchases with list of features", () => {
-        const Purchases = require("../dist/index").default;
-
         Purchases.canMakePayments([Purchases.BILLING_FEATURE.SUBSCRIPTIONS]);
 
         expect(NativeModules.RNPurchases.canMakePayments).toBeCalledTimes(1);
@@ -700,8 +631,6 @@ describe("Purchases", () => {
     });
     describe("when list of parameters are passed", () => {
         it("parameters are mapped successfully", () => {
-          const Purchases = require("../dist/index").default;
-
           Purchases.canMakePayments([Purchases.BILLING_FEATURE.SUBSCRIPTIONS,
             Purchases.BILLING_FEATURE.PRICE_CHANGE_CONFIRMATION,
             Purchases.BILLING_FEATURE.SUBSCRIPTIONS_ON_VR,
@@ -718,8 +647,6 @@ describe("Purchases", () => {
   describe("isConfigured", () => {
     describe("when Purchases is configured", () => {
       it("isConfigured returns true", async () => {
-        const Purchases = require("../dist/index").default;
-
         const isConfigured = await Purchases.isConfigured();
 
         expect(NativeModules.RNPurchases.isConfigured).toBeCalledTimes(1);
@@ -728,7 +655,6 @@ describe("Purchases", () => {
     });
     describe("when Purchases is not configured", () => {
       it("isConfigured returns false", async () => {
-        const Purchases = require("../dist/index").default;
         NativeModules.RNPurchases.isConfigured.mockResolvedValueOnce(false);
 
         const isConfigured = await Purchases.isConfigured();
@@ -745,7 +671,6 @@ describe("Purchases", () => {
     }
 
     it("for functions that require the SDK to be configured if called before configuring", async () => {
-      const Purchases = require("../dist/index").default;
       NativeModules.RNPurchases.isConfigured.mockResolvedValue(false);
 
       const allPropertyNames = Object.getOwnPropertyNames( Purchases );
@@ -764,7 +689,9 @@ describe("Purchases", () => {
         "canMakePayments",
         "UninitializedPurchasesError",
         "throwIfNotConfigured",
-        "isConfigured"
+        "throwIfAndroidPlatform",
+        "convertIntToRefundRequestStatus",
+        "isConfigured",
       ];
       const expected = new Purchases.UninitializedPurchasesError();
       for (let i = 0; i < allPropertyNames.length; i++) {
@@ -788,8 +715,6 @@ describe("Purchases", () => {
   describe("setCleverTapID", () => {
     describe("when setCleverTapID is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
-
         const attributionID = "65a1ds56adsgh6954asd";
 
         await Purchases.setCleverTapID(attributionID);
@@ -803,8 +728,6 @@ describe("Purchases", () => {
   describe("setMixpanelDistinctID", () => {
     describe("when setMixpanelDistinctID is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
-
         const attributionID = "65a1ds56adsgh6954asd";
 
         await Purchases.setMixpanelDistinctID(attributionID);
@@ -818,14 +741,191 @@ describe("Purchases", () => {
   describe("setFirebaseAppInstanceID", () => {
     describe("when setFirebaseAppInstanceID is called", () => {
       it("makes the right call to Purchases", async () => {
-        const Purchases = require("../dist/index").default;
-
         const attributionID = "65a1ds56adsgh6954asd";
 
         await Purchases.setFirebaseAppInstanceID(attributionID);
 
         expect(NativeModules.RNPurchases.setFirebaseAppInstanceID).toBeCalledTimes(1);
         expect(NativeModules.RNPurchases.setFirebaseAppInstanceID).toBeCalledWith(attributionID);
+      });
+    });
+  });
+
+  describe("beginRefundRequest", () => {
+    beforeEach(() => {
+      Platform.OS = "iOS";
+    });
+
+    describe("forActiveEntitlement", () => {
+      it("throws UnsupportedPlatformError if called on Android", async () => {
+        Platform.OS = "android";
+
+        try {
+          await Purchases.beginRefundRequestForActiveEntitlement();
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("throws UnsupportedPlatformError if native returns null", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement.mockResolvedValueOnce(null);
+
+        try {
+          await Purchases.beginRefundRequestForActiveEntitlement();
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("returns success if getting success from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement.mockResolvedValueOnce(0);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.SUCCESS);
+      });
+
+      it("returns user cancelled if getting user cancelled from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement.mockResolvedValueOnce(1);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.USER_CANCELLED);
+      });
+
+      it("returns error if getting different code from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement.mockResolvedValueOnce(2);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForActiveEntitlement();
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.ERROR);
+      });
+
+      it("makes right calls", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement.mockResolvedValueOnce(0);
+
+        await Purchases.beginRefundRequestForActiveEntitlement();
+
+        expect(NativeModules.RNPurchases.beginRefundRequestForActiveEntitlement).toBeCalledTimes(1);
+      });
+    });
+
+    describe("forEntitlement", () => {
+      it("throws UnsupportedPlatformError if called on Android", async () => {
+        Platform.OS = "android";
+
+        try {
+          await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("throws UnsupportedPlatformError if native returns null", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForEntitlementId.mockResolvedValueOnce(null);
+
+        try {
+          await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("returns success if getting success from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForEntitlementId.mockResolvedValueOnce(0);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.SUCCESS);
+      });
+
+      it("returns user cancelled if getting user cancelled from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForEntitlementId.mockResolvedValueOnce(1);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.USER_CANCELLED);
+      });
+
+      it("returns error if getting different code from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForEntitlementId.mockResolvedValueOnce(2);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.ERROR);
+      });
+
+      it("makes right calls", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForEntitlementId.mockResolvedValueOnce(0);
+
+        await Purchases.beginRefundRequestForEntitlement(entitlementInfoStub);
+
+        expect(NativeModules.RNPurchases.beginRefundRequestForEntitlementId).toBeCalledTimes(1);
+        expect(NativeModules.RNPurchases.beginRefundRequestForEntitlementId).toBeCalledWith("entitlement_id");
+      });
+    });
+
+    describe("forProduct", () => {
+      it("throws UnsupportedPlatformError if called on Android", async () => {
+        Platform.OS = "android";
+
+        try {
+          await Purchases.beginRefundRequestForProduct(productStub);
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("throws UnsupportedPlatformError if native returns null", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForProductId.mockResolvedValueOnce(null);
+
+        try {
+          await Purchases.beginRefundRequestForProduct(productStub);
+          fail("expected error");
+        } catch (error) {
+          if (!(error instanceof UnsupportedPlatformError)) {
+            fail("expected UnsupportedPlatformException");
+          }
+        }
+      });
+
+      it("returns success if getting success from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForProductId.mockResolvedValueOnce(0);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForProduct(productStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.SUCCESS);
+      });
+
+      it("returns user cancelled if getting user cancelled from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForProductId.mockResolvedValueOnce(1);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForProduct(productStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.USER_CANCELLED);
+      });
+
+      it("returns error if getting different code from native layer", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForProductId.mockResolvedValueOnce(2);
+
+        let refundRequestStatus = await Purchases.beginRefundRequestForProduct(productStub);
+        expect(refundRequestStatus).toEqual(REFUND_REQUEST_STATUS.ERROR);
+      });
+
+      it("makes right calls", async () => {
+        NativeModules.RNPurchases.beginRefundRequestForProductId.mockResolvedValueOnce(0);
+
+        await Purchases.beginRefundRequestForProduct(productStub);
+
+        expect(NativeModules.RNPurchases.beginRefundRequestForProductId).toBeCalledTimes(1);
+        expect(NativeModules.RNPurchases.beginRefundRequestForProductId).toBeCalledWith("onemonth_freetrial");
       });
     });
   });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -688,6 +688,7 @@ describe("Purchases", () => {
         "setDebugLogsEnabled",
         "canMakePayments",
         "UninitializedPurchasesError",
+        "UnsupportedPlatformError",
         "throwIfNotConfigured",
         "throwIfAndroidPlatform",
         "convertIntToRefundRequestStatus",

--- a/apitesters/enums.ts
+++ b/apitesters/enums.ts
@@ -2,6 +2,7 @@ import {
   BILLING_FEATURE,
   PURCHASE_TYPE,
   PACKAGE_TYPE,
+  REFUND_REQUEST_STATUS,
   INTRO_ELIGIBILITY_STATUS,
   PRORATION_MODE
 } from '../dist';
@@ -53,5 +54,13 @@ function checkProrationMode(mode: PRORATION_MODE): boolean {
     case PRORATION_MODE.IMMEDIATE_AND_CHARGE_PRORATED_PRICE: return true;
     case PRORATION_MODE.IMMEDIATE_WITHOUT_PRORATION: return true;
     case PRORATION_MODE.DEFERRED: return true;
+  }
+}
+
+function checkRefundRequestStatus(status: REFUND_REQUEST_STATUS): boolean {
+  switch (status) {
+    case REFUND_REQUEST_STATUS.SUCCESS: return true;
+    case REFUND_REQUEST_STATUS.USER_CANCELLED: return true;
+    case REFUND_REQUEST_STATUS.ERROR: return true;
   }
 }

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -1,11 +1,13 @@
 import {
   CustomerInfo,
+  PurchasesEntitlementInfo,
   PurchasesOfferings,
   PurchasesPackage,
   PurchasesPromotionalOffer,
   PurchasesStoreProduct,
   UpgradeInfo,
   MakePurchaseResult,
+  REFUND_REQUEST_STATUS,
   PURCHASE_TYPE, PurchasesStoreProductDiscount, BILLING_FEATURE, IntroEligibility,
   LogInResult, ShouldPurchasePromoProductListener, CustomerInfoUpdateListener
 } from '../dist';
@@ -133,4 +135,10 @@ function checkListeners() {
 
   Purchases.addShouldPurchasePromoProductListener(shouldPurchaseListener);
   Purchases.removeShouldPurchasePromoProductListener(shouldPurchaseListener);
+}
+
+async function checkBeginRefundRequest(entitlementInfo: PurchasesEntitlementInfo, storeProduct: PurchasesStoreProduct) {
+  const refundStatus1: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForActiveEntitlement();
+  const refundStatus2: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForEntitlement(entitlementInfo);
+  const refundStatus3: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForProduct(storeProduct);
 }

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -318,6 +318,52 @@ RCT_REMAP_METHOD(canMakePayments,
       resolve(@([RCCommonFunctionality canMakePaymentsWithFeatures:features]));
 }
 
+RCT_EXPORT_METHOD(beginRefundRequestForActiveEntitlement:(RCTPromiseResolveBlock)resolve
+                                                  reject:(RCTPromiseRejectBlock)reject) {
+    #if TARGET_OS_IPHONE
+    if (@available(iOS 15.0, *)) {
+        [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:[self getBeginRefundResponseCompletionBlockWithResolve:resolve
+                                                                                                                                reject:reject]];
+    } else {
+        resolve(nil);
+    }
+    #else
+    resolve(nil);
+    #endif
+}
+
+RCT_EXPORT_METHOD(beginRefundRequestForEntitlementId:(NSString *)entitlementIdentifier
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    #if TARGET_OS_IPHONE
+    if (@available(iOS 15.0, *)) {
+        [RCCommonFunctionality beginRefundRequestEntitlementId:entitlementIdentifier
+                                               completionBlock:[self getBeginRefundResponseCompletionBlockWithResolve:resolve
+                                                                                                               reject:reject]];
+    } else {
+        resolve(nil);
+    }
+    #else
+    resolve(nil);
+    #endif
+}
+
+RCT_EXPORT_METHOD(beginRefundRequestForProductId:(NSString *)productIdentifier
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    #if TARGET_OS_IPHONE
+    if (@available(iOS 15.0, *)) {
+        [RCCommonFunctionality beginRefundRequestProductId:productIdentifier
+                                           completionBlock:[self getBeginRefundResponseCompletionBlockWithResolve:resolve
+                                                                                                           reject:reject]];
+    } else {
+        resolve(nil);
+    }
+    #else
+    resolve(nil);
+    #endif
+}
+
 RCT_REMAP_METHOD(isConfigured,
                  isConfiguredWithResolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
@@ -344,19 +390,35 @@ readyForPromotedProduct:(RCStoreProduct *)product
 #pragma mark -
 #pragma mark Helper Methods
 
-- (void)rejectPromiseWithBlock:(RCTPromiseRejectBlock)reject error:(NSError *)error {
-    reject([NSString stringWithFormat: @"%ld", (long)error.code], error.localizedDescription, error);
+- (void)rejectPromiseWithBlock:(RCTPromiseRejectBlock)reject error:(RCErrorContainer *)error {
+    reject([NSString stringWithFormat:@"%ld", (long) error.code], error.message, error.error);
 }
 
 - (void (^)(NSDictionary *, RCErrorContainer *))getResponseCompletionBlockWithResolve:(RCTPromiseResolveBlock)resolve
                                                                                reject:(RCTPromiseRejectBlock)reject {
     return ^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
         if (error) {
-            reject([NSString stringWithFormat:@"%ld", (long) error.code], error.message, error.error);
+            [self rejectPromiseWithBlock:reject error:error];
         } else if (responseDictionary) {
             resolve([NSDictionary dictionaryWithDictionary:responseDictionary]);
         } else {
             resolve(nil);
+        }
+    };
+}
+
+- (void (^)(RCErrorContainer *))getBeginRefundResponseCompletionBlockWithResolve:(RCTPromiseResolveBlock)resolve
+                                                                          reject:(RCTPromiseRejectBlock)reject {
+    return ^(RCErrorContainer * _Nullable error) {
+        if (error == nil) {
+            NSLog(@"[Purchases] TEST LOG: 0");
+            resolve(@0);
+        } else if ([error.info[@"userCancelled"] isEqual:@YES]) {
+                        NSLog(@"[Purchases] TEST LOG: 1");
+            resolve(@1);
+        } else {
+                        NSLog(@"[Purchases] TEST LOG: 2");
+            [self rejectPromiseWithBlock:reject error:error];
         }
     };
 }

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -411,13 +411,10 @@ readyForPromotedProduct:(RCStoreProduct *)product
                                                                           reject:(RCTPromiseRejectBlock)reject {
     return ^(RCErrorContainer * _Nullable error) {
         if (error == nil) {
-            NSLog(@"[Purchases] TEST LOG: 0");
             resolve(@0);
         } else if ([error.info[@"userCancelled"] isEqual:@YES]) {
-                        NSLog(@"[Purchases] TEST LOG: 1");
             resolve(@1);
         } else {
-                        NSLog(@"[Purchases] TEST LOG: 2");
             [self rejectPromiseWithBlock:reject error:error];
         }
     };

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -710,7 +710,22 @@ global.promotionalOfferStub = {
   nonce: "nonce",
   signature: "signature",
   timestamp: 123,
-}
+};
+
+global.entitlementInfoStub = {
+  identifier: "entitlement_id",
+  isActive: true,
+  willRenew: true,
+  periodType: "",
+  latestPurchaseDate: "",
+  originalPurchaseDate: "",
+  expirationDate: "",
+  store: "APP_STORE",
+  productIdentifier: "product_id",
+  isSandbox: false,
+  unsubscribeDetectedAt: null,
+  billingIssueDetectedAt: null
+};
 
 NativeModules.RNPurchases = {
   setupPurchases: jest.fn(),
@@ -745,6 +760,9 @@ NativeModules.RNPurchases = {
   setMixpanelDistinctID: jest.fn(),
   setFirebaseAppInstanceID: jest.fn(),
   canMakePayments: jest.fn(),
+  beginRefundRequestForActiveEntitlement: jest.fn(),
+  beginRefundRequestForEntitlementId: jest.fn(),
+  beginRefundRequestForProductId: jest.fn(),
   isConfigured: jest.fn()
 };
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,5 +64,8 @@ export class UninitializedPurchasesError extends Error {
 export class UnsupportedPlatformError extends Error {
     constructor() {
         super("This method is not available in the current platform.");
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, UnsupportedPlatformError.prototype);
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-
+/* tslint:disable:max-classes-per-file */
 // Error codes indicating the reason for an error.
 export enum PURCHASES_ERROR_CODE {
     UNKNOWN_ERROR = "0",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -64,8 +64,5 @@ export class UninitializedPurchasesError extends Error {
 export class UnsupportedPlatformError extends Error {
     constructor() {
         super("This method is not available in the current platform.");
-
-        // Set the prototype explicitly.
-        Object.setPrototypeOf(this, UnsupportedPlatformError.prototype);
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,7 +34,7 @@ export interface PurchasesError {
     readableErrorCode: string;
     userInfo: ErrorInfo;
     underlyingErrorMessage: string;
-    
+
     // @deprecated
     // use code === Purchases.PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR instead
     userCancelled: boolean | null;
@@ -55,5 +55,17 @@ export class UninitializedPurchasesError extends Error {
 
         // Set the prototype explicitly.
         Object.setPrototypeOf(this, UninitializedPurchasesError.prototype);
+    }
+}
+
+/**
+ * @internal
+ */
+export class UnsupportedPlatformError extends Error {
+    constructor() {
+        super("This method is not available in the current platform.");
+
+        // Set the prototype explicitly.
+        Object.setPrototypeOf(this, UnsupportedPlatformError.prototype);
     }
 }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -93,14 +93,14 @@ export enum BILLING_FEATURE {
 
 export enum REFUND_REQUEST_STATUS {
     /**
+     * Apple has received the refund request.
+     */
+        SUCCESS,
+
+    /**
      * User canceled submission of the refund request.
      */
     USER_CANCELLED,
-
-    /**
-     * Apple has received the refund request.
-     */
-    SUCCESS,
 
     /**
      * There was an error with the request. See message for more details.

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -950,6 +950,9 @@ export default class Purchases {
      * iOS 15+ only. Presents a refund request sheet in the current window scene for
      * the latest transaction associated with the active entitlement.
      *
+     * If the request was unsuccessful, no active entitlements could be found for
+     * the user, or multiple active entitlements were found for the user,
+     * the promise will return an error.
      * If called in an unsupported platform (Android or iOS < 15), an `UnsupportedPlatformException` will be thrown.
      *
      * Important: This method should only be used if your user can only have a single active entitlement at a given time.
@@ -970,6 +973,7 @@ export default class Purchases {
      * iOS 15+ only. Presents a refund request sheet in the current window scene for
      * the latest transaction associated with the `entitlement`.
      *
+     * If the request was unsuccessful, the promise will return an error.
      * If called in an unsupported platform (Android or iOS < 15), an `UnsupportedPlatformException` will be thrown.
      *
      * @param entitlementInfo The entitlement to begin a refund request for.
@@ -988,6 +992,7 @@ export default class Purchases {
      * iOS 15+ only. Presents a refund request sheet in the current window scene for
      * the latest transaction associated with the `product`.
      *
+     * If the request was unsuccessful, the promise will return an error.
      * If called in an unsupported platform (Android or iOS < 15), an `UnsupportedPlatformException` will be thrown.
      *
      * @param storeProduct The StoreProduct to begin a refund request for.

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -964,7 +964,7 @@ export default class Purchases {
     public static async beginRefundRequestForActiveEntitlement(): Promise<REFUND_REQUEST_STATUS> {
         await Purchases.throwIfNotConfigured();
         await Purchases.throwIfAndroidPlatform();
-        let refundRequestStatusInt = await RNPurchases.beginRefundRequestForActiveEntitlement();
+        const refundRequestStatusInt = await RNPurchases.beginRefundRequestForActiveEntitlement();
         if (refundRequestStatusInt == null) { throw new UnsupportedPlatformError() }
         return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
     }
@@ -983,7 +983,7 @@ export default class Purchases {
     public static async beginRefundRequestForEntitlement(entitlementInfo: PurchasesEntitlementInfo): Promise<REFUND_REQUEST_STATUS> {
         await Purchases.throwIfNotConfigured();
         await Purchases.throwIfAndroidPlatform();
-        let refundRequestStatusInt = await RNPurchases.beginRefundRequestForEntitlementId(entitlementInfo.identifier);
+        const refundRequestStatusInt = await RNPurchases.beginRefundRequestForEntitlementId(entitlementInfo.identifier);
         if (refundRequestStatusInt == null) { throw new UnsupportedPlatformError() }
         return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
     }
@@ -1002,7 +1002,7 @@ export default class Purchases {
     public static async beginRefundRequestForProduct(storeProduct: PurchasesStoreProduct): Promise<REFUND_REQUEST_STATUS> {
         await Purchases.throwIfNotConfigured();
         await Purchases.throwIfAndroidPlatform();
-        let refundRequestStatusInt = await RNPurchases.beginRefundRequestForProductId(storeProduct.identifier);
+        const refundRequestStatusInt = await RNPurchases.beginRefundRequestForProductId(storeProduct.identifier);
         if (refundRequestStatusInt == null) { throw new UnsupportedPlatformError() }
         return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
     }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -1025,7 +1025,6 @@ export default class Purchases {
     }
 
     private static convertIntToRefundRequestStatus(refundRequestStatusInt: number): REFUND_REQUEST_STATUS {
-        console.log(`REFUND STATUS: ${refundRequestStatusInt}`);
         switch (refundRequestStatusInt) {
             case 0:
                 return REFUND_REQUEST_STATUS.SUCCESS;

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -151,6 +151,13 @@ export default class Purchases {
      */
      public static BILLING_FEATURE = BILLING_FEATURE;
 
+     /**
+      * Enum with possible return states for beginning refund request.
+      * @readonly
+      * @enum  {string}
+      */
+     public static REFUND_REQUEST_STATUS = REFUND_REQUEST_STATUS;
+
     /**
      * Replace SKU's ProrationMode.
      * @readonly
@@ -179,10 +186,15 @@ export default class Purchases {
      */
     public static PURCHASES_ERROR_CODE = PURCHASES_ERROR_CODE;
 
-  /**
-   * @internal
-   */
-  public static UninitializedPurchasesError = UninitializedPurchasesError;
+    /**
+     * @internal
+     */
+    public static UninitializedPurchasesError = UninitializedPurchasesError;
+
+    /**
+     * @internal
+     */
+    public static UnsupportedPlatformError = UnsupportedPlatformError;
 
     /**
      * Sets up Purchases with your API key and an app user id.

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -95,7 +95,7 @@ export enum REFUND_REQUEST_STATUS {
     /**
      * Apple has received the refund request.
      */
-        SUCCESS,
+    SUCCESS,
 
     /**
      * User canceled submission of the refund request.


### PR DESCRIPTION
Deals with [CSDK-569](https://revenuecats.atlassian.net/browse/CSDK-569)

This PR adds 3 new methods to the react native API that will only be available in iOS 15+.
- `beginRefundRequestForActiveEntitlement`
- `beginRefundRequestForProduct`
- `beginRefundRequestForEntitlement`

In Android/iOS < 15, we will throw an `UnsupportedPlatformException`.


[CSDK-569]: https://revenuecats.atlassian.net/browse/CSDK-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ