### PR TITLE
Changes to npm scripts and DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,25 +6,25 @@ Setup the development by running:
 yarn bootstrap
 ```
 
-That will link the local package so that changes are automatically applied to the example
+That will link the local package so that changes are automatically applied to the purchaseTesterTypescript example. MagicWeather will not point to the local package and will point to the latest release instead.
 
 ---
 
-`cd` one of the example projects (`cd examples/MagicWeather` or `cd examples/purchaseTesterTypescript`), then run:
+To run purchaseTesterTypescript on a device run the following from the root of the repository:
 
-`npx react-native run-android`
-or 
-`npx react-native run-ios`
+`yarn example android` or `npx example ios`
 
-If you have a connected device, the app will run on that device. If not, it will run on a simulator.
+If you have a connected device, the app will run on that device. If not, it will run on a simulator. If you get issues when running iOS try opening the xcworkspace with xcode and build the project, it might point to what the error is, like for example a missing Team for signing.
 
 You can install Flipper https://fbflipper.com/docs/features/index in your machine as a helper for debugging. I don't think it works with physical iOS devices.
+
+MagicWeather should be run from its directory directly since it's a completely separate proyect. Do `yarn` to build the dependencies then `yarn pods` and `yarn ios` or `yarn android` to run it.
 
 ---
 
 To edit the iOS code, open the example project with Xcode, there should be a subproject there RNPurchases.xcodeproj that can be used to edit the plugin. 
 If touching common files, you can point to your local project in the podspec. 
-You can run the project from Xcode without having to run `react-native run-ios`, but make sure that if you are touching `.ts` files, you run `npm run build` to compile the plugin.
+You can run the project from Xcode without having to run `react-native run-ios` (or `yarn example ios` from the root). If you are touching `.ts` files, watchman should detect the changes and compile them automatically, or run `npm run build` to compile.
 
 In Android, if you are touching common files, you can run in `examples/purchaseTesterTypescript/android` the following command `gradle enableLocalBuild -PcommonPath="$HOME/Development/repos/purchases-hybrid-common/android"`. Make sure you set the right path in your local machine. This will add the `purchases-hybrid-common` as a project that you can edit on the fly when opening the example project.
 

--- a/examples/MagicWeather/package.json
+++ b/examples/MagicWeather/package.json
@@ -8,7 +8,7 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "pods": "bundle install && pod-install --quiet"
+    "pods": "bundle install && rm -f ios/Podfile.lock && pod-install --quiet"
   },
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",

--- a/examples/MagicWeather/package.json
+++ b/examples/MagicWeather/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "pods": "bundle install && pod-install --quiet"
   },
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.10",
@@ -32,7 +33,8 @@
     "eslint": "^6.5.1",
     "jest": "^25.1.0",
     "metro-react-native-babel-preset": "^0.66.2",
-    "react-test-renderer": "17.0.2"
+    "react-test-renderer": "17.0.2",
+    "pod-install": "^0.1.0"
   },
   "jest": {
     "preset": "react-native"

--- a/examples/purchaseTesterTypescript/package.json
+++ b/examples/purchaseTesterTypescript/package.json
@@ -7,7 +7,8 @@
     "ios": "react-native run-ios",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "pods": "bundle install && rm -f ios/Podfile.lock && pod-install --quiet"
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.0.9",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
     "test": "jest",
     "tslint": "tslint -c tslint.json 'src/*.ts'",
     "prepare": "tsc",
-    "example": "yarn --cwd examples/MagicWeather && yarn --cwd examples/purchaseTesterTypescript",
-    "pods": "(cd examples/MagicWeather && rm -f ios/Podfile.lock && bundle install && npx pod-install --quiet) && (cd examples/purchaseTesterTypescript && rm -f ios/Podfile.lock && bundle install && npx pod-install --quiet)",
-    "bootstrap": "yarn && yarn example && yarn pods"
+    "example": "yarn --cwd examples/purchaseTesterTypescript",
+    "bootstrap": "yarn && yarn example && yarn example pods"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Since MagicWeather uses a remote dependency, it didn't make sense to build it when doing `yarn bootstrap` from the root of the repository. It should be treated as a regular project and be built from its folder instead using `yarn` and `yarn pods`. Another reason for this is that MagicWeather was using ruby 2.7.2 and purchaseTester 2.7.4 which was causing issues when running pod install from the root (which uses 2.7.2). Anyways, I think this is cleaner and actually improves CI too.
- Added `pods` as a script to both MagicWeather and purchaseTester so the root package.json is more lean.
- I found out commands are chainable, so this is possible `yarn example ios`. `yarn example` changes the current working directory to purchaseTesterTypescript and `ios` will run the ios script in that folder. This is by the way what the new plugin creation tool does and what the official react native docs mention https://reactnative.dev/docs/native-modules-setup
- I also improved DEVELOPMENT.md to reflect the most latest changes.