### PR TITLE
Fix V6 migration docs to use correct method name

### DIFF
--- a/migrations/v6-MIGRATION.md
+++ b/migrations/v6-MIGRATION.md
@@ -44,7 +44,7 @@ be found through `subscriptionOptions` on `StoreProduct`:
 
 ```dart
 const basePlan = storeProduct.subscriptionOptions?.filter((option) => { option.isBasePlan });
-const defaultOffer = storeProduct.defaultOffer
+const defaultOption = storeProduct.defaultOption
 const freeOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.freePhase });
 const trialOffer = storeProduct.subscriptionOptions?.filter((option) => { !!option.introPhase });
 ```


### PR DESCRIPTION
Fix an incorrect method name in the V6 migration docs.
