### PR TITLE
Use correct type in offering metadata

### DIFF
--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -56,7 +56,7 @@ function checkPackage(pack: PurchasesPackage) {
 function checkOffering(offering: PurchasesOffering) {
   const identifier: string = offering.identifier;
   const serverDescription: string = offering.serverDescription;
-  const metadata: Map<string, any> = offering.metadata;
+  const metadata: { [key: string]: unknown } = offering.metadata;
   const availablePackages: PurchasesPackage[] = offering.availablePackages;
   const lifetime: PurchasesPackage | null = offering.lifetime;
   const annual: PurchasesPackage | null = offering.annual;

--- a/src/offerings.ts
+++ b/src/offerings.ts
@@ -242,9 +242,12 @@ export interface PurchasesOffering {
      */
     readonly serverDescription: string;
     /**
-     * Offering metadata defined in RevenueCat dashboard.
+     * Offering metadata defined in RevenueCat dashboard. To access values, you need
+     * to check the type beforehand. For example:
+     * const my_unknown_value: unknown = offering.metadata['my_key'];
+     * const my_string_value: string | undefined = typeof(my_unknown_value) === 'string' ? my_unknown_value : undefined;
      */
-    readonly metadata: Map<string, any>;
+    readonly metadata: { [key: string]: unknown };
     /**
      * Array of `Package` objects available for purchase.
      */


### PR DESCRIPTION
As reported in #700. The typescript interface has specified the wrong type for metadata. We're not using typescript `Map`s, but simple objects for metadata This should be an object of key strings and unknown values.
