### PR TITLE
Throw error if null module

### DIFF
--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -15,12 +15,16 @@ import React, { type ReactNode, useEffect, useState } from "react";
 export { PAYWALL_RESULT } from "@revenuecat/purchases-typescript-internal";
 
 const LINKING_ERROR =
-  `The package 'react-native-purchases-view' doesn't seem to be linked. Make sure: \n\n` +
+  `The package 'react-native-purchases-ui' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ios: "- You have run 'pod install'\n", default: ''}) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
 const RNPaywalls = NativeModules.RNPaywalls;
+
+if (!RNPaywalls) {
+  throw new Error(LINKING_ERROR);
+}
 
 const eventEmitter = new NativeEventEmitter(RNPaywalls);
 


### PR DESCRIPTION
Trying to add a more meaningful error message if RNPaywalls is null. Related to #857 