### PR TITLE
`CI`: disable `prepare-next-version`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,20 +128,6 @@ jobs:
           project_path: examples/purchaseTesterTypescript/ios/PurchaseTester.xcworkspace
           scheme: PurchaseTester
 
-  prepare-next-version:
-    description: "Creates a PR with the new snapshot version"
-    docker:
-      - image: cimg/ruby:3.1.2
-    steps:
-      - checkout
-      - revenuecat/install-gem-unix-dependencies:
-          cache-version: v1
-      - revenuecat/trust-github-key
-      - revenuecat/setup-git-credentials
-      - run:
-          name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
-
   make-release:
     description: "Publishes the new version and creates a github release"
     executor:
@@ -204,14 +190,6 @@ workflows:
           <<: *release-tags
           requires:
             - make-release
-
-  snapshot-bump:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - prepare-next-version:
-          <<: *only-main-branch
 
   danger:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -76,17 +76,6 @@ lane :github_release do |options|
   )
 end
 
-desc "Creates PR changing version to next minor adding a -SNAPSHOT suffix"
-lane :prepare_next_version do |options|
-  create_next_snapshot_version(
-    current_version: current_version_number,
-    repo_name: repo_name,
-    github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
-    files_to_update: files_with_version_number,
-    files_to_update_without_prerelease_modifiers: {}
-  )
-end
-
 desc "Creates GitHub release and publishes package"
 lane :release do |options|
   version_number = current_version_number


### PR DESCRIPTION
As discussed, these provide little value in the hybrids and instead create unnecessary busy work.