### PR TITLE
Add offering metadata

### DIFF
--- a/RNPurchases.podspec
+++ b/RNPurchases.podspec
@@ -24,6 +24,6 @@ Pod::Spec.new do |spec|
   ]
 
   spec.dependency   "React-Core"
-  spec.dependency   "PurchasesHybridCommon", '5.0.0-beta.6'
+  spec.dependency   "PurchasesHybridCommon", '5.0.0-rc.1'
   spec.swift_version    = '5.0'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,6 +121,6 @@ def kotlin_version = getExtOrDefault('kotlinVersion')
 dependencies {
     //noinspection GradleDynamicVersion
     api 'com.facebook.react:react-native:+'
-    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-beta.6'
+    implementation 'com.revenuecat.purchases:purchases-hybrid-common:5.0.0-rc.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -53,6 +53,7 @@ function checkPackage(pack: PurchasesPackage) {
 function checkOffering(offering: PurchasesOffering) {
   const identifier: string = offering.identifier;
   const serverDescription: string = offering.serverDescription;
+  const metadata: Map<string, any> = offering.metadata;
   const availablePackages: PurchasesPackage[] = offering.availablePackages;
   const lifetime: PurchasesPackage | null = offering.lifetime;
   const annual: PurchasesPackage | null = offering.annual;

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -80,6 +80,10 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
           <Text style={styles.value}>
             { route.params.offering?.identifier }
           </Text>
+          <Text style={styles.title}>Metadata</Text>
+          <Text style={styles.value}>
+            { JSON.stringify(route.params.offering?.metadata) }
+          </Text>
 
           {
             route.params.offering?.availablePackages.map((pkg: PurchasesPackage) => {

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -330,6 +330,16 @@ global.offeringsStub = {
         identifier: 'Custom'
       }
     ],
+    metadata: {
+      "int": 5,
+      "double": 5.5,
+      "boolean": true,
+      "string": "five",
+      "array": ["five"],
+      "dictionary": {
+          "string": "five"
+      }
+    },
     serverDescription: 'Default Offering',
     identifier: 'default'
   },

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -242,6 +242,10 @@ export interface PurchasesOffering {
      */
     readonly serverDescription: string;
     /**
+     * Offering metadata defined in RevenueCat dashboard.
+     */
+    readonly metadata: Map<string, any>;
+    /**
      * Array of `Package` objects available for purchase.
      */
     readonly availablePackages: PurchasesPackage[];


### PR DESCRIPTION
## Motivation

Add `metadata` to `PurchasesOffering `

## Description

- Adds `metadata` to `PurchasesOffering`
- Adds API tester for `metadata`
- Adds new test
- Displays `metadata` in purchase tester app
- Bump to PHC `5.0.0-rc.1`