### PR TITLE
fixes a change in unsubscribedDetectedAt property name of PurchasesEntitlementInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ export interface PurchasesEntitlementInfo {
    *
    * @note: Entitlement may still be active even if user has unsubscribed. Check the `isActive` property.
    */
-  readonly unsubscribeDetectedAt: string | null;
+  readonly unsubscribedDetectedAt: string | null;
   /**
    * The date a billing issue was detected. Can be `null` if there is no billing issue or an issue has been resolved
    *


### PR DESCRIPTION
> [ X ] A description about what and why you are contributing, even if it's trivial.

It seems that the property ```unsubscribeDetectedAt``` from PurchasesEntitlementInfo has been renamed to ```unsubscribedDetectedAt```. Here is an extract of the console log from the callback on ```Purchases.addCustomerInfoUpdateListener``` (showing a inactive entitlement) : 

```yaml
billingIssueDetectedAt: null
billingIssueDetectedAtMillis: null
expirationDate: "2023-02-22T16:06:04Z"
expirationDateMillis: 1677081964000
identifier: "xxxxx"
isActive: false
isSandbox: true
latestPurchaseDate: "2023-02-22T16:03:04Z"
latestPurchaseDateMillis: 1677081784000
originalPurchaseDate: "2023-02-22T15:30:09Z"
originalPurchaseDateMillis: 1677079809000
ownershipType: "PURCHASED"
periodType: "NORMAL"
productIdentifier: "mensuel"
store: "APP_STORE"
unsubscribedDetectedAt: "2023-02-22T16:06:44Z" // <-
unsubscribedDetectedAtMillis: 1677082004000 // <-
willRenew: false
```

That change has not been reflected in the definition file, this commit fixes that.

> [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

None found

> [ ] If applicable, unit tests.

Not applicable