### PR TITLE
Use parameter instead of multiple commands to install yarn dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,29 +36,19 @@ parameters:
     default: false
 
 commands:
-  install-dependencies-unix:
+  install-dependencies:
+    parameters:
+      machine:
+        type: string
     steps:
       - restore_cache:
           keys:
-            - yarn-v2-unix-{{ checksum "yarn.lock" }}
+            - yarn-v2-<<parameters.machine>>-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn
       - save_cache:
-          key: yarn-v2-unix-{{ checksum "yarn.lock" }}
-          paths:
-            - .yarn/cache
-
-  install-dependencies-macos:
-    steps:
-      - restore_cache:
-          keys:
-            - yarn-v2-macos-{{ checksum "yarn.lock" }}
-      - run:
-          name: Yarn Install
-          command: yarn
-      - save_cache:
-          key: yarn-v2-macos-{{ checksum "yarn.lock" }}
+          key: yarn-v2-<<parameters.machine>>-{{ checksum "yarn.lock" }}
           paths:
             - .yarn/cache
 
@@ -75,7 +65,8 @@ jobs:
       node_version: '18.2'
     steps:
       - checkout
-      - install-dependencies-unix
+      - install-dependencies:
+          machine: "unix"
       - run:
           name: Prepare package
           command: yarn prepare
@@ -99,7 +90,8 @@ jobs:
       xcode_version: 14.3.1
     steps:
       - checkout
-      - install-dependencies-macos
+      - install-dependencies:
+          machine: "macos"
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - revenuecat/setup-git-credentials
@@ -119,7 +111,8 @@ jobs:
       resource_class: medium
     steps:
       - checkout
-      - install-dependencies-unix
+      - install-dependencies:
+          machine: "unix"
       - rn/android_build:
           project_path: examples/purchaseTesterTypescript/android
   ios:
@@ -134,7 +127,8 @@ jobs:
       - run:
           name: Update CocoaPods repo
           command: pod repo update
-      - install-dependencies-macos
+      - install-dependencies:
+          machine: "macos"
       - run:
           name: Install example dependencies
           command: |
@@ -155,7 +149,8 @@ jobs:
       xcode_version: 14.3.1
     steps:
       - checkout
-      - install-dependencies-macos
+      - install-dependencies:
+          machine: "macos"
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - revenuecat/trust-github-key


### PR DESCRIPTION
In #841 we separated the install dependencies command into 2 in order to fix an issue where the cache was wrong in different machine types. This unifies them back and uses a parameter instead.
