### PR TITLE
[WIP] BC5 Support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,6 +121,6 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:4.14.1'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.hybridcommon.OnResultList;
 import com.revenuecat.purchases.hybridcommon.SubscriberAttributesKt;
 import com.revenuecat.purchases.hybridcommon.mappers.CustomerInfoMapperKt;
 import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener;
+import com.revenuecat.purchases.models.GoogleProrationMode;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
@@ -131,12 +132,21 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 final String type,
                                 @Nullable final String discountTimestamp,
                                 final Promise promise) {
+        String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
+
+        // TODO: Map int
+        int prorationModeInt = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        GoogleProrationMode googleProrationModeEnum = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION;
+
+        boolean googleIsPersonalized = false;
+
         CommonKt.purchaseProduct(
             getCurrentActivity(),
             productIdentifier,
-            upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null,
-            upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null,
             type,
+            googleOldProductId,
+            googleProrationModeEnum,
+            googleIsPersonalized,
             getOnResult(promise));
     }
 
@@ -146,12 +156,21 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final ReadableMap upgradeInfo,
                                 @Nullable final String discountTimestamp,
                                 final Promise promise) {
+        String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
+
+        // TODO: Map int
+        Integer prorationModeInt = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        GoogleProrationMode googleProrationModeEnum = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION;
+
+        boolean googleIsPersonalized = false;
+
         CommonKt.purchasePackage(
             getCurrentActivity(),
             packageIdentifier,
             offeringIdentifier,
-            upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null,
-            upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null,
+            googleOldProductId,
+            googleProrationModeEnum,
+            googleIsPersonalized,
             getOnResult(promise));
     }
 


### PR DESCRIPTION
⚠️ DO NOT MERGE

## Motivation

Support [Purchases Android V6 (BC5 Support)](https://github.com/RevenueCat/purchases-android/tree/bc5-support) and [Purchases Hybrid Common (BC5 Support)](https://github.com/RevenueCat/purchases-hybrid-common/pull/327) in Purchases Flutter

## Description

### Tasks

- [x] Update to use BC5 Hybrid Common with latest Purchases Android V6 (current `6.0.0-alpha.3`)
- [x] Fix compile issues
- [ ] Allow subscription options
- [ ] Map Google proration mode
- [ ] Rename all sku stuff
- [ ] Tests