### PR TITLE
RevenueCatUI: FooterView and full screen paywall fixes

### DIFF
--- a/examples/purchaseTesterTypescript/app/screens/FooterPaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/FooterPaywallScreen.tsx
@@ -1,24 +1,22 @@
 import React from 'react';
-import { PaywallFooterView } from 'react-native-purchases-ui';
+import {PaywallFooterView} from 'react-native-purchases-ui';
 
-import { Text, View } from 'react-native';
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import RootStackParamList from "../RootStackParamList";
+import {StyleSheet, View} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import RootStackParamList from '../RootStackParamList';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'FooterPaywall'>;
 
 const FooterPaywallScreen: React.FC<Props> = () => {
+  const styles = StyleSheet.create({
+    flex1: {
+      flex: 1,
+    },
+  });
+
   return (
-    <View style={{
-      justifyContent: 'space-between',
-      flexDirection: 'column',
-      flexGrow: 1,
-      backgroundColor: '#4b72f6',
-    }}>
-      <View style={{ backgroundColor: '#ff0000'}}>
-        <Text>Top</Text>
-      </View>
-      <PaywallFooterView/>
+    <View style={styles.flex1}>
+      <PaywallFooterView style={styles.flex1} />
     </View>
   );
 };

--- a/examples/purchaseTesterTypescript/app/screens/PaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/PaywallScreen.tsx
@@ -1,28 +1,24 @@
 import React from 'react';
-import { Paywall } from 'react-native-purchases-ui';
+import {Paywall} from 'react-native-purchases-ui';
 
-import {
-  StyleSheet,
-  View,
-} from 'react-native';
-import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import RootStackParamList from "../RootStackParamList";
+import {StyleSheet, View} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import RootStackParamList from '../RootStackParamList';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Paywall'>;
 
 const PaywallScreen: React.FC<Props> = () => {
+  const styles = StyleSheet.create({
+    flex1: {
+      flex: 1,
+    },
+  });
+
   return (
-    <View style={styles.container}>
-      <Paywall/>
+    <View style={styles.flex1}>
+      <Paywall style={styles.flex1} />
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    width: '100%',
-    height: '100%'
-  },
-});
 
 export default PaywallScreen;


### PR DESCRIPTION
Fixes a couple of issues in the layout of footerView and full screen paywalls. 

Requires https://github.com/RevenueCat/purchases-ios/pull/3547


| Full Screen | Footer |
| :-: | :-: |
| ![Simulator Screenshot - iPhone 15 - 2024-01-02 at 17 36 45](https://github.com/RevenueCat/react-native-purchases/assets/3922667/02f86e0a-0e11-4622-847e-50b558496ece) | ![Simulator Screenshot - iPhone 15 - 2024-01-02 at 17 37 31](https://github.com/RevenueCat/react-native-purchases/assets/3922667/951a3b1a-006d-4b65-b115-e9dc5748ea9b) |