### PR TITLE
Update RevenueCat orb to 2.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   rn: react-native-community/react-native@7.1.1
-  revenuecat: revenuecat/sdks-common-config@2.0.0
+  revenuecat: revenuecat/sdks-common-config@2.2.0
 
 aliases:
   release-tags: &release-tags


### PR DESCRIPTION
Updated orb to 2.2.0 https://github.com/RevenueCat/sdks-circleci-orb/compare/v2.0.0...v2.2.0
