### PR TITLE
`purchasePackage`: add `StoreTransaction` in `MakePurchaseResult`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -198,7 +198,8 @@ describe("Purchases", () => {
   it("purchaseProduct with immediate_and_change_full_price proration mode sends the correct proration mode", async () => {
     NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
       purchasedProductIdentifier: "123",
-      customerInfo: customerInfoStub
+      customerInfo: customerInfoStub,
+      transaction: transactionStub
     });
 
     await Purchases.purchasePackage(
@@ -230,7 +231,8 @@ describe("Purchases", () => {
   it("purchaseStoreProduct works", async () => {
     NativeModules.RNPurchases.purchaseProduct.mockResolvedValue({
       purchasedProductIdentifier: "123",
-      customerInfo: customerInfoStub
+      customerInfo: customerInfoStub,
+      transaction: transactionStub
     });
 
     const aProduct = {
@@ -247,7 +249,9 @@ describe("Purchases", () => {
   it("purchasePackage works", async () => {
     NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
       purchasedProductIdentifier: "123",
-      customerInfo: customerInfoStub
+      customerInfo: customerInfoStub,
+      transaction: transactionStub,
+      transaction: transactionStub
     });
 
     await Purchases.purchasePackage(
@@ -326,7 +330,8 @@ describe("Purchases", () => {
     Platform.OS = "android";
     NativeModules.RNPurchases.purchaseSubscriptionOption.mockResolvedValue({
       purchasedProductIdentifier: "123",
-      customerInfo: customerInfoStub
+      customerInfo: customerInfoStub,
+      transaction: transactionStub
     });
 
     const billingPeriod = {

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -64,7 +64,7 @@ global.customerInfoStub = {
 global.transactionStub = {
     productIdentifier: "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
     transactionIdentifier: "1",
-    purchaseDateMilis: 1000
+    purchaseDate: "2024-01-29T18:43:21.000Z"
 };
 
 global.offeringsStub = {

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -61,6 +61,11 @@ global.customerInfoStub = {
   requestDate: "2019-12-03T00:47:58.000Z",
   managementURL: "https://url.com"
 };
+global.transactionStub = {
+    productIdentifier: "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",
+    transactionIdentifier: "1",
+    purchaseDateMilis: 1000
+};
 
 global.offeringsStub = {
   current: {


### PR DESCRIPTION
See https://github.com/RevenueCat/purchases-hybrid-common/pull/685, https://github.com/RevenueCat/purchases-hybrid-common/pull/686, and https://github.com/RevenueCat/purchases-hybrid-common/pull/690.

The main changes were in those PRs. This just updates the stub data to reflect that.

Fixes #659
