### PR TITLE
Fix `update-hybrid-common-versions`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
   update-hybrid-common-versions:
     description: "Creates a PR updating purchases-hybrid-common to latest release"
     docker:
-      - image: cimg/ruby:3.1.2
+      - image: cimg/ruby:3.3.0-node
     steps:
       - checkout
       - revenuecat/install-gem-unix-dependencies:


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/2997/workflows/4b7f7128-c95d-46fe-847a-4011d6980d38/jobs/11357

`yarn` wasn't available on the previous image.
