### PR TITLE
Add `offering` option to paywall views

### DIFF
--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import RevenueCatUI, {
-  PAYWALL_RESULT,
+  FooterPaywallViewOptions,
+  FullScreenPaywallViewOptions,
+  PAYWALL_RESULT, PaywallViewOptions,
   PresentPaywallIfNeededParams,
   PresentPaywallParams
 } from "../react-native-purchases-ui";
-import { PurchasesOffering } from "@revenuecat/purchases-typescript-internal";
+import { PurchasesOffering, PurchasesOfferings } from "@revenuecat/purchases-typescript-internal";
 
 async function checkPresentPaywall(offering: PurchasesOffering) {
   let paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywall({});
@@ -52,13 +54,55 @@ function checkPresentPaywallIfNeededParams(params: PresentPaywallParams) {
   const displayCloseButton: boolean | undefined = params.displayCloseButton;
 }
 
+function checkFullScreenPaywallViewOptions(options: FullScreenPaywallViewOptions) {
+  const offering: PurchasesOffering | undefined | null = options.offering;
+}
+
+function checkFooterPaywallViewOptions(options: FooterPaywallViewOptions) {
+  const offering: PurchasesOffering | undefined | null = options.offering;
+}
+
 const PaywallScreen = () => {
+  return (
+    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
+      offering: null
+    }}/>
+  );
+};
+
+const PaywallScreenWithOffering = (offering: PurchasesOffering) => {
+  return (
+    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
+      offering: offering
+    }}/>
+  );
+};
+
+const PaywallScreenNoOptions = () => {
   return (
     <RevenueCatUI.Paywall style={{marginBottom: 10}}/>
   );
 };
 
 const FooterPaywallScreen = () => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView options={{
+      offering: null,
+    }}>
+    </RevenueCatUI.PaywallFooterContainerView>
+  );
+};
+
+const FooterPaywallScreenWithOffering = (offering: PurchasesOffering) => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView options={{
+      offering: offering,
+    }}>
+    </RevenueCatUI.PaywallFooterContainerView>
+  );
+};
+
+const FooterPaywallScreenNoOptions = () => {
   return (
     <RevenueCatUI.PaywallFooterContainerView>
     </RevenueCatUI.PaywallFooterContainerView>

--- a/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
+++ b/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
@@ -4,8 +4,8 @@ type RootStackParamList = {
   Home: undefined;
   CustomerInfo: {appUserID: String | null, customerInfo: CustomerInfo | null};
   OfferingDetail: {offering: PurchasesOffering | null};
-  Paywall: undefined;
-  FooterPaywall: undefined;
+  Paywall: {offering: PurchasesOffering | null};
+  FooterPaywall: {offering: PurchasesOffering | null};
 };
 
 export default RootStackParamList;

--- a/examples/purchaseTesterTypescript/app/screens/FooterPaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/FooterPaywallScreen.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import RevenueCatUI from 'react-native-purchases-ui';
 
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Text } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'FooterPaywall'>;
 
-const FooterPaywallScreen: React.FC<Props> = () => {
+const FooterPaywallScreen: React.FC<Props> = ({ route, navigation }: Props) => {
   return (
-    <RevenueCatUI.PaywallFooterContainerView style={{ backgroundColor: '#f8f8f8' }}>
+    <RevenueCatUI.PaywallFooterContainerView style={{backgroundColor: '#f8f8f8'}}
+                                             options={{
+                                               offering: route.params.offering,
+                                             }}>
       <Text>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec
         ligula in dolor efficitur accumsan nec vel nisl. Sed vitae lectus eget

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -182,9 +182,15 @@ const HomeScreen: React.FC<Props> = ({
             </TouchableOpacity>
             <Divider />
             <TouchableOpacity
-              onPress={() => navigation.navigate('Paywall')}>
+              onPress={() => navigation.navigate('Paywall', { offering: null })}>
               <Text style={styles.otherActions}>
                 Go to Paywall Screen
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => navigation.navigate('FooterPaywall', { offering: null })}>
+              <Text style={styles.otherActions}>
+                Go to Paywall Screen as Footer
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
@@ -208,12 +214,6 @@ const HomeScreen: React.FC<Props> = ({
               }}>
               <Text style={styles.otherActions}>
                 Present paywall
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              onPress={() => navigation.navigate('FooterPaywall')}>
-              <Text style={styles.otherActions}>
-                Go to Paywall Screen as Footer
               </Text>
             </TouchableOpacity>
           </View>

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -32,7 +32,8 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
   }
 
   const purchaseProduct = (product: PurchasesStoreProduct) => {
-    Purchases.purchaseStoreProduct(product).then(() => {
+    Purchases.purchaseStoreProduct(product).then((result) => {
+      console.log("success", result)
     }).catch((err) => {
       console.log("error", err)
     });

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -32,7 +32,7 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
   }
 
   const purchaseProduct = (product: PurchasesStoreProduct) => {
-    Purchases.purchaseStoreProduct(product,).then(() => {
+    Purchases.purchaseStoreProduct(product).then(() => {
     }).catch((err) => {
       console.log("error", err)
     });

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
 
-import {ScrollView, StyleSheet, Text, TouchableOpacity, useColorScheme, View,} from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, useColorScheme, View, } from 'react-native';
 
-import {Colors,} from 'react-native/Libraries/NewAppScreen';
+import { Colors, } from 'react-native/Libraries/NewAppScreen';
 
 import Purchases, {
-  PURCHASE_TYPE,
   PurchasesPackage,
   PurchasesStoreProduct,
   SubscriptionOption
 } from 'react-native-purchases';
 import RevenueCatUI from 'react-native-purchases-ui';
 
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList'
 
 type Props = NativeStackScreenProps<RootStackParamList, 'OfferingDetail'>;
@@ -26,27 +25,21 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
   };
 
   const purchasePackage = (pkg: PurchasesPackage) => {
-    Purchases.purchasePackage(pkg).then((result) => {
+    Purchases.purchasePackage(pkg).then(() => {
     }).catch((err) => {
       console.log("error", err)
     });
   }
 
   const purchaseProduct = (product: PurchasesStoreProduct) => {
-    Purchases.purchaseProduct(
-      product.identifier,
-      null,
-      PURCHASE_TYPE.SUBS,
-      null,
-      product.presentedOfferingIdentifier,
-      ).then((result) => {
+    Purchases.purchaseStoreProduct(product,).then(() => {
     }).catch((err) => {
       console.log("error", err)
     });
   }
 
   const purchaseSubscriptionOption = (option: SubscriptionOption) => {
-    Purchases.purchaseSubscriptionOption(option).then((result) => {
+    Purchases.purchaseSubscriptionOption(option).then(() => {
     }).catch((err) => {
       console.log("error", err)
     });
@@ -93,6 +86,20 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
               })}>
               <Text>
                 Present paywall if needed "pro_cat"
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={() => navigation.navigate('Paywall', { offering: route.params.offering })}>
+              <Text>
+                Show paywall
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={() => navigation.navigate('FooterPaywall', { offering: route.params.offering })}>
+              <Text>
+                Show paywall as footer
               </Text>
             </TouchableOpacity>
           </View>

--- a/examples/purchaseTesterTypescript/app/screens/PaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/PaywallScreen.tsx
@@ -1,22 +1,24 @@
 import React from 'react';
 import RevenueCatUI from 'react-native-purchases-ui';
 
-import {StyleSheet, View} from 'react-native';
-import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import { StyleSheet, View } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Paywall'>;
 
-const PaywallScreen: React.FC<Props> = () => {
+const PaywallScreen: React.FC<Props> = ({ route }: Props) => {
   const styles = StyleSheet.create({
     flex1: {
       flex: 1,
     },
   });
-
   return (
     <View style={styles.flex1}>
-      <RevenueCatUI.Paywall/>
+      <RevenueCatUI.Paywall
+        options={{
+          offering: route.params.offering,
+        }}/>
     </View>
   );
 };

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -1,0 +1,25 @@
+package com.revenuecat.purchases.react.ui
+
+import android.view.View
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.annotations.ReactProp
+
+internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>() {
+
+    abstract fun setOfferingId(view: T, identifier: String)
+
+    @ReactProp(name = "options")
+    fun setOptions(view: T, options: ReadableMap?) {
+        options?.let { props ->
+            if (props.hasKey("offering")) {
+                props.getDynamic("offering").asMap()?.let { offeringMap ->
+                    if (offeringMap.hasKey("identifier") && !offeringMap.isNull("identifier")) {
+                        setOfferingId(view, offeringMap.getString("identifier")!!)
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -2,9 +2,11 @@ package com.revenuecat.purchases.react.ui
 
 import android.annotation.SuppressLint
 import androidx.core.view.children
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
+import com.facebook.react.uimanager.annotations.ReactProp
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
 
@@ -59,6 +61,20 @@ internal class PaywallFooterViewManager : SimpleViewManager<PaywallFooterView>()
         }
 
         return paywallFooterView
+    }
+
+    @ReactProp(name = "options")
+    fun setOptions(view: PaywallFooterView, options: ReadableMap?) {
+        options?.let { props ->
+            if (props.hasKey("offering")) {
+                props.getDynamic("offering").asMap()?.let { offeringMap ->
+                    if (offeringMap.hasKey("identifier")) {
+                        view.setOfferingId(offeringMap.getString("identifier"))
+                    }
+                }
+
+            }
+        }
     }
 
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -11,7 +11,8 @@ import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIP
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
-internal class PaywallFooterViewManager : SimpleViewManager<PaywallFooterView>() {
+internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterView>() {
+
     override fun getName(): String {
         return "RCPaywallFooterView"
     }
@@ -63,18 +64,8 @@ internal class PaywallFooterViewManager : SimpleViewManager<PaywallFooterView>()
         return paywallFooterView
     }
 
-    @ReactProp(name = "options")
-    fun setOptions(view: PaywallFooterView, options: ReadableMap?) {
-        options?.let { props ->
-            if (props.hasKey("offering")) {
-                props.getDynamic("offering").asMap()?.let { offeringMap ->
-                    if (offeringMap.hasKey("identifier")) {
-                        view.setOfferingId(offeringMap.getString("identifier"))
-                    }
-                }
-
-            }
-        }
+    override fun setOfferingId(view: PaywallFooterView, identifier: String) {
+        view.setOfferingId(identifier)
     }
 
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -8,7 +8,8 @@ import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIP
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
-internal class PaywallViewManager : SimpleViewManager<PaywallView>() {
+internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
+
     companion object {
         const val REACT_CLASS = "Paywall"
     }
@@ -25,17 +26,8 @@ internal class PaywallViewManager : SimpleViewManager<PaywallView>() {
         return PaywallViewShadowNode()
     }
 
-    @ReactProp(name = "options")
-    fun setOptions(view: PaywallView, options: ReadableMap?) {
-        options?.let { props ->
-            if (props.hasKey("offering")) {
-                props.getDynamic("offering").asMap()?.let { offeringMap ->
-                    if (offeringMap.hasKey("identifier")) {
-                        view.setOfferingId(offeringMap.getString("identifier"))
-                    }
-                }
-
-            }
-        }
+    override fun setOfferingId(view: PaywallView, identifier: String) {
+        view.setOfferingId(identifier)
     }
+
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -1,7 +1,9 @@
 package com.revenuecat.purchases.react.ui
 
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 
@@ -21,5 +23,19 @@ internal class PaywallViewManager : SimpleViewManager<PaywallView>() {
 
     override fun createShadowNodeInstance(): PaywallViewShadowNode {
         return PaywallViewShadowNode()
+    }
+
+    @ReactProp(name = "options")
+    fun setOptions(view: PaywallView, options: ReadableMap?) {
+        options?.let { props ->
+            if (props.hasKey("offering")) {
+                props.getDynamic("offering").asMap()?.let { offeringMap ->
+                    if (offeringMap.hasKey("identifier")) {
+                        view.setOfferingId(offeringMap.getString("identifier"))
+                    }
+                }
+
+            }
+        }
     }
 }

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -14,6 +14,8 @@
 
 @implementation PaywallViewManager
 
+RCT_EXPORT_VIEW_PROPERTY(options, NSDictionary);
+
 RCT_EXPORT_MODULE(Paywall)
 
 - (UIView *)view

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -12,9 +12,10 @@
 @import PurchasesHybridCommonUI;
 @import RevenueCatUI;
 
+API_AVAILABLE(ios(15.0))
 @interface PaywallViewWrapper () <RCPaywallViewControllerDelegate>
 
-@property (strong, nonatomic) UIViewController *paywallViewController;
+@property (strong, nonatomic) RCPaywallViewController *paywallViewController;
 
 @property (nonatomic) BOOL addedToHierarchy;
 
@@ -22,7 +23,7 @@
 
 @implementation PaywallViewWrapper
 
-- (instancetype)initWithPaywallViewController:(UIViewController *)paywallViewController {
+- (instancetype)initWithPaywallViewController:(RCPaywallViewController *)paywallViewController API_AVAILABLE(ios(15.0)){
     NSParameterAssert(paywallViewController);
 
     if ((self = [super initWithFrame:paywallViewController.view.bounds])) {
@@ -64,7 +65,7 @@
         if (offering && ![offering isKindOfClass:[NSNull class]]) {
             NSString *identifier = offering[@"identifier"];
             if (identifier) {
-                [(RCPaywallViewController *)self.paywallViewController updateWithOfferingIdentifier:identifier];
+                [self.paywallViewController updateWithOfferingIdentifier:identifier];
             }
         }
     } else {

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -58,4 +58,18 @@
     }
 }
 
+- (void)setOptions:(NSDictionary *)options {
+    if (@available(iOS 15.0, *)) {
+        NSDictionary *offering = options[@"offering"];
+        if (offering && ![offering isKindOfClass:[NSNull class]]) {
+            NSString *identifier = offering[@"identifier"];
+            if (identifier) {
+                [(RCPaywallViewController *)self.paywallViewController updateWithOfferingIdentifier:identifier];
+            }
+        }
+    } else {
+        NSLog(@"Error: attempted to present paywalls on unsupported iOS version.");
+    }
+}
+
 @end

--- a/react-native-purchases-ui/ios/RCPaywallFooterViewManager.m
+++ b/react-native-purchases-ui/ios/RCPaywallFooterViewManager.m
@@ -24,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FooterViewWrapper: PaywallViewWrapper
 
-- (instancetype)initWithFooterViewController:(UIViewController *)footerViewController 
-                                      bridge:(RCTBridge *)bridge;
+- (instancetype)initWithPaywallViewController:(UIViewController *)footerViewController
+                                       bridge:(RCTBridge *)bridge;
 
 @end
 
@@ -35,13 +35,11 @@ NS_ASSUME_NONNULL_END
 
 @property (strong, nonatomic) RCTBridge *bridge;
 
-@property BOOL addedToHierarchy;
-
 @end
 
 @implementation FooterViewWrapper
 
-- (instancetype)initWithFooterViewController:(UIViewController *)footerViewController bridge:(RCTBridge *)bridge {
+- (instancetype)initWithPaywallViewController:(UIViewController *)footerViewController bridge:(RCTBridge *)bridge {
     if ((self = [super initWithPaywallViewController:footerViewController])) {
         _bridge = bridge;
     }
@@ -81,6 +79,8 @@ NS_ASSUME_NONNULL_END
 
 @implementation RCPaywallFooterViewManager
 
+RCT_EXPORT_VIEW_PROPERTY(options, NSDictionary);
+
 RCT_EXPORT_MODULE(RCPaywallFooterView)
 
 - (instancetype)init {
@@ -101,8 +101,8 @@ RCT_EXPORT_MODULE(RCPaywallFooterView)
 {
     if (@available(iOS 15.0, *)) {
         UIViewController *footerViewController = [self.proxy createFooterPaywallView];
-        FooterViewWrapper *wrapper = [[FooterViewWrapper alloc] initWithFooterViewController:footerViewController
-                                                                                      bridge:self.bridge];
+        FooterViewWrapper *wrapper = [[FooterViewWrapper alloc] initWithPaywallViewController:footerViewController 
+                                                                                       bridge:self.bridge];
         self.proxy.delegate = wrapper;
 
         return wrapper;

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -24,20 +24,15 @@ const RNPaywalls = NativeModules.RNPaywalls;
 
 const eventEmitter = new NativeEventEmitter(RNPaywalls);
 
-type PaywallViewProps = {
-  style?: StyleProp<ViewStyle>;
-  children?: ReactNode;
-};
-
 const InternalPaywall =
   UIManager.getViewManagerConfig('Paywall') != null
-    ? requireNativeComponent<PaywallViewProps>('Paywall')
+    ? requireNativeComponent<FullScreenPaywallViewProps>('Paywall')
     : () => {
       throw new Error(LINKING_ERROR);
     };
 
 const InternalPaywallFooterView = UIManager.getViewManagerConfig('Paywall') != null
-  ? requireNativeComponent<PaywallViewProps>('RCPaywallFooterView')
+  ? requireNativeComponent<FooterPaywallViewProps>('RCPaywallFooterView')
   : () => {
     throw new Error(LINKING_ERROR);
   };
@@ -60,6 +55,31 @@ export type PresentPaywallIfNeededParams = PresentPaywallParams & {
    */
   requiredEntitlementIdentifier: string;
 }
+
+export interface PaywallViewOptions {
+  offering?: PurchasesOffering | null;
+}
+
+export interface FullScreenPaywallViewOptions extends PaywallViewOptions {
+  // Additional properties for FullScreenPaywallViewOptions can be added here if needed in the future
+}
+
+// Currently the same as the base type, but can be extended later if needed
+export interface FooterPaywallViewOptions extends PaywallViewOptions {
+  // Additional properties for FooterPaywallViewOptions can be added here if needed in the future
+}
+
+type FullScreenPaywallViewProps = {
+  style?: StyleProp<ViewStyle>;
+  children?: ReactNode;
+  options?: FullScreenPaywallViewOptions;
+};
+
+type FooterPaywallViewProps = {
+  style?: StyleProp<ViewStyle>;
+  children?: ReactNode;
+  options?: FooterPaywallViewOptions;
+};
 
 export default class RevenueCatUI {
 
@@ -112,11 +132,11 @@ export default class RevenueCatUI {
     return RNPaywalls.presentPaywallIfNeeded(requiredEntitlementIdentifier, offering?.identifier ?? null, displayCloseButton)
   }
 
-  public static Paywall: React.FC<PaywallViewProps> = (props) => (
+  public static Paywall: React.FC<FullScreenPaywallViewProps> = (props) => (
     <InternalPaywall {...props} style={[{flex: 1}, props.style]}/>
   );
 
-  public static PaywallFooterContainerView: React.FC<PaywallViewProps> = ({style, children}) => {
+  public static PaywallFooterContainerView: React.FC<FooterPaywallViewProps> = ({style, children, options}) => {
     // We use 20 as the default paddingBottom because that's the corner radius in the Android native SDK.
     // We also listen to safeAreaInsetsDidChange which is only sent from iOS and which is triggered when the
     // safe area insets change. Not adding this extra padding on iOS will cause the content of the scrollview
@@ -148,7 +168,7 @@ export default class RevenueCatUI {
           {children}
         </ScrollView>
         {/*Adding negative margin to the footer view to make it overlap with the extra padding of the scroll*/}
-        <InternalPaywallFooterView style={{marginTop: -20}}/>
+        <InternalPaywallFooterView style={{marginTop: -20}} options={options}/>
       </View>
     );
   };


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/3592/

Add an `options` prop to pass an Offering to the Paywall and Footer Paywall view