### PR TITLE
`PaywallViewManager`: added controller to UIVC hierarchy

### DIFF
--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -7,52 +7,9 @@
 //
 
 #import "PaywallViewManager.h"
-#import "UIView+Extensions.h"
+#import "PaywallViewWrapper.h"
+
 @import PurchasesHybridCommon;
-
-@interface PaywallView : UIView
-
-@property (strong, nonatomic) UIViewController *paywallViewController;
-@property  BOOL addedToHierarchy;
-
-@end
-
-@implementation PaywallView
-
-- (instancetype)initWithPaywallViewController:(UIViewController *)paywallViewController
-                                    innerView:(UIView *)innerView {
-    if ((self = [super initWithFrame:innerView.bounds])) {
-        _paywallViewController = paywallViewController;
-        [self addSubview:innerView];
-        _addedToHierarchy = NO;
-    }
-    return self;
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-
-    if (!self.addedToHierarchy) {
-        UIViewController *parentController = self.parentViewController;
-        if (parentController) {
-            self.paywallViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
-            [parentController addChildViewController:self.paywallViewController];
-            [self addSubview:self.paywallViewController.view];
-            [self.paywallViewController didMoveToParentViewController:parentController];
-
-            [NSLayoutConstraint activateConstraints:@[
-                [self.paywallViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
-                [self.paywallViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-                [self.paywallViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
-                [self.paywallViewController.view.rightAnchor constraintEqualToAnchor:self.rightAnchor]
-            ]];
-
-            self.addedToHierarchy = YES;
-        }
-    }
-}
-
-@end
 
 @implementation PaywallViewManager
 
@@ -62,12 +19,8 @@ RCT_EXPORT_MODULE(Paywall)
 {
     if (@available(iOS 15.0, *)) {
         PaywallProxy *proxy = [[PaywallProxy alloc] init];
-        UIViewController *viewController = [proxy createPaywallView];
-        UIView *innerView = viewController.view;
 
-        PaywallView *paywallView = [[PaywallView alloc] initWithPaywallViewController:viewController
-                                                                            innerView:innerView];
-        return paywallView;
+        return [[PaywallViewWrapper alloc] initWithPaywallViewController:[proxy createPaywallView]];
     } else {
         NSLog(@"Error: attempted to present paywalls on unsupported iOS version.");
         return nil;

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -10,7 +10,6 @@
 #import "PaywallViewWrapper.h"
 
 @import PurchasesHybridCommonUI;
-@import PurchasesHybridCommon;
 @import RevenueCatUI;
 
 @implementation PaywallViewManager

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -7,7 +7,52 @@
 //
 
 #import "PaywallViewManager.h"
+#import "UIView+Extensions.h"
 @import PurchasesHybridCommon;
+
+@interface PaywallView : UIView
+
+@property (strong, nonatomic) UIViewController *paywallViewController;
+@property  BOOL addedToHierarchy;
+
+@end
+
+@implementation PaywallView
+
+- (instancetype)initWithPaywallViewController:(UIViewController *)paywallViewController
+                                    innerView:(UIView *)innerView {
+    if ((self = [super initWithFrame:innerView.bounds])) {
+        _paywallViewController = paywallViewController;
+        [self addSubview:innerView];
+        _addedToHierarchy = NO;
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    if (!self.addedToHierarchy) {
+        UIViewController *parentController = self.parentViewController;
+        if (parentController) {
+            self.paywallViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+            [parentController addChildViewController:self.paywallViewController];
+            [self addSubview:self.paywallViewController.view];
+            [self.paywallViewController didMoveToParentViewController:parentController];
+
+            [NSLayoutConstraint activateConstraints:@[
+                [self.paywallViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
+                [self.paywallViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+                [self.paywallViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
+                [self.paywallViewController.view.rightAnchor constraintEqualToAnchor:self.rightAnchor]
+            ]];
+
+            self.addedToHierarchy = YES;
+        }
+    }
+}
+
+@end
 
 @implementation PaywallViewManager
 
@@ -17,7 +62,12 @@ RCT_EXPORT_MODULE(Paywall)
 {
     if (@available(iOS 15.0, *)) {
         PaywallProxy *proxy = [[PaywallProxy alloc] init];
-        return [proxy createPaywallView].view;
+        UIViewController *viewController = [proxy createPaywallView];
+        UIView *innerView = viewController.view;
+
+        PaywallView *paywallView = [[PaywallView alloc] initWithPaywallViewController:viewController
+                                                                            innerView:innerView];
+        return paywallView;
     } else {
         NSLog(@"Error: attempted to present paywalls on unsupported iOS version.");
         return nil;

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.h
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.h
@@ -1,0 +1,21 @@
+//
+//  PaywallViewWrapper.h
+//  RNPaywalls
+//
+//  Created by Nacho Soto on 1/23/24.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PaywallViewWrapper : UIView
+
+- (instancetype)initWithCoder:(NSCoder *)coder NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+
+- (instancetype)initWithPaywallViewController:(UIViewController *)paywallViewController NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -1,0 +1,61 @@
+//
+//  PaywallViewWrapper.m
+//  RNPaywalls
+//
+//  Created by Nacho Soto on 1/23/24.
+//
+
+#import "PaywallViewWrapper.h"
+
+#import "UIView+Extensions.h"
+
+@import PurchasesHybridCommon;
+@import RevenueCatUI;
+
+@interface PaywallViewWrapper () <RCPaywallViewControllerDelegate>
+
+@property (strong, nonatomic) UIViewController *paywallViewController;
+
+@property (nonatomic) BOOL addedToHierarchy;
+
+@end
+
+@implementation PaywallViewWrapper
+
+- (instancetype)initWithPaywallViewController:(UIViewController *)paywallViewController {
+    NSParameterAssert(paywallViewController);
+
+    if ((self = [super initWithFrame:paywallViewController.view.bounds])) {
+        _paywallViewController = paywallViewController;
+    }
+
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+
+    // Need to wait for this view to be in the hierarchy to look for the parent UIVC.
+    // This is required to add a SwiftUI `UIHostingController` to the hierarchy in a way that allows
+    // UIKit to read properties from the environment, like traits and safe area.
+    if (!self.addedToHierarchy) {
+        UIViewController *parentController = self.parentViewController;
+        if (parentController) {
+            self.paywallViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+            [parentController addChildViewController:self.paywallViewController];
+            [self addSubview:self.paywallViewController.view];
+            [self.paywallViewController didMoveToParentViewController:parentController];
+
+            [NSLayoutConstraint activateConstraints:@[
+                [self.paywallViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
+                [self.paywallViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+                [self.paywallViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
+                [self.paywallViewController.view.rightAnchor constraintEqualToAnchor:self.rightAnchor]
+            ]];
+
+            self.addedToHierarchy = YES;
+        }
+    }
+}
+
+@end

--- a/react-native-purchases-ui/ios/RCPaywallFooterViewManager.m
+++ b/react-native-purchases-ui/ios/RCPaywallFooterViewManager.m
@@ -11,7 +11,7 @@
 @import RevenueCatUI;
 @import PurchasesHybridCommon;
 
-#import "UIView+Extensions.h"
+#import "PaywallViewWrapper.h"
 
 #import <React/RCTShadowView.h>
 #import <React/RCTUIManager.h>
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FooterViewWrapper : UIView
+@interface FooterViewWrapper: PaywallViewWrapper
 
 - (instancetype)initWithFooterViewController:(UIViewController *)footerViewController 
                                       bridge:(RCTBridge *)bridge;
@@ -33,7 +33,6 @@ NS_ASSUME_NONNULL_END
 
 @interface FooterViewWrapper () <RCPaywallViewControllerDelegate>
 
-@property (strong, nonatomic) UIViewController *footerViewController;
 @property (strong, nonatomic) RCTBridge *bridge;
 
 @property BOOL addedToHierarchy;
@@ -43,9 +42,8 @@ NS_ASSUME_NONNULL_END
 @implementation FooterViewWrapper
 
 - (instancetype)initWithFooterViewController:(UIViewController *)footerViewController bridge:(RCTBridge *)bridge {
-    if ((self = [super initWithFrame:footerViewController.view.bounds])) {
+    if ((self = [super initWithPaywallViewController:footerViewController])) {
         _bridge = bridge;
-        _footerViewController = footerViewController;
     }
 
     return self;
@@ -71,32 +69,6 @@ NS_ASSUME_NONNULL_END
 
 - (void)paywallViewController:(RCPaywallViewController *)controller didChangeSizeTo:(CGSize)size API_AVAILABLE(ios(15.0)){
     [_bridge.uiManager setSize:size forView:self];
-}
-
-- (void)layoutSubviews {
-    [super layoutSubviews];
-
-    // Need to wait for this view to be in the hierarchy to look for the parent UIVC.
-    // This is required to add a SwiftUI `UIHostingController` to the hierarchy in a way that allows
-    // UIKit to read properties from the environment, like traits and safe area.
-    if (!self.addedToHierarchy) {
-        UIViewController *parentController = self.parentViewController;
-        if (parentController) {
-            self.footerViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
-            [parentController addChildViewController:self.footerViewController];
-            [self addSubview:self.footerViewController.view];
-            [self.footerViewController didMoveToParentViewController:parentController];
-
-            [NSLayoutConstraint activateConstraints:@[
-                [self.footerViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
-                [self.footerViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-                [self.footerViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
-                [self.footerViewController.view.rightAnchor constraintEqualToAnchor:self.rightAnchor]
-            ]];
-
-            self.addedToHierarchy = YES;
-        }
-    }
 }
 
 @end

--- a/react-native-purchases-ui/ios/UIView+Extensions.h
+++ b/react-native-purchases-ui/ios/UIView+Extensions.h
@@ -10,6 +10,6 @@
 
 @interface UIView (ParentViewController)
 
-- (UIViewController *)parentViewController;
+@property (nonatomic, readonly) UIViewController *_Nullable parentViewController;
 
 @end

--- a/react-native-purchases-ui/ios/UIView+Extensions.m
+++ b/react-native-purchases-ui/ios/UIView+Extensions.m
@@ -9,7 +9,7 @@
 
 @implementation UIView (ParentViewController)
 
-- (UIViewController *)parentViewController {
+- (UIViewController * _Nullable)parentViewController {
     UIResponder *responder = self;
     while (responder) {
         responder = responder.nextResponder;


### PR DESCRIPTION
This will only be needed if we update `createPaywallView` to return a `PaywallViewController`

```
    @objc
    public func createPaywallView() -> UIViewController {
        let controller = PaywallViewController()
        controller.delegate = self
        return controller
    }
```    

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/RevenueCat/react-native-purchases/assets/664544/ef0e7622-6e94-4d2b-ad74-31dcf0ae799a" alt="Before" width="303">
    </td>
    <td>
      <img src="https://github.com/RevenueCat/react-native-purchases/assets/664544/d2fc3d50-5757-4085-b417-2147c525eb50" alt="After" width="303">
    </td>
  </tr>
</table>
