### PR TITLE
[BC5] Add `SubscriptionOption`, `isPersonalizedPrice`, `presentedOfferingIdentifier` support

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |spec|
   ]
 
   spec.dependency   "React-Core"
-  spec.dependency   "PurchasesHybridCommon", '4.14.1'
+  spec.dependency   "PurchasesHybridCommon", '5.0.0-beta.4'
   spec.swift_version    = '5.0'
 end

--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |spec|
   ]
 
   spec.dependency   "React-Core"
-  spec.dependency   "PurchasesHybridCommon", '5.0.0-beta.4'
+  spec.dependency   "PurchasesHybridCommon", '5.0.0-beta.6'
   spec.swift_version    = '5.0'
 end

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -173,14 +173,14 @@ describe("Purchases", () => {
 
     await Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
     }, Purchases.PURCHASE_TYPE.INAPP)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
@@ -191,7 +191,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
-    }, Purchases.PURCHASE_TYPE.INAPP, null);
+    }, Purchases.PURCHASE_TYPE.INAPP, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 
@@ -654,12 +654,13 @@ describe("Purchases", () => {
 
     const aProduct = {
       ...productStub,
-      discounts: [discountStub]
+      discounts: [discountStub],
+      presentedOfferingIdentifier: null
     }
 
     await Purchases.purchaseDiscountedProduct(aProduct, promotionalOfferStub)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString());
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -173,14 +173,14 @@ describe("Purchases", () => {
 
     await Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
     }, Purchases.PURCHASE_TYPE.INAPP)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
@@ -191,7 +191,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
-    }, Purchases.PURCHASE_TYPE.INAPP, null, null);
+    }, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 
@@ -224,7 +224,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, null);
+    }, null, null);
   });
 
   it("purchasePackage works", async () => {
@@ -249,7 +249,7 @@ describe("Purchases", () => {
         offeringIdentifier: "offering",
       });
 
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", undefined, null);
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", undefined, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
 
     await Purchases.purchasePackage(
@@ -276,7 +276,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
-    }, null);
+    }, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(2);
   });
 
@@ -660,7 +660,7 @@ describe("Purchases", () => {
 
     await Purchases.purchaseDiscountedProduct(aProduct, promotionalOfferStub)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -151,15 +151,15 @@ describe("Purchases", () => {
 
     let products = await Purchases.getProducts("onemonth_freetrial");
 
-    expect(NativeModules.RNPurchases.getProductInfo).toBeCalledWith("onemonth_freetrial", "subs");
+    expect(NativeModules.RNPurchases.getProductInfo).toBeCalledWith("onemonth_freetrial", "SUBSCRIPTION");
     expect(NativeModules.RNPurchases.getProductInfo).toBeCalledTimes(1);
     expect(products).toEqual(productsStub);
 
     NativeModules.RNPurchases.getProductInfo.mockResolvedValueOnce([]);
 
-    products = await Purchases.getProducts("onemonth_freetrial", "nosubs")
+    products = await Purchases.getProducts("onemonth_freetrial", "NON_SUBSCRIPTION")
 
-    expect(NativeModules.RNPurchases.getProductInfo).toBeCalledWith("onemonth_freetrial", "nosubs");
+    expect(NativeModules.RNPurchases.getProductInfo).toBeCalledWith("onemonth_freetrial", "NON_SUBSCRIPTION");
     expect(NativeModules.RNPurchases.getProductInfo).toBeCalledTimes(2);
     expect(products).toEqual([]);
   });
@@ -173,14 +173,14 @@ describe("Purchases", () => {
 
     await Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, undefined);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
-    }, Purchases.PURCHASE_TYPE.INAPP)
+    }, Purchases.PRODUCT_CATEGORY.NON_SUBSCRIPTION)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null, undefined);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PRODUCT_CATEGORY.NON_SUBSCRIPTION, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
@@ -191,7 +191,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
-    }, Purchases.PURCHASE_TYPE.INAPP, null, null, undefined);
+    }, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -173,14 +173,14 @@ describe("Purchases", () => {
 
     await Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, undefined);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
     }, Purchases.PURCHASE_TYPE.INAPP)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PURCHASE_TYPE.INAPP, null, null, undefined);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
@@ -191,7 +191,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
-    }, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
+    }, Purchases.PURCHASE_TYPE.INAPP, null, null, undefined);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -227,6 +227,23 @@ describe("Purchases", () => {
     }, null, null);
   });
 
