### PR TITLE
Update `react-native-reanimated` in MagicWeather example app

### DIFF
--- a/examples/MagicWeather/package.json
+++ b/examples/MagicWeather/package.json
@@ -20,7 +20,7 @@
     "react-native-eject": "^0.1.2",
     "react-native-gesture-handler": "^1.9.0",
     "react-native-purchases": "^5.0.0",
-    "react-native-reanimated": "^1.13.2",
+    "react-native-reanimated": "^2.10.0",
     "react-native-safe-area-context": "^3.1.9",
     "react-native-screens": "^2.17.1",
     "react-native-vector-icons": "^8.0.0"


### PR DESCRIPTION
Updaters the `react-native-reanimated` library verison in MagicWeather sample app to >2.10.0 to get rid of a vulnerability. 

Solves https://github.com/RevenueCat/react-native-purchases/security/dependabot/8