### PR TITLE
`Trusted Entitlements`: add support for setting `EntitlementVerificationMode`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -589,7 +589,7 @@ describe("Purchases", () => {
       useAmazon: true,
       shouldShowInAppMessagesAutomatically: false
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, false);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, false, defaultVerificationMode);
 
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(5);
   })

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,6 @@
 const {NativeModules, NativeEventEmitter, Platform} = require("react-native");
 const {UnsupportedPlatformError} = require("../dist/errors");
-const {REFUND_REQUEST_STATUS} = require("../dist/purchases");
+const {REFUND_REQUEST_STATUS, ENTITLEMENT_VERIFICATION_MODE} = require("../dist/purchases");
 
 const nativeEmitter = new NativeEventEmitter();
 
@@ -552,11 +552,13 @@ describe("Purchases", () => {
   })
 
   it("configure works", async () => {
+    const defaultVerificationMode= "DISABLED"
+
     Purchases.configure({apiKey: "key", appUserID: "user"});
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false, true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false, true, defaultVerificationMode);
 
     Purchases.configure({apiKey: "key", appUserID: "user", observerMode: true});
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false, false, true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false, false, true, defaultVerificationMode);
 
     Purchases.configure({
       apiKey: "key",
@@ -565,7 +567,7 @@ describe("Purchases", () => {
       userDefaultsSuiteName: "suite name",
       usesStoreKit2IfAvailable: true
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suite name", true, false, true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suite name", true, false, true, defaultVerificationMode);
 
     Purchases.configure({
       apiKey: "key",
@@ -573,9 +575,10 @@ describe("Purchases", () => {
       observerMode: true,
       userDefaultsSuiteName: "suite name",
       usesStoreKit2IfAvailable: true,
+      entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
       useAmazon: true
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true, "INFORMATIONAL");
 
     Purchases.configure({
       apiKey: "key",

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -552,7 +552,7 @@ describe("Purchases", () => {
   })
 
   it("configure works", async () => {
-    const defaultVerificationMode= "DISABLED"
+    const defaultVerificationMode = "DISABLED"
 
     Purchases.configure({apiKey: "key", appUserID: "user"});
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false, true, defaultVerificationMode);

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,6 @@
 const {NativeModules, NativeEventEmitter, Platform} = require("react-native");
 const {UnsupportedPlatformError} = require("../dist/errors");
-const {REFUND_REQUEST_STATUS, ENTITLEMENT_VERIFICATION_MODE} = require("../dist/purchases");
+const {REFUND_REQUEST_STATUS} = require("../dist/purchases");
 
 const nativeEmitter = new NativeEventEmitter();
 
@@ -575,10 +575,11 @@ describe("Purchases", () => {
       observerMode: true,
       userDefaultsSuiteName: "suite name",
       usesStoreKit2IfAvailable: true,
-      entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
-      useAmazon: true
+      useAmazon: true,
+      shouldShowInAppMessagesAutomatically: true,
+      entitlementVerificationMode: Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true, "INFORMATIONAL");
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true, Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL);
 
     Purchases.configure({
       apiKey: "key",

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -83,7 +83,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     public void setupPurchases(String apiKey, @Nullable String appUserID,
                                boolean observerMode, @Nullable String userDefaultsSuiteName,
                                @Nullable Boolean usesStoreKit2IfAvailable, boolean useAmazon,
-                               boolean shouldShowInAppMessagesAutomatically) {
+                               boolean shouldShowInAppMessagesAutomatically,
+                               @Nullable String entitlementVerificationMode) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         Store store = Store.PLAY_STORE;
         if (useAmazon) {
@@ -97,7 +98,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             platformInfo,
             store,
             new DangerousSettings(),
-            shouldShowInAppMessagesAutomatically
+            shouldShowInAppMessagesAutomatically,
+            entitlementVerificationMode
         );
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(this);
     }

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -15,7 +15,7 @@ import {
 } from '../dist';
 
 import Purchases from '../dist/purchases';
-import { GoogleProductChangeInfo, SubscriptionOption } from '../src';
+import { ENTITLEMENT_VERIFICATION_MODE, GoogleProductChangeInfo, SubscriptionOption } from '../src';
 
 async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
@@ -132,6 +132,7 @@ async function checkConfigure() {
   const observerMode: boolean = false;
   const usesStoreKit2IfAvailable: boolean = true;
   const useAmazon: boolean = true;
+  const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE = ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
   const userDefaultsSuiteName: string = "";
   const shouldShowInAppMessagesAutomatically: boolean = true;
 
@@ -159,6 +160,15 @@ async function checkConfigure() {
     observerMode,
     userDefaultsSuiteName,
     usesStoreKit2IfAvailable,
+    entitlementVerificationMode
+  });  
+  Purchases.configure({
+    apiKey,
+    appUserID,
+    observerMode,
+    userDefaultsSuiteName,
+    usesStoreKit2IfAvailable,
+    entitlementVerificationMode,
     useAmazon
   });
   Purchases.configure({
@@ -191,6 +201,14 @@ async function checkLogLevelEnum(level: LOG_LEVEL) {
     case LOG_LEVEL.INFO:
     case LOG_LEVEL.WARN:
     case LOG_LEVEL.ERROR:
+  }
+}
+
+async function checkEntitlementVerificationModeEnum(mode: ENTITLEMENT_VERIFICATION_MODE) {
+  switch (mode) {
+    case ENTITLEMENT_VERIFICATION_MODE.DISABLED:
+    case ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL:
+    case ENTITLEMENT_VERIFICATION_MODE.ENFORCED:
   }
 }
 

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -1,4 +1,4 @@
-import { IN_APP_MESSAGE_TYPE } from '@revenuecat/purchases-typescript-internal';
+import {ENTITLEMENT_VERIFICATION_MODE, IN_APP_MESSAGE_TYPE} from '@revenuecat/purchases-typescript-internal';
 import {
   CustomerInfo,
   PurchasesEntitlementInfo,
@@ -15,7 +15,7 @@ import {
 } from '../dist';
 
 import Purchases from '../dist/purchases';
-import { ENTITLEMENT_VERIFICATION_MODE, GoogleProductChangeInfo, SubscriptionOption } from '../src';
+import { GoogleProductChangeInfo, SubscriptionOption } from '../src';
 
 async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
@@ -132,7 +132,7 @@ async function checkConfigure() {
   const observerMode: boolean = false;
   const usesStoreKit2IfAvailable: boolean = true;
   const useAmazon: boolean = true;
-  const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE = ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
+  const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE = Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
   const userDefaultsSuiteName: string = "";
   const shouldShowInAppMessagesAutomatically: boolean = true;
 
@@ -161,7 +161,7 @@ async function checkConfigure() {
     userDefaultsSuiteName,
     usesStoreKit2IfAvailable,
     entitlementVerificationMode
-  });  
+  });
   Purchases.configure({
     apiKey,
     appUserID,
@@ -208,7 +208,8 @@ async function checkEntitlementVerificationModeEnum(mode: ENTITLEMENT_VERIFICATI
   switch (mode) {
     case ENTITLEMENT_VERIFICATION_MODE.DISABLED:
     case ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL:
-    case ENTITLEMENT_VERIFICATION_MODE.ENFORCED:
+    // Add back when adding enforced support.
+    // case ENTITLEMENT_VERIFICATION_MODE.ENFORCED:
   }
 }
 

--- a/examples/purchaseTesterTypescript/App.tsx
+++ b/examples/purchaseTesterTypescript/App.tsx
@@ -34,15 +34,18 @@ const App = () => {
     if (!hasKeys()) { return }
 
     Purchases.setLogLevel(Purchases.LOG_LEVEL.DEBUG);
+
+    const verificationMode = Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
+
     if (Platform.OS == "android") {
       const useAmazon = false;
       if (useAmazon) {
-        Purchases.configure({apiKey: APIKeys.amazon, useAmazon: true});
+        Purchases.configure({apiKey: APIKeys.amazon, useAmazon: true, entitlementVerificationMode: verificationMode});
       } else {
-        Purchases.configure({apiKey: APIKeys.google});
+        Purchases.configure({apiKey: APIKeys.google, entitlementVerificationMode: verificationMode});
       }
     } else {
-      Purchases.configure({apiKey: APIKeys.apple});
+      Purchases.configure({apiKey: APIKeys.apple, entitlementVerificationMode: verificationMode});
     }
 
     Purchases.enableAdServicesAttributionTokenCollection();

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -54,7 +54,7 @@ RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                                      usesStoreKit2IfAvailable:usesStoreKit2IfAvailable
                                             dangerousSettings:nil 
                          shouldShowInAppMessagesAutomatically:shouldShowInAppMessagesAutomatically 
-                                             verificationMode:nil];
+                                             verificationMode:entitlementVerificationMode];
     purchases.delegate = self;
 }
 

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -43,7 +43,8 @@ RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                   userDefaultsSuiteName:(nullable NSString *)userDefaultsSuiteName
                   usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable
                   useAmazon:(BOOL)useAmazon
-                  shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically) {
+                  shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
+                  entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode) {
     RCPurchases *purchases = [RCPurchases configureWithAPIKey:apiKey
                                                     appUserID:appUserID
                                                  observerMode:observerMode

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -29,7 +29,9 @@ import {
   MakePurchaseResult,
   LogHandler,
   LogInResult,
-  IN_APP_MESSAGE_TYPE
+  IN_APP_MESSAGE_TYPE,
+  ENTITLEMENT_VERIFICATION_MODE,
+  VERIFICATION_RESULT
 } from '@revenuecat/purchases-typescript-internal';
 
 // This export is kept to keep backwards compatibility to any possible users using this file directly
@@ -154,6 +156,20 @@ export default class Purchases {
   public static IN_APP_MESSAGE_TYPE = IN_APP_MESSAGE_TYPE;
 
   /**
+   * Enum of entitlement verification modes.
+   * @readonly
+   * @enum {string}
+   */
+  public static ENTITLEMENT_VERIFICATION_MODE = ENTITLEMENT_VERIFICATION_MODE;
+
+  /**
+   * The result of the verification process.
+   * @readonly
+   * @enum {string}
+   */
+  public static VERIFICATION_RESULT = VERIFICATION_RESULT;
+
+  /**
    * @internal
    */
   public static UninitializedPurchasesError = UninitializedPurchasesError;
@@ -181,10 +197,10 @@ export default class Purchases {
                             appUserID = null,
                             observerMode = false,
                             userDefaultsSuiteName,
-                            entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED,
                             usesStoreKit2IfAvailable = false,
                             useAmazon = false,
-                            shouldShowInAppMessagesAutomatically = true
+                            shouldShowInAppMessagesAutomatically = true,
+                            entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED
                           }: PurchasesConfiguration): void {
     if (apiKey === undefined || typeof apiKey !== "string") {
       throw new Error("Invalid API key. It must be called with an Object: configure({apiKey: \"key\"})");

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -186,7 +186,7 @@ export default class Purchases {
    * @param {boolean} [observerMode=false] An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
    * @param {boolean} [usesStoreKit2IfAvailable=false] DEPRECATED. An optional boolean. iOS-only. Defaults to FALSE. Setting this to TRUE will enable StoreKit2 on compatible devices.
    * We recommend not using this parameter, letting RevenueCat decide for you which StoreKit implementation to use.
-   * @param {ENTITLEMENT_VERIFICATION_MODE} [entitlementVerificationMode=ENTITLEMENT_VERIFICATION_MODE.DISABLED]
+   * @param {ENTITLEMENT_VERIFICATION_MODE} [entitlementVerificationMode=ENTITLEMENT_VERIFICATION_MODE.DISABLED] Sets the entitlement verifciation mode to use. For more details, check https://rev.cat/trusted-entitlements
    * @param {boolean} [useAmazon=false] An optional boolean. Android-only. Set this to TRUE to enable Amazon on compatible devices.
    * @param {String?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -170,6 +170,7 @@ export default class Purchases {
    * @param {boolean} [observerMode=false] An optional boolean. Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
    * @param {boolean} [usesStoreKit2IfAvailable=false] DEPRECATED. An optional boolean. iOS-only. Defaults to FALSE. Setting this to TRUE will enable StoreKit2 on compatible devices.
    * We recommend not using this parameter, letting RevenueCat decide for you which StoreKit implementation to use.
+   * @param {ENTITLEMENT_VERIFICATION_MODE} [entitlementVerificationMode=ENTITLEMENT_VERIFICATION_MODE.DISABLED]
    * @param {boolean} [useAmazon=false] An optional boolean. Android-only. Set this to TRUE to enable Amazon on compatible devices.
    * @param {String?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.
@@ -180,6 +181,7 @@ export default class Purchases {
                             appUserID = null,
                             observerMode = false,
                             userDefaultsSuiteName,
+                            entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED,
                             usesStoreKit2IfAvailable = false,
                             useAmazon = false,
                             shouldShowInAppMessagesAutomatically = true
@@ -191,6 +193,7 @@ export default class Purchases {
     if (appUserID !== null && typeof appUserID !== "undefined" && typeof appUserID !== "string") {
       throw new Error("appUserID needs to be a string");
     }
+
     RNPurchases.setupPurchases(
       apiKey,
       appUserID,
@@ -198,7 +201,8 @@ export default class Purchases {
       userDefaultsSuiteName,
       usesStoreKit2IfAvailable,
       useAmazon,
-      shouldShowInAppMessagesAutomatically
+      shouldShowInAppMessagesAutomatically,
+      entitlementVerificationMode
     );
   }
 


### PR DESCRIPTION
See http://rev.cat/trusted-entitlements for more information.

Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/451