### PR TITLE
[DENG-418] Accept `GoogleProductChangeInfo` in `purchasePackage` in Android

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -295,6 +295,31 @@ describe("Purchases", () => {
       prorationMode: Purchases.PRORATION_MODE.DEFERRED
     }, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(2);
+    await Purchases.purchasePackage(
+      {
+        identifier: "$rc_onemonth",
+        packageType: Purchases.PACKAGE_TYPE.MONTHLY,
+        product: {
+          identifier: "onemonth_freetrial",
+          description: "description",
+          title: "title",
+          price: 4.5,
+          priceString: "$4.5",
+          currency_code: "USD",
+          introPrice: null
+        },
+        offeringIdentifier: "offering",
+      },
+      {
+        oldProductIdentifier: "viejo",
+        prorationMode: Purchases.PRORATION_MODE.DEFERRED
+      },
+    );
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
+      oldProductIdentifier: "viejo",
+      prorationMode: Purchases.PRORATION_MODE.DEFERRED
+    }, null, null);
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(3);
   });
 
   it("purchaseSubscriptionOption works", async () => {

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -146,9 +146,6 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             if (googleOldProductId == null) {
                 googleOldProductId = googleProductChangeInfo.hasKey("oldSKU") ? googleProductChangeInfo.getString("oldSKU") : null;
             }
-            if (googleProrationMode == null) {
-                googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
-            }
         }
 
         Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
@@ -183,9 +180,6 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             // Legacy UpgradeInfo in V5 and earlier
             if (googleOldProductId == null) {
                 googleOldProductId = googleProductChangeInfo.hasKey("oldSKU") ? googleProductChangeInfo.getString("oldSKU") : null;
-            }
-            if (googleProrationMode == null) {
-                googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
             }
         }
         Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -172,6 +172,9 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
                                 final Promise promise) {
+        String googleOldProductId = null;
+        Integer googleProrationMode = null;
+
         if (googleProductChangeInfo != null) {
             // GoogleProductChangeInfo in V6 and later
             googleOldProductId = googleProductChangeInfo.hasKey("oldProductIdentifier") ? googleProductChangeInfo.getString("oldProductIdentifier") : null;

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -168,13 +168,23 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     @ReactMethod
     public void purchasePackage(final String packageIdentifier,
                                 final String offeringIdentifier,
-                                @Nullable final ReadableMap upgradeInfo,
+                                @Nullable final ReadableMap googleProductChangeInfo,
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
                                 final Promise promise) {
-        String googleOldProductId = upgradeInfo != null && upgradeInfo.hasKey("oldSKU") ? upgradeInfo.getString("oldSKU") : null;
-        Integer googleProrationMode = upgradeInfo != null && upgradeInfo.hasKey("prorationMode") ? upgradeInfo.getInt("prorationMode") : null;
+        if (googleProductChangeInfo != null) {
+            // GoogleProductChangeInfo in V6 and later
+            googleOldProductId = googleProductChangeInfo.hasKey("oldProductIdentifier") ? googleProductChangeInfo.getString("oldProductIdentifier") : null;
+            googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
 
+            // Legacy UpgradeInfo in V5 and earlier
+            if (googleOldProductId == null) {
+                googleOldProductId = googleProductChangeInfo.hasKey("oldSKU") ? googleProductChangeInfo.getString("oldSKU") : null;
+            }
+            if (googleProrationMode == null) {
+                googleProrationMode = googleProductChangeInfo.hasKey("prorationMode") ? googleProductChangeInfo.getInt("prorationMode") : null;
+            }
+        }
         Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
         CommonKt.purchasePackage(


### PR DESCRIPTION
We were only accepting parameters for the old `UpgradeInfo` object in the Android native side.

With this change, both `UpgradeInfo` and `GoogleProductChangeInfo` objects are accepted.