### PR TITLE
Update entitlement types

### DIFF
--- a/src/customerInfo.ts
+++ b/src/customerInfo.ts
@@ -48,13 +48,25 @@ export interface PurchasesEntitlementInfo {
      *
      * @note: Entitlement may still be active even if user has unsubscribed. Check the `isActive` property.
      */
-    readonly unsubscribeDetectedAt: string | null;
+    readonly unsubscribedDetectedAtMillis: number | null;
+    /**
+     * The date in milliseconds an unsubscribe was detected. Can be `null`.
+     *
+     * @note: Entitlement may still be active even if user has unsubscribed. Check the `isActive` property.
+     */
+    readonly unsubscribedDetectedAt: string | null;
     /**
      * The date a billing issue was detected. Can be `null` if there is no billing issue or an issue has been resolved
      *
      * @note: Entitlement may still be active even if there is a billing issue. Check the `isActive` property.
      */
     readonly billingIssueDetectedAt: string | null;
+    /**
+     * The date in milliseconds a billing issue was detected. Can be `null` if there is no billing issue or an issue has been resolved
+     *
+     * @note: Entitlement may still be active even if there is a billing issue. Check the `isActive` property.
+     */
+    readonly billingIssueDetectedAtMillis: number | null;
 }
 
 /**


### PR DESCRIPTION
- Adds to `Entitlement` interface unsubscribedDetectedAtMillis and billingIssueDetectedAtMillis.
- Corrects typo on `unsubscribedDetectedAt`

Locally I've been adding `@ts-expect-error` to skip over type errors. I noticed the typo when logging out an entitlement payload. 

<img width="506" alt="image" src="https://user-images.githubusercontent.com/987654/236592942-78a82918-78a7-4a9d-bb21-c315624b82a3.png">

<img width="944" alt="image" src="https://user-images.githubusercontent.com/987654/236592960-8a747252-205f-4445-83e8-978502d45733.png">

