### PR TITLE
Fixes the build for Mac Catalyst target

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -328,7 +328,7 @@ RCT_REMAP_METHOD(canMakePayments,
 
 RCT_EXPORT_METHOD(beginRefundRequestForActiveEntitlement:(RCTPromiseResolveBlock)resolve
                                                   reject:(RCTPromiseRejectBlock)reject) {
-    #if TARGET_OS_IPHONE
+    #if defined(TARGET_OS_IPHONE) && !defined(TARGET_OS_MACCATALYST)
     if (@available(iOS 15.0, *)) {
         [RCCommonFunctionality beginRefundRequestForActiveEntitlementCompletion:[self getBeginRefundResponseCompletionBlockWithResolve:resolve
                                                                                                                                 reject:reject]];
@@ -343,7 +343,7 @@ RCT_EXPORT_METHOD(beginRefundRequestForActiveEntitlement:(RCTPromiseResolveBlock
 RCT_EXPORT_METHOD(beginRefundRequestForEntitlementId:(NSString *)entitlementIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-    #if TARGET_OS_IPHONE
+    #if defined(TARGET_OS_IPHONE) && !defined(TARGET_OS_MACCATALYST)
     if (@available(iOS 15.0, *)) {
         [RCCommonFunctionality beginRefundRequestEntitlementId:entitlementIdentifier
                                                completionBlock:[self getBeginRefundResponseCompletionBlockWithResolve:resolve
@@ -359,7 +359,7 @@ RCT_EXPORT_METHOD(beginRefundRequestForEntitlementId:(NSString *)entitlementIden
 RCT_EXPORT_METHOD(beginRefundRequestForProductId:(NSString *)productIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-    #if TARGET_OS_IPHONE
+    #if defined(TARGET_OS_IPHONE) && !defined(TARGET_OS_MACCATALYST)
     if (@available(iOS 15.0, *)) {
         [RCCommonFunctionality beginRefundRequestProductId:productIdentifier
                                            completionBlock:[self getBeginRefundResponseCompletionBlockWithResolve:resolve


### PR DESCRIPTION
Hey guys 👋 I am here trying to build an existing Android / iOS RN project, relying on RevenueCat, for **Mac Catalyst** as the target. Not sure, whether **react-native-purchases** is supposed to support Catalyst, but I'll give it a try. The first problem I encountered was the build failing on the safeguards corrected in this PR. The problem was that `TARGET_OS_IPHONE` is defined both when building for iOS and Mac Catalyst targets, and apparently `@available(..)` safeguard also considers Mac Catalyst build as targeting latest iOS; however, MacOS SDK it relies upon when building for Catalyst does not contain those methods used inside safeguarded blocks. Luckily, it seems an easy fix, as you see I just added a check for `TARGET_OS_MACCATALYST` pragma to the other safeguard condition, and with this change done **react-native-purchases** do compile fine for Catalyst.

P.S.: Though, my build still fails due to issues with some other libs I rely on, thus can't say yet, if react-native-purchases works on Catalyst without further changes.
