### PR TITLE
Publish to npm with next tag if prerelease

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -85,8 +85,16 @@ end
 desc "Creates GitHub release and publishes package"
 lane :release do |options|
   version_number = current_version_number
+  is_prerelease = Gem::Version.new(version_number).prerelease?
+
+  args = [
+    'npm',
+    'publish',
+    is_prerelease ? 'tag --next' : nil
+  ].compact
+
   Dir.chdir(get_root_folder) do
-    sh('npm', 'publish')
+    sh(args)
   end
   github_release(version: version_number)
 end


### PR DESCRIPTION
## Motivation

CI published `6.0.0-alpha.1` with the default tag of "latest". This caused `npm install react-native-purchases` to install `6.0.0-alpha.1` instead of `5.13.3`

This change will call `npm publish --tag next` if the current version is a prerelease.

## Description

Adds `--tag next` to `npm publish` command if the current version is a prerelease 💪 