### PR TITLE
Remove 'new NativeEventEmitter() was called with a non-null argument'

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
@@ -6,7 +6,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReadableMap
 import com.revenuecat.purchases.hybridcommon.ui.PaywallResultListener
 import com.revenuecat.purchases.hybridcommon.ui.PaywallSource
 import com.revenuecat.purchases.hybridcommon.ui.PresentPaywallOptions
@@ -60,6 +59,16 @@ internal class RNPaywallsModule(reactContext: ReactApplicationContext) :
             displayCloseButton,
             promise
         )
+    }
+
+    @ReactMethod
+    fun addListener(eventName: String?) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int?) {
+        // Keep: Required for RN built in Event Emitter Calls.
     }
 
     private fun presentPaywall(


### PR DESCRIPTION
We have the same empty functions in `RNPurchasesModule.java` to prevent the warning https://github.com/RevenueCat/react-native-purchases/blob/138d2bf05a0c0770f195ef73dd21f060718fed31/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java#L73


<img width="307" alt="Screenshot 2024-01-30 at 15 30 42" src="https://github.com/RevenueCat/react-native-purchases/assets/664544/8fdfbbb9-0382-4291-bf71-2b969899f6b1">