+  it("purchaseStoreProduct works", async () => {
+    NativeModules.RNPurchases.purchaseProduct.mockResolvedValue({
+      purchasedProductIdentifier: "123",
+      customerInfo: customerInfoStub
+    });
+
+    const aProduct = {
+      ...productStub,
+      presentedOfferingIdentifier: "the-offerings"
+    }
+
+    await Purchases.purchaseStoreProduct(aProduct)
+
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, undefined, Purchases.PRODUCT_CATEGORY.SUBSCRIPTION, null, null, "the-offerings");
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
+  });
+
   it("purchasePackage works", async () => {
     NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
       purchasedProductIdentifier: "123",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,6 +121,6 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.4'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.6'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,6 +121,6 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.1'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -131,11 +131,14 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final ReadableMap upgradeInfo,
                                 final String type,
                                 @Nullable final String discountTimestamp,
+                                @Nullable final ReadableMap googleInfo,
                                 @Nullable final String presentedOfferingIdentifier,
                                 final Promise promise) {
         String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
         Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
-        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
+
+        Log.d("GROVER", "googleInfo: " + googleInfo);
+        Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
         CommonKt.purchaseProduct(
             getCurrentActivity(),
@@ -154,10 +157,12 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 final String offeringIdentifier,
                                 @Nullable final ReadableMap upgradeInfo,
                                 @Nullable final String discountTimestamp,
+                                @Nullable final ReadableMap googleInfo,
                                 final Promise promise) {
         String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
         Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
-        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
+
+        Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
         CommonKt.purchasePackage(
             getCurrentActivity(),
@@ -174,11 +179,13 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                            final String optionIdentifier,
                                            @Nullable final ReadableMap upgradeInfo,
                                            @Nullable final String discountTimestamp,
+                                           @Nullable final ReadableMap googleInfo,
                                            @Nullable final String presentedOfferingIdentifier,
                                            final Promise promise) {
         String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
         Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
-        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
+
+        Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
         CommonKt.purchaseSubscriptionOption(
             getCurrentActivity(),

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -131,22 +131,21 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final ReadableMap upgradeInfo,
                                 final String type,
                                 @Nullable final String discountTimestamp,
+                                @Nullable final String presentedOfferingIdentifier,
                                 final Promise promise) {
         String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
-
-        // TODO: Map int
-        int prorationModeInt = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
-        GoogleProrationMode googleProrationModeEnum = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION;
-
-        boolean googleIsPersonalized = false;
+        Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
 
         CommonKt.purchaseProduct(
             getCurrentActivity(),
             productIdentifier,
             type,
+            null,
             googleOldProductId,
-            googleProrationModeEnum,
+            googleProrationMode,
             googleIsPersonalized,
+            presentedOfferingIdentifier,
             getOnResult(promise));
     }
 
@@ -157,20 +156,38 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final String discountTimestamp,
                                 final Promise promise) {
         String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
-
-        // TODO: Map int
-        Integer prorationModeInt = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
-        GoogleProrationMode googleProrationModeEnum = GoogleProrationMode.IMMEDIATE_WITHOUT_PRORATION;
-
-        boolean googleIsPersonalized = false;
+        Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
 
         CommonKt.purchasePackage(
             getCurrentActivity(),
             packageIdentifier,
             offeringIdentifier,
             googleOldProductId,
-            googleProrationModeEnum,
+            googleProrationMode,
             googleIsPersonalized,
+            getOnResult(promise));
+    }
+
+    @ReactMethod
+    public void purchaseSubscriptionOption(final String productIdentifer,
+                                           final String optionIdentifier,
+                                           @Nullable final ReadableMap upgradeInfo,
+                                           @Nullable final String discountTimestamp,
+                                           @Nullable final String presentedOfferingIdentifier,
+                                           final Promise promise) {
+        String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
+        Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        Boolean googleIsPersonalized = upgradeInfo != null && upgradeInfo.hasKey("googleIsPersonalized") ? upgradeInfo.getBoolean("googleIsPersonalized") : null;
+
+        CommonKt.purchaseSubscriptionOption(
+            getCurrentActivity(),
+            productIdentifer,
+            optionIdentifier,
+            googleOldProductId,
+            googleProrationMode,
+            googleIsPersonalized,
+            presentedOfferingIdentifier,
             getOnResult(promise));
     }
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -128,16 +128,29 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     @ReactMethod
     public void purchaseProduct(final String productIdentifier,
-                                @Nullable final ReadableMap upgradeInfo,
+                                @Nullable final ReadableMap googleProductChangeInfo,
                                 final String type,
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
                                 @Nullable final String presentedOfferingIdentifier,
                                 final Promise promise) {
-        String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
-        Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        String googleOldProductId = null;
+        Integer googleProrationMode = null;
 
-        Log.d("GROVER", "googleInfo: " + googleInfo);
+        if (googleProductChangeInfo != null) {
+            // GoogleProductChangeInfo in V6 and later
+            googleOldProductId = googleProductChangeInfo.hasKey("oldProductIdentifier") ? googleProductChangeInfo.getString("oldProductIdentifier") : null;
+            googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
+
+            // Legacy UpgradeInfo in V5 and earlier
+            if (googleOldProductId == null) {
+                googleOldProductId = googleProductChangeInfo.hasKey("oldSKU") ? googleProductChangeInfo.getString("oldSKU") : null;
+            }
+            if (googleProrationMode == null) {
+                googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
+            }
+        }
+
         Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
         CommonKt.purchaseProduct(

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -8,7 +8,7 @@ import {
   PurchasesPackage, PurchasesPromotionalOffer,
   PurchasesStoreProduct, UpgradeInfo,
   SubscriptionOption, PricingPhase,
-  Price, Period, OFFER_PAYMENT_MODE, UNIT, RECURRENCE_MODE
+  Price, Period, OFFER_PAYMENT_MODE, PERIOD_UNIT, RECURRENCE_MODE
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -130,13 +130,13 @@ function checkRecurrenceMode(mode: RECURRENCE_MODE) {
   };
 }
 
-function checkUnit(unit: UNIT) {
-  switch(unit) { 
-    case UNIT.DAY, 
-    UNIT.WEEK, 
-    UNIT.MONTH,
-    UNIT.YEAR,
-    UNIT.UNKNOWN: { 
+function checkPeriodUnit(periodUnit: PERIOD_UNIT) {
+  switch(periodUnit) { 
+    case PERIOD_UNIT.DAY, 
+    PERIOD_UNIT.WEEK, 
+    PERIOD_UNIT.MONTH,
+    PERIOD_UNIT.YEAR,
+    PERIOD_UNIT.UNKNOWN: { 
        break; 
     } 
   };

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -6,7 +6,9 @@ import {
   PurchasesIntroPrice,
   PurchasesOffering, PurchasesOfferings,
   PurchasesPackage, PurchasesPromotionalOffer,
-  PurchasesStoreProduct, UpgradeInfo
+  PurchasesStoreProduct, UpgradeInfo,
+  SubscriptionOption, PricingPhase,
+  Price, Period, OFFER_PAYMENT_MODE, UNIT, RECURRENCE_MODE
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -19,6 +21,7 @@ function checkProduct(product: PurchasesStoreProduct) {
   const introPrice: PurchasesIntroPrice | null = product.introPrice;
   const discounts: PurchasesStoreProductDiscount[] | null = product.discounts;
   const subscriptionPeriod: string | null = product.subscriptionPeriod;
+  const presentedOfferingIdentifier: string | null = product.presentedOfferingIdentifier;
 }
 
 function checkDiscount(discount: PurchasesStoreProductDiscount) {
@@ -81,4 +84,70 @@ function checkPromotionalOffer(discount: PurchasesPromotionalOffer) {
   const nonce: string = discount.nonce;
   const signature: string = discount.signature;
   const timestamp: number = discount.timestamp;
+}
+
+function checkSubscriptionOption(option: SubscriptionOption) {
+  const id: string = option.id;
+  const storeProductId: string = option.storeProductId;
+  const productId: string = option.productId;
+  const pricingPhase: PricingPhase[] = option.pricingPhases;
+  const tags: string[] = option.tags;
+  const isBasePlan: boolean = option.isBasePlan;
+  const billingPeriod: Period | null = option.billingPeriod;
+  const fullPricePhase: PricingPhase | null = option.fullPricePhase;
+  const freePhase: PricingPhase | null = option.freePhase;
+  const introPhase: PricingPhase | null = option.introPhase;
+  const presentedOfferingIdentifier: string | null = option.presentedOfferingIdentifier;
+}
+
+function checkPricingPhase(pricePhase: PricingPhase) {
+  const billingPeriod: Period = pricePhase.billingPeriod;
+  const recurrenceMode: RECURRENCE_MODE | null = pricePhase.recurrenceMode;
+  const billingCycleCount: number | null = pricePhase.billingCycleCount;
+  const price: Price = pricePhase.price;
+  const offerPaymentMode: OFFER_PAYMENT_MODE | null = pricePhase.offerPaymentMode;
+}
+
+function checkPeriod(period: Period) {
+  const unit: UNIT = period.unit;
+  const value: number = period.value;
+  const iso8601: string = period.iso8601;
+}
+
+function checkPrice(price: Price) {
+  const formatted: string = price.formatted;
+  const amountMicros: number = price.amountMicros;
+  const currencyCode: string = price.currencyCode;
+}
+
+function checkRecurrenceMode(mode: RECURRENCE_MODE) {
+  switch(mode) { 
+    case RECURRENCE_MODE.INFINITE_RECURRING, 
+    RECURRENCE_MODE.FINITE_RECURRING, 
+    RECURRENCE_MODE.NON_RECURRING: { 
+       break; 
+    } 
+  };
+}
+
+function checkUnit(unit: UNIT) {
+  switch(unit) { 
+    case UNIT.DAY, 
+    UNIT.WEEK, 
+    UNIT.MONTH,
+    UNIT.YEAR,
+    UNIT.UNKNOWN: { 
+       break; 
+    } 
+  };
+}
+
+function checkOfferPaymentMode(offerPaymentMode: OFFER_PAYMENT_MODE) {
+  switch(offerPaymentMode) { 
+    case OFFER_PAYMENT_MODE.FREE_TRIAL, 
+    OFFER_PAYMENT_MODE.SINGLE_PAYMENT, 
+    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: { 
+       break; 
+    } 
+  };
 }

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -109,7 +109,7 @@ function checkPricingPhase(pricePhase: PricingPhase) {
 }
 
 function checkPeriod(period: Period) {
-  const unit: UNIT = period.unit;
+  const unit: PERIOD_UNIT = period.unit;
   const value: number = period.value;
   const iso8601: string = period.iso8601;
 }

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -14,7 +14,7 @@ import {
 } from '../dist';
 
 import Purchases from '../dist/purchases';
-import { SubscriptionOption } from '../src';
+import { GoogleProductChangeInfo, SubscriptionOption } from '../src';
 
 async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
@@ -45,41 +45,70 @@ async function checkPurchasing(purchases: Purchases,
                                discount: PurchasesStoreProductDiscount,
                                paymentDiscount: PurchasesPromotionalOffer,
                                pack: PurchasesPackage,
-                               subscriptionOption: SubscriptionOption) {
+                               subscriptionOption: SubscriptionOption,
+                               upgradeInfo: UpgradeInfo,
+                               googleProductChangeInfo: GoogleProductChangeInfo) {
   const productId: string = ""
   const productIds: string[] = [productId];
-  const upgradeInfo: UpgradeInfo | null = null;
   const features: BILLING_FEATURE[] = [];
+  const googleIsPersonalizedPrice: boolean = false;
 
   const paymentDiscount2: PurchasesPromotionalOffer | undefined = await Purchases.getPromotionalOffer(
     product,
     discount,
   );
 
-  const result1: MakePurchaseResult = await Purchases.purchaseProduct(
+  const productResult1: MakePurchaseResult = await Purchases.purchaseProduct(
     productId,
     upgradeInfo,
     PURCHASE_TYPE.INAPP
   );
 
-  const result2: MakePurchaseResult = await Purchases.purchaseDiscountedProduct(
+  const storeProductResult1: MakePurchaseResult = await Purchases.purchaseStoreProduct(
+    product,
+    googleProductChangeInfo
+  );
+  const storeProductResult2: MakePurchaseResult = await Purchases.purchaseStoreProduct(
+    product,
+    googleProductChangeInfo,
+    googleIsPersonalizedPrice
+  );
+
+  const discountedProductResult1: MakePurchaseResult = await Purchases.purchaseDiscountedProduct(
     product,
     paymentDiscount
   );
 
-  const result3: MakePurchaseResult = await Purchases.purchasePackage(
+  const packageResult1: MakePurchaseResult = await Purchases.purchasePackage(
     pack,
     upgradeInfo
   );
+  const packageResult2: MakePurchaseResult = await Purchases.purchasePackage(
+    pack,
+    upgradeInfo,
+    null,
+    googleIsPersonalizedPrice
+  );
+  const packageResult3: MakePurchaseResult = await Purchases.purchasePackage(
+    pack,
+    null,
+    googleProductChangeInfo,
+    googleIsPersonalizedPrice
+  );
 
-  const result4: MakePurchaseResult = await Purchases.purchaseDiscountedPackage(
+  const discountedPackageResult1: MakePurchaseResult = await Purchases.purchaseDiscountedPackage(
     pack,
     paymentDiscount
   );
 
-  const result5: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
+  const subscriptionOptionResult1: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
     subscriptionOption,
-    upgradeInfo
+    googleProductChangeInfo
+  );
+  const subscriptionOptionResult2: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
+    subscriptionOption,
+    googleProductChangeInfo,
+    googleIsPersonalizedPrice
   );
 
   const syncPurchases: void = await Purchases.syncPurchases();

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -14,6 +14,7 @@ import {
 } from '../dist';
 
 import Purchases from '../dist/purchases';
+import { SubscriptionOption } from '../src';
 
 async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
@@ -43,7 +44,8 @@ async function checkPurchasing(purchases: Purchases,
                                product: PurchasesStoreProduct,
                                discount: PurchasesStoreProductDiscount,
                                paymentDiscount: PurchasesPromotionalOffer,
-                               pack: PurchasesPackage) {
+                               pack: PurchasesPackage,
+                               subscriptionOpton: SubscriptionOption) {
   const productId: string = ""
   const productIds: string[] = [productId];
   const upgradeInfo: UpgradeInfo | null = null;
@@ -73,6 +75,11 @@ async function checkPurchasing(purchases: Purchases,
   const result4: MakePurchaseResult = await Purchases.purchaseDiscountedPackage(
     pack,
     paymentDiscount
+  );
+
+  const result5: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
+    subscriptionOpton,
+    upgradeInfo
   );
 
   const syncPurchases: void = await Purchases.syncPurchases();

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -45,7 +45,7 @@ async function checkPurchasing(purchases: Purchases,
                                discount: PurchasesStoreProductDiscount,
                                paymentDiscount: PurchasesPromotionalOffer,
                                pack: PurchasesPackage,
-                               subscriptionOpton: SubscriptionOption) {
+                               subscriptionOption: SubscriptionOption) {
   const productId: string = ""
   const productIds: string[] = [productId];
   const upgradeInfo: UpgradeInfo | null = null;
@@ -78,7 +78,7 @@ async function checkPurchasing(purchases: Purchases,
   );
 
   const result5: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
-    subscriptionOpton,
+    subscriptionOption,
     upgradeInfo
   );
 

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -20,7 +20,7 @@ import {
   ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
 
-import Purchases, { PurchasesPackage, PurchasesStoreProduct, SubscriptionOption, PURCHASE_TYPE, UNIT } from 'react-native-purchases';
+import Purchases, { PurchasesPackage, PurchasesStoreProduct, SubscriptionOption, PURCHASE_TYPE, PERIOD_UNIT } from 'react-native-purchases';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList'

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -20,7 +20,7 @@ import {
   ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
 
-import Purchases, { PurchasesPackage, PurchasesStoreProduct, SubscriptionOption, PURCHASE_TYPE } from 'react-native-purchases';
+import Purchases, { PurchasesPackage, PurchasesStoreProduct, SubscriptionOption, PURCHASE_TYPE, UNIT } from 'react-native-purchases';
 
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList'
@@ -47,6 +47,7 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
       product.identifier,
       null,
       PURCHASE_TYPE.SUBS,
+      null,
       product.presentedOfferingIdentifier,
       ).then((result) => {
     }).catch((err) => {

--- a/examples/purchaseTesterTypescript/package.json
+++ b/examples/purchaseTesterTypescript/package.json
@@ -29,6 +29,7 @@
     "@types/react": "^18.0.24",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.2.1",
+    "babel-plugin-module-resolver": "^4.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "0.73.9",

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -101,7 +101,7 @@ RCT_REMAP_METHOD(purchasePackage,
                  offeringIdentifier:(NSString *)offeringIdentifier
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
-                 googleIsPersonalized:(BOOL)googleIsPersonalized
+                 googleInfo:(NSDictionary *)googleInfo
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchasePackage:packageIdentifier

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -86,6 +86,7 @@ RCT_REMAP_METHOD(purchaseProduct,
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  type:(NSString *)type
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
+                 googleInfo:(NSDictionary *)googleInfo
                  presentedOfferingIdentifier:(NSString *)presentedOfferingIdentifier
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
@@ -100,6 +101,7 @@ RCT_REMAP_METHOD(purchasePackage,
                  offeringIdentifier:(NSString *)offeringIdentifier
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
+                 googleIsPersonalized:(BOOL)googleIsPersonalized
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchasePackage:packageIdentifier

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -86,6 +86,7 @@ RCT_REMAP_METHOD(purchaseProduct,
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  type:(NSString *)type
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
+                 presentedOfferingIdentifier:(NSString *)presentedOfferingIdentifier
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchaseProduct:productIdentifier

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -18,7 +18,7 @@ This latest release updates the Android SDK dependency from v5 to [v6](https://g
 | `Period`                   |
 | `Price`                    |
 | `RecurrenceMode`           |
-| `Unit`                     |
+| `PeriodUnit`               |
 
 #### Methods
 

--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -1,0 +1,68 @@
+## v6 API Changes
+
+This latest release updates the Android SDK dependency from v5 to [v6](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 5. This version of BillingClient brings an entire new subscription model which has resulted in large changes across the entire SDK.
+
+### Migration Guides
+- See [Android Native - 5.x to 6.x Migration](https://www.revenuecat.com/docs/android-native-5x-to-6x-migration) for a
+  more thorough explanation of the new Google subscription model announced with BillingClient 5 and how to take
+  advantage of it in React Native v6. This guide includes tips on product setup with the new model.
+
+### New API
+
+#### Classes
+
+| New                        |
+|----------------------------|
+| `SubscriptionOption`       |
+| `PricingPhase`             |
+| `Period`                   |
+| `Price`                    |
+| `RecurrenceMode`           |
+| `Unit`                     |
+
+#### Methods
+
+| New                                                                                 |
+|-------------------------------------------------------------------------------------|
+| `purchaseSubscriptionOption(SubscriptionOption, UpgradeInfo | null})` |
+
+
+### StoreProduct changes
+
+| New                 |
+|---------------------|
+| subscriptionOptions |
+| defaultOption       |
+
+#### Free Trial and Introductory Offers
+
+`StoreProduct` can now have multiple free trials and introductory offers on Google Play. There is a `defaultOption` property
+on `StoreProduct` that will select the offer with the longest free trial period or the cheapest introductory offer.
+
+If more control is needed, the free trial, intro offer, and other `SubscriptionOption`s can
+be found through `subscriptionOptions` on `StoreProduct`:
+
+```dart
+const basePlan = storeProduct.subscriptionOptions?.filter((option) => { option.isBasePlan });
+const defaultOffer = storeProduct.defaultOffer
+const freeOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.freePhase });
+const trialOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.introPhase });
+```
+
+#### Applying offers on a purchase
+In v4, a purchase of a `Package` or `StoreProduct` represented a single purchaseable entity, and free trials or intro
+prices would automatically be applied if the user was eligible.
+
+Now, in v6, a `Package` or `StoreProduct` could contain multiple offers along with a base plan. 
+When passing a `Package` or `StoreProduct` to `purchase()`, the SDK will use the following logic to choose which 
+[SubscriptionOption] to purchase:
+*   - Filters out offers with "rc-ignore-default-offer" tag
+*   - Uses [SubscriptionOption] with the longest free trial or cheapest first phase
+*   - Falls back to use base plan
+
+For more control, find the `SubscriptionOption` to purchase on a `StoreProduct`.
+
+### Reporting undocumented issues:
+
+Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-flutter/issues/new/).
+

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -680,7 +680,8 @@ global.productStub = {
   price: 0.99,
   description: "The best service.",
   title: "One Month Free Trial",
-  identifier: "onemonth_freetrial"
+  identifier: "onemonth_freetrial",
+  productCategory: "SUBSCRIPTION",
 };
 
 global.productsStub = [

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -100,7 +100,10 @@ export interface PurchasesStoreProduct {
      * Collection of discount offers for a product. Null for Android.
      */
     readonly discounts: PurchasesStoreProductDiscount[] | null;
-
+    /**
+     * Product category.
+     */
+    readonly productCategory: PRODUCT_CATEGORY | null;
     /**
      * Subscription period, specified in ISO 8601 format. For example,
      * P1W equates to one week, P1M equates to one month,
@@ -109,12 +112,37 @@ export interface PurchasesStoreProduct {
      * Note: Not available for Amazon.
      */
     readonly subscriptionPeriod: string | null;
-
+    /**
+     * Default subscription option for a product. Google Play only.
+     */
     readonly defaultOption: SubscriptionOption | null;
+    /**
+     * Collection of subscription options for a product. Google Play only.
+     */
     readonly subscriptionOptions: SubscriptionOption[] | null;
-
+    /**
+     * Offering identifier the store product was presented from.
+     * Null if not using offerings or if fetched directly from store via getProducts.
+     */
     readonly presentedOfferingIdentifier: string | null;
 }
+
+export enum PRODUCT_CATEGORY {
+    /**
+     * A type of product for non-subscription.
+     */
+    NON_SUBSCRIPTION = "NON_SUBSCRIPTION",
+  
+    /**
+     * A type of product for subscriptions.
+     */
+    SUBSCRIPTION = "SUBSCRIPTION",
+
+    /**
+     * A type of product for unknowns.
+     */
+    UNKNOWN = "UNKNOWN",
+  }
 
 export interface PurchasesStoreProductDiscount {
     /**
@@ -261,12 +289,27 @@ export interface PurchasesOfferings {
 
 /**
  * Holds the information used when upgrading from another sku. For Android use only.
+ * @deprecated, use GoogleProductChangeInfo
  */
 export interface UpgradeInfo {
     /**
      * The oldSKU to upgrade from.
      */
     readonly oldSKU: string;
+    /**
+     * The [PRORATION_MODE] to use when upgrading the given oldSKU.
+     */
+    readonly prorationMode?: PRORATION_MODE;
+}
+
+/**
+ * Holds the information used when upgrading from another sku. For Android use only.
+ */
+export interface GoogleProductChangeInfo {
+    /**
+     * The old product identifier to upgrade from.
+     */
+    readonly oldProductIdentifier: string;
     /**
      * The [PRORATION_MODE] to use when upgrading the given oldSKU.
      */

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -397,7 +397,7 @@ export interface SubscriptionOption {
     readonly introPhase: PricingPhase | null;
 
     /**
-     * Offering identifier the subscriptioni option was presented from
+     * Offering identifier the subscription option was presented from
      */
     readonly presentedOfferingIdentifier: string | null;
 }
@@ -484,7 +484,7 @@ export interface Period {
     /**
      * The number of period units: day, week, month, year, unknown
      */
-    readonly unit: UNIT;
+    readonly unit: PERIOD_UNIT;
 
     /**
      * The increment of time that a subscription period is specified in
@@ -502,7 +502,7 @@ export interface Period {
 /**
  * Time duration unit for Period.
  */
-export enum UNIT {
+export enum PERIOD_UNIT {
     DAY = "DAY",
     WEEK = "WEEK",
     MONTH = "MONTH",

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -82,14 +82,17 @@ export interface PurchasesStoreProduct {
     readonly title: string;
     /**
      * Price of the product in the local currency.
+     * Contains the price value of defaultOption for Google Play.
      */
     readonly price: number;
     /**
      * Formatted price of the item, including its currency sign.
+     * Contains the formatted price value of defaultOption for Google Play.
      */
     readonly priceString: string;
     /**
      * Currency code for price and original price.
+     * Contains the currency code value of defaultOption for Google Play.
      */
     readonly currencyCode: string;
     /**
@@ -393,7 +396,7 @@ export interface SubscriptionOption {
     readonly storeProductId: string;
 
     /**
-     * Identifer of the subscription associated with this SubsriptionOption
+     * Identifer of the subscription associated with this SubscriptionOption
      * This will be {subId}
      */
     readonly productId: string;
@@ -409,8 +412,7 @@ export interface SubscriptionOption {
     readonly tags: string[];
 
     /**
-     * True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
-     * Not applicable for Amazon subscriptions.
+     * True if this SubscriptionOption represents a subscription base plan (rather than an offer).
      */
     readonly isBasePlan: boolean;
 
@@ -486,7 +488,7 @@ export enum RECURRENCE_MODE {
 }
 
 /**
- * Payment mode for offer pricing phases
+ * Payment mode for offer pricing phases. Google Play only.
  */
 export enum OFFER_PAYMENT_MODE {
     FREE_TRIAL = "FREE_TRIAL",

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -267,7 +267,7 @@ export interface UpgradeInfo {
      * The oldSKU to upgrade from.
      */
     readonly oldSKU: string;
-    /*
+    /**
      * The [PRORATION_MODE] to use when upgrading the given oldSKU.
      */
     readonly prorationMode?: PRORATION_MODE;
@@ -331,39 +331,181 @@ export enum PRORATION_MODE {
     IMMEDIATE_AND_CHARGE_FULL_PRICE = 5,
 }
 
+/**
+ * Contains all details associated with a SubscriptionOption
+ * Used only for Google
+ */
 export interface SubscriptionOption {
-    
+    /**
+     * Identifier of the subscription option
+     * If this SubscriptionOption represents a base plan, this will be the basePlanId.
+     * If it represents an offer, it will be {basePlanId}:{offerId}
+     */
     readonly id: string;
+
+    /**
+     * Identifier of the StoreProduct associated with this SubscriptionOption
+     * This will be {subId}:{basePlanId}
+     */
     readonly storeProductId: string;
+
+    /**
+     * Identifer of the subscription associated with this SubsriptionOption
+     * This will be {subId}
+     */
     readonly productId: string;
+
+    /**
+     * Pricing phases defining a user's payment plan for the product over time.
+     */
     readonly pricingPhases: PricingPhase[];
+
+    /**
+     * Tags defined on the base plan or offer. Empty for Amazon.
+     */
     readonly tags: string[];
+
+    /**
+     * True if this SubscriptionOption represents a Google subscription base plan (rather than an offer).
+     * Not applicable for Amazon subscriptions.
+     */
     readonly isBasePlan: boolean;
+
+    /**
+     * The subscription period of fullPricePhase (after free and intro trials).
+     */
     readonly billingPeriod: Period | null;
+
+    /**
+     * The full price PricingPhase of the subscription.
+     * Looks for the last price phase of the SubscriptionOption.
+     */
     readonly fullPricePhase: PricingPhase | null;
+
+    /**
+     * The free trial PricingPhase of the subscription.
+     * Looks for the first pricing phase of the SubscriptionOption where amountMicros is 0.
+     * There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
+     */
     readonly freePhase: PricingPhase | null;
+
+    /**
+     * The intro trial PricingPhase of the subscription.
+     * Looks for the first pricing phase of the SubscriptionOption where amountMicros is greater than 0.
+     * There can be a freeTrialPhase and an introductoryPhase in the same SubscriptionOption.
+     */
     readonly introPhase: PricingPhase | null;
+
+    /**
+     * Offering identifier the subscriptioni option was presented from
+     */
     readonly presentedOfferingIdentifier: string | null;
 }
 
+/**
+ * Contains all the details associated with a PricingPhase
+ */
 export interface PricingPhase {
-    
+    /**
+     * Billing period for which the PricingPhase applies
+     */
     readonly billingPeriod: Period;
-    readonly recurrenceMode: number | null;
+
+    /**
+     * Recurrence mode of the PricingPhase
+     */
+    readonly recurrenceMode: RECURRENCE_MODE | null;
+
+    /**
+     * Number of cycles for which the pricing phase applies.
+     * Null for infiniteRecurring or finiteRecurring recurrence modes.
+     */
     readonly billingCycleCount: number | null;
+
+    /**
+     * Price of the PricingPhase
+     */
     readonly price: Price;
+
+    /**
+     * Indicates how the pricing phase is charged for finiteRecurring pricing phases
+     */
+    readonly offerPaymentMode: OFFER_PAYMENT_MODE | null;
 }
 
+/**
+ * Recurrence mode for a pricing phase
+ */
+export enum RECURRENCE_MODE {
+    INFINITE_RECURRING = 1,
+    FINITE_RECURRING = 2,
+    NON_RECURRING = 3,
+}
+
+/**
+ * Payment mode for offer pricing phases
+ */
+export enum OFFER_PAYMENT_MODE {
+    FREE_TRIAL = "FREE_TRIAL",
+    SINGLE_PAYMENT = "SINGLE_PAYMENT",
+    DISCOUNTED_RECURRING_PAYMENT = "DISCOUNTED_RECURRING_PAYMENT",
+}
+
+/**
+ * Contains all the details associated with a Price
+ */
 export interface Price {
-    
+    /**
+     * Formatted price of the item, including its currency sign. For example $3.00
+     */
     readonly formatted: string;
+
+    /**
+     * Price in micro-units, where 1,000,000 micro-units equal one unit of the currency.
+     * 
+     * For example, if price is "€7.99", price_amount_micros is 7,990,000. This value represents
+     * the localized, rounded price for a particular currency.
+     */
     readonly amountMicros: number;
+
+    /**
+     * Returns ISO 4217 currency code for price and original price.
+     * 
+     * For example, if price is specified in British pounds sterling, price_currency_code is "GBP".
+     * If currency code cannot be determined, currency symbol is returned.
+     */
     readonly currencyCode: string;
 }
 
+/**
+ * Contains all the details associated with a Period
+ */
 export interface Period {
-    
-    readonly unit: string;
+    /**
+     * The number of period units: day, week, month, year, unknown
+     */
+    readonly unit: UNIT;
+
+    /**
+     * The increment of time that a subscription period is specified in
+     */
     readonly value: number;
+
+    /**
+     * Specified in ISO 8601 format. For example, P1W equates to one week,
+     * P1M equates to one month, P3M equates to three months, P6M equates to six months,
+     * and P1Y equates to one year
+     */
     readonly iso8601: string;
+}
+
+/**
+ * Time duration unit for Period.
+ */
+export enum UNIT {
+    DAY = "DAY",
+    WEEK = "WEEK",
+    MONTH = "MONTH",
+    YEAR = "YEAR",
+    UNKNOWN = "UNKNOWN",
 }

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -109,6 +109,11 @@ export interface PurchasesStoreProduct {
      * Note: Not available for Amazon.
      */
     readonly subscriptionPeriod: string | null;
+
+    readonly defaultOption: SubscriptionOption | null;
+    readonly subscriptionOptions: SubscriptionOption[] | null;
+
+    readonly presentedOfferingIdentifier: string | null;
 }
 
 export interface PurchasesStoreProductDiscount {
@@ -262,7 +267,7 @@ export interface UpgradeInfo {
      * The oldSKU to upgrade from.
      */
     readonly oldSKU: string;
-    /**
+    /*
      * The [PRORATION_MODE] to use when upgrading the given oldSKU.
      */
     readonly prorationMode?: PRORATION_MODE;
@@ -324,4 +329,41 @@ export enum PRORATION_MODE {
      * plus remaining prorated time from the old plan.
      */
     IMMEDIATE_AND_CHARGE_FULL_PRICE = 5,
+}
+
+export interface SubscriptionOption {
+    
+    readonly id: string;
+    readonly storeProductId: string;
+    readonly productId: string;
+    readonly pricingPhases: PricingPhase[];
+    readonly tags: string[];
+    readonly isBasePlan: boolean;
+    readonly billingPeriod: Period | null;
+    readonly fullPricePhase: PricingPhase | null;
+    readonly freePhase: PricingPhase | null;
+    readonly introPhase: PricingPhase | null;
+    readonly presentedOfferingIdentifier: string | null;
+}
+
+export interface PricingPhase {
+    
+    readonly billingPeriod: Period;
+    readonly recurrenceMode: number | null;
+    readonly billingCycleCount: number | null;
+    readonly price: Price;
+}
+
+export interface Price {
+    
+    readonly formatted: string;
+    readonly amountMicros: number;
+    readonly currencyCode: string;
+}
+
+export interface Period {
+    
+    readonly unit: string;
+    readonly value: number;
+    readonly iso8601: string;
 }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -13,7 +13,8 @@ import {
   IntroEligibility,
   PurchasesStoreProductDiscount,
   SubscriptionOption,
-  PRODUCT_CATEGORY
+  PRODUCT_CATEGORY,
+  GoogleProductChangeInfo
 } from "./offerings";
 
 import {Platform} from "react-native";
@@ -464,8 +465,8 @@ export default class Purchases {
    * Make a purchase
    *
    * @param {PurchasesStoreProduct} product The product you want to purchase
-   * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
-   * and the optional prorationMode.
+   * @param {GoogleProductChangeInfo} googleProductChangeInfo Android only. Optional GoogleProductChangeInfo you 
+   * wish to upgrade from containing the oldProductIdentifier and the optional prorationMode.
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
@@ -476,13 +477,13 @@ export default class Purchases {
    */
   public static async purchaseStoreProduct(
     product: PurchasesStoreProduct,
-    upgradeInfo?: UpgradeInfo | null,
+    googleProductChangeInfo?: GoogleProductChangeInfo | null,
     googleIsPersonalizedPrice?: boolean | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
       product.identifier,
-      upgradeInfo,
+      googleProductChangeInfo,
       product.productCategory,
       null,
       googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
@@ -531,8 +532,9 @@ export default class Purchases {
    * Make a purchase
    *
    * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
-   * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
-   * and the optional prorationMode.
+   * @param {UpgradeInfo} upgradeInfo DEPRECATED. Use googleProductChangeInfo.
+   * @param {GoogleProductChangeInfo} googleProductChangeInfo Android only. Optional GoogleProductChangeInfo you 
+   * wish to upgrade from containing the oldProductIdentifier and the optional prorationMode.
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
@@ -544,13 +546,14 @@ export default class Purchases {
   public static async purchasePackage(
     aPackage: PurchasesPackage,
     upgradeInfo?: UpgradeInfo | null,
+    googleProductChangeInfo?: GoogleProductChangeInfo | null,
     googleIsPersonalizedPrice?: boolean | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchasePackage(
       aPackage.identifier,
       aPackage.offeringIdentifier,
-      upgradeInfo,
+      googleProductChangeInfo || upgradeInfo,
       null,
       googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
     ).catch((error: PurchasesError) => {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -11,7 +11,8 @@ import {
   PurchasesPromotionalOffer,
   PurchasesPackage,
   IntroEligibility,
-  PurchasesStoreProductDiscount
+  PurchasesStoreProductDiscount,
+  SubscriptionOption
 } from "./offerings";
 
 import {Platform} from "react-native";
@@ -431,14 +432,16 @@ export default class Purchases {
   public static async purchaseProduct(
     productIdentifier: string,
     upgradeInfo?: UpgradeInfo | null,
-    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
+    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS,
+    presentedOfferingIdentifier: string | null = null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
       productIdentifier,
       upgradeInfo,
       type,
-      null
+      null,
+      presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
@@ -467,7 +470,8 @@ export default class Purchases {
       product.identifier,
       null,
       null,
-      discount.timestamp.toString()
+      discount.timestamp.toString(),
+      product.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
@@ -495,6 +499,34 @@ export default class Purchases {
       aPackage.offeringIdentifier,
       upgradeInfo,
       null
+    ).catch((error: PurchasesError) => {
+      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      throw error;
+    });
+  }
+
+  /**
+   * Make a purchase
+   *
+   * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
+   * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
+   * and the optional prorationMode.
+   * @returns {Promise<{ productIdentifier: string, customerInfo: CustomerInfo }>} A promise of an object containing
+   * a customer info object and a product identifier. Rejections return an error code, a boolean indicating if the
+   * user cancelled the purchase, and an object with more information. The promise will be also be rejected if configure
+   * has not been called yet.
+   */
+  public static async purchaseSubscriptionOption(
+    aOption: SubscriptionOption,
+    upgradeInfo?: UpgradeInfo | null
+  ): Promise<MakePurchaseResult> {
+    await Purchases.throwIfNotConfigured();
+    return RNPurchases.purchaseSubscriptionOption(
+      aOption.productId,
+      aOption.id,
+      upgradeInfo,
+      null,
+      aOption.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -566,8 +566,8 @@ export default class Purchases {
    * Google only. Make a purchase of a subscriptionOption
    *
    * @param {SubscriptionOption} subscriptionOption The SubscriptionOption you wish to purchase. You can get the SubscriptionOption from StoreProducts by calling getOfferings
-   * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
-   * and the optional prorationMode.
+   * @param {GoogleProductChangeInfo} googleProductChangeInfo Android only. Optional GoogleProductChangeInfo you 
+   * wish to upgrade from containing the oldProductIdentifier and the optional prorationMode.
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
@@ -578,7 +578,7 @@ export default class Purchases {
    */
   public static async purchaseSubscriptionOption(
     subscriptionOption: SubscriptionOption,
-    upgradeInfo?: UpgradeInfo | null,
+    googleProductChangeInfo?: GoogleProductChangeInfo | null,
     googleIsPersonalizedPrice?: boolean | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
@@ -586,7 +586,7 @@ export default class Purchases {
     return RNPurchases.purchaseSubscriptionOption(
       subscriptionOption.productId,
       subscriptionOption.id,
-      upgradeInfo,
+      googleProductChangeInfo,
       null,
       googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
       subscriptionOption.presentedOfferingIdentifier

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -438,8 +438,8 @@ export default class Purchases {
     productIdentifier: string,
     upgradeInfo?: UpgradeInfo | null,
     type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS,
-    googleIsPersonalizedPrice: boolean | null = null,
-    presentedOfferingIdentifier: string | null = null,
+    googleIsPersonalizedPrice?: boolean | null,
+    presentedOfferingIdentifier?: string | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
@@ -506,7 +506,7 @@ export default class Purchases {
   public static async purchasePackage(
     aPackage: PurchasesPackage,
     upgradeInfo?: UpgradeInfo | null,
-    googleIsPersonalizedPrice: boolean | null = null,
+    googleIsPersonalizedPrice?: boolean | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchasePackage(
@@ -522,9 +522,9 @@ export default class Purchases {
   }
 
   /**
-   * Make a purchase
+   * Google only. Make a purchase of a subscriptionOption
    *
-   * @param {SubscriptionOption} subscriptionOption The SubscriptionOption you wish to purchase. You can get the SubscriptionOption from StoreProdcuts by calling getOfferings
+   * @param {SubscriptionOption} subscriptionOption The SubscriptionOption you wish to purchase. You can get the SubscriptionOption from StoreProducts by calling getOfferings
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
    * and the optional prorationMode.
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
@@ -538,10 +538,10 @@ export default class Purchases {
   public static async purchaseSubscriptionOption(
     subscriptionOption: SubscriptionOption,
     upgradeInfo?: UpgradeInfo | null,
-    googleIsPersonalizedPrice: boolean | null = null,
+    googleIsPersonalizedPrice?: boolean | null,
   ): Promise<MakePurchaseResult> {
-    await Purchases.throwIfIOSPlatform();
     await Purchases.throwIfNotConfigured();
+    await Purchases.throwIfIOSPlatform();
     return RNPurchases.purchaseSubscriptionOption(
       subscriptionOption.productId,
       subscriptionOption.id,

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -483,7 +483,7 @@ export default class Purchases {
     return RNPurchases.purchaseProduct(
       product.identifier,
       upgradeInfo,
-      null, // TODO: JOSH
+      product.productCategory,
       null,
       googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
       product.presentedOfferingIdentifier

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -12,7 +12,8 @@ import {
   PurchasesPackage,
   IntroEligibility,
   PurchasesStoreProductDiscount,
-  SubscriptionOption
+  SubscriptionOption,
+  PRODUCT_CATEGORY
 } from "./offerings";
 
 import {Platform} from "react-native";
@@ -58,6 +59,9 @@ eventEmitter.addListener(
   }
 );
 
+/**
+ * @deprecated, use PRODUCT_CATEGORY
+ */
 export enum PURCHASE_TYPE {
   /**
    * A type of SKU for in-app products.
@@ -188,8 +192,16 @@ export default class Purchases {
    * Supported SKU types.
    * @readonly
    * @enum {string}
+   * @deprecated, use PRODUCT_CATEGORY
    */
   public static PURCHASE_TYPE = PURCHASE_TYPE;
+
+  /**
+   * Supported product categories.
+   * @readonly
+   * @enum {string}
+   */
+  public static PRODUCT_CATEGORY = PRODUCT_CATEGORY;
 
   /**
    * Enum for billing features.
@@ -403,7 +415,7 @@ export default class Purchases {
   /**
    * Fetch the product info
    * @param {String[]} productIdentifiers Array of product identifiers
-   * @param {String} type Optional type of products to fetch, can be inapp or subs. Subs by default
+   * @param {String} type Optional type of products to fetch, can be SUBSCRIPTION or NON_SUBSCRIPTION. SUBSCRIPTION by default
    * @returns {Promise<PurchasesStoreProduct[]>} A promise containing an array of products. The promise will be rejected
    * if the products are not properly configured in RevenueCat or if there is another error retrieving them.
    * Rejections return an error code, and a userInfo object with more information. The promise will also be rejected
@@ -411,7 +423,7 @@ export default class Purchases {
    */
   public static async getProducts(
     productIdentifiers: string[],
-    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
+    type: PURCHASE_TYPE | PRODUCT_CATEGORY = PRODUCT_CATEGORY.SUBSCRIPTION
   ): Promise<PurchasesStoreProduct[]> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.getProductInfo(productIdentifiers, type);
@@ -427,19 +439,12 @@ export default class Purchases {
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
-   * @param {String} presentedOfferingIdentifier The offering identifier this product was returned from. The presentedOfferingIdentifier
-   * can be found on a StoreProduct.
-   * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
-   * a customer info object and a product identifier. Rejections return an error code,
-   * a boolean indicating if the user cancelled the purchase, and an object with more information. The promise will
-   * also be rejected if configure has not been called yet.
+   * @deprecated, use purchaseStoreProduct instead
    */
   public static async purchaseProduct(
     productIdentifier: string,
     upgradeInfo?: UpgradeInfo | null,
     type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS,
-    googleIsPersonalizedPrice?: boolean | null,
-    presentedOfferingIdentifier?: string | null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
@@ -447,8 +452,41 @@ export default class Purchases {
       upgradeInfo,
       type,
       null,
+      null,
+      null
+    ).catch((error: PurchasesError) => {
+      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      throw error;
+    });
+  }
+
+  /**
+   * Make a purchase
+   *
+   * @param {PurchasesStoreProduct} product The product you want to purchase
+   * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
+   * and the optional prorationMode.
+   * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+   * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
+   * a customer info object and a product identifier. Rejections return an error code,
+   * a boolean indicating if the user cancelled the purchase, and an object with more information. The promise will
+   * also be rejected if configure has not been called yet.
+   */
+  public static async purchaseStoreProduct(
+    product: PurchasesStoreProduct,
+    upgradeInfo?: UpgradeInfo | null,
+    googleIsPersonalizedPrice?: boolean | null,
+  ): Promise<MakePurchaseResult> {
+    await Purchases.throwIfNotConfigured();
+    return RNPurchases.purchaseProduct(
+      product.identifier,
+      upgradeInfo,
+      null, // TODO: JOSH
+      null,
       googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
-      presentedOfferingIdentifier
+      product.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
@@ -676,7 +714,7 @@ export default class Purchases {
    * This method will send all the purchases to the RevenueCat backend. Call this when using your own implementation
    * for subscriptions anytime a sync is needed, like after a successful purchase.
    *
-   * @warning This function should only be called if you're not calling purchaseProduct/purchasePackage.
+   * @warning This function should only be called if you're not calling purchaseProduct/purchaseStoreProduct/purchasePackage/purchaseSubscriptionOption.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * syncing purchases.
    */

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -424,6 +424,11 @@ export default class Purchases {
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
    * and the optional prorationMode.
    * @param {String} type Optional type of product, can be inapp or subs. Subs by default
+   * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+   * @param {String} presentedOfferingIdentifier The offering identifier this product was returned from. The presentedOfferingIdentifier
+   * can be found on a StoreProduct.
    * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code,
    * a boolean indicating if the user cancelled the purchase, and an object with more information. The promise will
@@ -433,6 +438,7 @@ export default class Purchases {
     productIdentifier: string,
     upgradeInfo?: UpgradeInfo | null,
     type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS,
+    googleIsPersonalizedPrice: boolean | null = null,
     presentedOfferingIdentifier: string | null = null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
@@ -441,6 +447,7 @@ export default class Purchases {
       upgradeInfo,
       type,
       null,
+      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
       presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -453,6 +460,9 @@ export default class Purchases {
    *
    * @param {PurchasesStoreProduct} product The product you want to purchase
    * @param {PurchasesPromotionalOffer} discount Discount to apply to this package. Retrieve this discount using getPromotionalOffer.
+   * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
    * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code,
    * a boolean indicating if the user cancelled the purchase, and an object with more information. The promise will be
@@ -460,7 +470,7 @@ export default class Purchases {
    */
   public static async purchaseDiscountedProduct(
     product: PurchasesStoreProduct,
-    discount: PurchasesPromotionalOffer
+    discount: PurchasesPromotionalOffer,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     if (typeof discount === "undefined" || discount == null) {
@@ -471,6 +481,7 @@ export default class Purchases {
       null,
       null,
       discount.timestamp.toString(),
+      null,
       product.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -484,6 +495,9 @@ export default class Purchases {
    * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
    * and the optional prorationMode.
+   * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
    * @returns {Promise<{ productIdentifier: string, customerInfo: CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code, a boolean indicating if the
    * user cancelled the purchase, and an object with more information. The promise will be also be rejected if configure
@@ -491,14 +505,16 @@ export default class Purchases {
    */
   public static async purchasePackage(
     aPackage: PurchasesPackage,
-    upgradeInfo?: UpgradeInfo | null
+    upgradeInfo?: UpgradeInfo | null,
+    googleIsPersonalizedPrice: boolean | null = null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchasePackage(
       aPackage.identifier,
       aPackage.offeringIdentifier,
       upgradeInfo,
-      null
+      null,
+      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
@@ -511,6 +527,9 @@ export default class Purchases {
    * @param {SubscriptionOption} subscriptionOption The SubscriptionOption you wish to purchase. You can get the SubscriptionOption from StoreProdcuts by calling getOfferings
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
    * and the optional prorationMode.
+   * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
+   * For compliance with EU regulations. User will see "This price has been customize for you" in the purchase dialog when true.
+   * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
    * @returns {Promise<{ productIdentifier: string, customerInfo: CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code, a boolean indicating if the
    * user cancelled the purchase, and an object with more information. The promise will be also be rejected if configure
@@ -518,7 +537,8 @@ export default class Purchases {
    */
   public static async purchaseSubscriptionOption(
     subscriptionOption: SubscriptionOption,
-    upgradeInfo?: UpgradeInfo | null
+    upgradeInfo?: UpgradeInfo | null,
+    googleIsPersonalizedPrice: boolean | null = null,
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseSubscriptionOption(
@@ -526,6 +546,7 @@ export default class Purchases {
       subscriptionOption.id,
       upgradeInfo,
       null,
+      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
       subscriptionOption.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -540,6 +540,7 @@ export default class Purchases {
     upgradeInfo?: UpgradeInfo | null,
     googleIsPersonalizedPrice: boolean | null = null,
   ): Promise<MakePurchaseResult> {
+    await Purchases.throwIfIOSPlatform();
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseSubscriptionOption(
       subscriptionOption.productId,

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -508,7 +508,7 @@ export default class Purchases {
   /**
    * Make a purchase
    *
-   * @param {PurchasesPackage} aPackage The Package you wish to purchase. You can get the Packages by calling getOfferings
+   * @param {SubscriptionOption} subscriptionOption The SubscriptionOption you wish to purchase. You can get the SubscriptionOption from StoreProdcuts by calling getOfferings
    * @param {UpgradeInfo} upgradeInfo Android only. Optional UpgradeInfo you wish to upgrade from containing the oldSKU
    * and the optional prorationMode.
    * @returns {Promise<{ productIdentifier: string, customerInfo: CustomerInfo }>} A promise of an object containing
@@ -517,16 +517,16 @@ export default class Purchases {
    * has not been called yet.
    */
   public static async purchaseSubscriptionOption(
-    aOption: SubscriptionOption,
+    subscriptionOption: SubscriptionOption,
     upgradeInfo?: UpgradeInfo | null
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseSubscriptionOption(
-      aOption.productId,
-      aOption.id,
+      subscriptionOption.productId,
+      subscriptionOption.id,
       upgradeInfo,
       null,
-      aOption.presentedOfferingIdentifier
+      subscriptionOption.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
       error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;


### PR DESCRIPTION
## Motivation

- Consume `SubscriptionOption`s and add `purchaseSubscriptionOption()`
- Set `isPersonalizedPrice`
- Consume and purchase with `presentedOfferingIdentifier `

## Description

- Bumped Purchases Hybrid Common to `5.0.0-beta.6` on Android and iOS
- Added `v6-MIGRATION.md` doc

### 1. Consuming `SubscriptionOption`

New `SubscriptionOption` onto `PurchasesStoreProduct` with the following new interfaces and enums:
- `SubscriptionOption`
- `PricingPhase`
- `Period`
- `Price`
- `RecurrenceMode`
- `PeriodUnit`

```dart
const basePlan = storeProduct.subscriptionOptions?.filter((option) => { option.isBasePlan });
const defaultOffer = storeProduct.defaultOffer
const freeOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.freePhase });
const trialOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.introPhase });
```

### 2. Purchase `SubscriptionOption`

New `Purchases.purchaseSubscriptionOption(SubscriptionOption)`
- Added native Android method
- **Did not** add a native iOS method since this method will throw on iOS

```dart
Purchases.purchaseSubscriptionOption(
  subscriptionOption: SubscriptionOption,
  googleProductChangeInfo?: GoogleProductChangeInfo | null,
  googleIsPersonalizedPrice: boolean | null,
)
```

### 3. Deprecated `purchaseProduct(String)` and added `purchaseStoreProduct(StoreProduct)`

This is easier on the developer because `StoreProduct` contains all the following info needed for purchase:
- product identifier
- product type/category (subscription or non-subscription)
- presented offering identifier

### 4. Supporting `isPersonalizedPrice`

Added `isPersonalizedPrice` parameter to `purchaseStoreProduct()`, `purchasedPackage()`, and `purchaseSubscriptionOption()`

ℹ️  This is a `Dictionary` with an optional boolean because straight optional booleans aren't supported by React Native 🤷‍♂️ 

### 5. Supporting `presentedOfferingIdentifier`

Added `presentedOfferingIdentifier` to `purchaseProduct()`

- Added new parameter onto Android and iOS method
  - iOS method does nothing with it since it doesn't need it but needed the parameter on it for reasons

### 6. Deprecated `UpgradeInfo` and replaced with `GoogleProductChangeInfo`

Prefixed with Google so that its known that this is only for Android and Google. Google also doesn't refer to these as upgrades/downgrades but as product change.

- Added as a new parameter on `purchasePackage()`
- Added on `purchaseSubscriptionOption()
- Added on `purchaseStoreProduct()`