### PR TITLE
[EXTERNAL] Adding fontFamily from RN to CustomFontProvider in PaywallView (contributed by @Jjastiny)

### DIFF
--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -61,10 +61,12 @@ function checkPresentPaywallIfNeededParams(params: PresentPaywallParams) {
 
 function checkFullScreenPaywallViewOptions(options: FullScreenPaywallViewOptions) {
   const offering: PurchasesOffering | undefined | null = options.offering;
+  const fontFamily: string | undefined | null = options.fontFamily;
 }
 
 function checkFooterPaywallViewOptions(options: FooterPaywallViewOptions) {
   const offering: PurchasesOffering | undefined | null = options.offering;
+  const fontFamily: string | undefined | null = options.fontFamily;
 }
 
 
@@ -105,12 +107,21 @@ const PaywallScreenWithOffering = (offering: PurchasesOffering) => {
   );
 };
 
-const PaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering) => {
+const PaywallScreenWithFontFamily = (fontFamily: string | undefined | null) => {
+  return (
+    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
+      fontFamily: fontFamily
+    }}/>
+  );
+};
+
+const PaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, fontFamily: string | undefined | null) => {
   return (
     <RevenueCatUI.Paywall
       style={{marginBottom: 10}}
       options={{
-        offering: offering
+        offering: offering,
+        fontFamily: fontFamily,
       }}
       onPurchaseCompleted={onPurchaseCompleted}
       onPurchaseError={onPurchaseError}
@@ -145,11 +156,22 @@ const FooterPaywallScreenWithOffering = (offering: PurchasesOffering) => {
   );
 };
 
-const FooterPaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering) => {
+const FooterPaywallScreenWithFontFamily = (fontFamily: string | null | undefined) => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView options={{
+      fontFamily: fontFamily,
+    }}>
+    </RevenueCatUI.PaywallFooterContainerView>
+  );
+};
+
+
+const FooterPaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, fontFamily: string | undefined | null) => {
   return (
     <RevenueCatUI.PaywallFooterContainerView
       options={{
         offering: offering,
+        fontFamily: fontFamily,
       }}
       onPurchaseCompleted={onPurchaseCompleted}
       onPurchaseError={onPurchaseError}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -16,9 +16,9 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
 
     companion object PropNames {
         private const val PROP_OPTIONS = "options"
-        private const val OFFERING = "offering"
-        private const val IDENTIFIER = "identifier"
-        private const val FONT_FAMILY = "fontFamily"
+        private const val OPTION_OFFERING = "offering"
+        private const val OFFERING_IDENTIFIER = "identifier"
+        private const val OPTION_FONT_FAMILY = "fontFamily"
     }
 
     abstract fun setOfferingId(view: T, identifier: String)
@@ -46,7 +46,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
     }
 
     private fun setOfferingIdProp(view: T, props: ReadableMap?) {
-        val offeringIdentifier = props?.getDynamic(OFFERING)?.asMap()?.getString(IDENTIFIER)
+        val offeringIdentifier = props?.getDynamic(OPTION_OFFERING)?.asMap()?.getString(OFFERING_IDENTIFIER)
         offeringIdentifier?.let {
             setOfferingId(view, it)
         }
@@ -54,7 +54,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
 
     @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
     private fun setFontFamilyProp(view: T, props: ReadableMap?) {
-        props?.getString(FONT_FAMILY)?.let {
+        props?.getString(OPTION_FONT_FAMILY)?.let {
             FontAssetManager.getFontFamily(fontFamilyName = it, view.resources.assets)?.let {
                 setFontFamily(view, CustomFontProvider(it))
             }
@@ -160,4 +160,3 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         )
     }
 }
-

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/FontAssetManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/FontAssetManager.kt
@@ -1,0 +1,59 @@
+package com.revenuecat.purchases.react.ui
+
+import android.content.res.AssetManager
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+
+
+object FontAssetManager {
+    private val fontFamilyHashMap: MutableMap<String, FontFamily> = hashMapOf()
+    private val FILE_EXTENSIONS = arrayOf(".ttf", ".otf")
+
+    private const val FONT_PATH = "fonts/"
+
+    private enum class FontStyleExtension(
+        val extension: String,
+        val weight: FontWeight,
+        val style: FontStyle
+    ) {
+        REGULAR("", FontWeight.Normal, FontStyle.Normal),
+        BOLD("_bold", FontWeight.Bold, FontStyle.Normal),
+        ITALIC("_italic", FontWeight.Normal, FontStyle.Italic),
+        BOLD_ITALIC("_bold_italic", FontWeight.Bold, FontStyle.Italic);
+    }
+
+    fun getFontFamily(fontFamilyName: String, assetManager: AssetManager): FontFamily? {
+        val cachedFontFamily = fontFamilyHashMap[fontFamilyName]
+        if (cachedFontFamily != null) {
+            return cachedFontFamily
+        }
+
+        val fontList = mutableListOf<Font>()
+        FontStyleExtension.values().forEach { styleExtension ->
+            FILE_EXTENSIONS.forEach { fileNameExtension ->
+                val fileName = "$fontFamilyName${styleExtension.extension}$fileNameExtension"
+                val mapList = assetManager.list(FONT_PATH)?.toList() ?: emptyList()
+                if (mapList.contains(fileName)) {
+                    fontList.add(
+                        Font(
+                            path = FONT_PATH + fileName,
+                            assetManager = assetManager,
+                            weight = styleExtension.weight,
+                            style = styleExtension.style
+                        )
+                    )
+                }
+            }
+        }
+
+        return if (fontList.isNotEmpty()) {
+            val fontFamily = FontFamily(fontList)
+            fontFamilyHashMap[fontFamilyName] = fontFamily
+            fontFamily
+        } else {
+            null
+        }
+    }
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -3,10 +3,9 @@ package com.revenuecat.purchases.react.ui
 import androidx.core.view.children
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
-import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallFooterView
-
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterView>() {
@@ -66,4 +65,7 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterVi
         view.setOfferingId(identifier)
     }
 
+    override fun setFontFamily(view: PaywallFooterView, customFontProvider: CustomFontProvider) {
+        view.setFontProvider(customFontProvider)
+    }
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -1,8 +1,8 @@
 package com.revenuecat.purchases.react.ui
 
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
+import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
@@ -31,4 +31,7 @@ internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
         view.setOfferingId(identifier)
     }
 
+    override fun setFontFamily(view: PaywallView, customFontProvider: CustomFontProvider) {
+        view.setFontProvider(customFontProvider)
+    }
 }

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -70,6 +70,11 @@ API_AVAILABLE(ios(15.0))
                 [self.paywallViewController updateWithOfferingIdentifier:identifier];
             }
         }
+        
+        NSString *fontFamily = options[@"fontFamily"];
+        if (fontFamily && [fontFamily isKindOfClass:[NSString class]] && fontFamily.length > 0) {
+            [self.paywallViewController updateFontWithFontName:fontFamily];
+        }
     } else {
         NSLog(@"Error: attempted to present paywalls on unsupported iOS version.");
     }

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -66,8 +66,22 @@ export type PresentPaywallIfNeededParams = PresentPaywallParams & {
 }
 
 export interface PaywallViewOptions {
+  /**
+   * The offering to load the paywall with. This will be the "current" offering by default.
+   */
   offering?: PurchasesOffering | null;
-  fontFamily?: String | null;
+
+  /**
+   * The fontFamily name to use in the Paywall. In order to add a font family, add it in the react native app and make
+   * sure to run `npx react-native-asset` so it's added to the native components.
+   * Supported font types are `.ttf` and `.otf`.
+   * Make sure the file names follow the convention:
+   * - Regular: MyFont.ttf/MyFont.otf
+   * - Bold: MyFont_bold.ttf/MyFont_bold.otf
+   * - Italic: MyFont_italic.ttf/MyFont_italic.otf
+   * - Bold and Italic: MyFont_bold_italic.ttf/MyFont_bold_italic.otf
+   */
+  fontFamily?: string | null;
 }
 
 export interface FullScreenPaywallViewOptions extends PaywallViewOptions {

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -67,6 +67,7 @@ export type PresentPaywallIfNeededParams = PresentPaywallParams & {
 
 export interface PaywallViewOptions {
   offering?: PurchasesOffering | null;
+  fontFamily?: String | null;
 }
 
 export interface FullScreenPaywallViewOptions extends PaywallViewOptions {


### PR DESCRIPTION
Thank you for contributing to react-native-purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.

This PR adds a fontFamily string in PaywallOptions Prop, which enables the developers to change the font for the paywall to their custom font.
```typescript
export interface PaywallViewOptions {
  offering?: PurchasesOffering | null;
  fontFamily?: String | null; // New
}
```

This is the RN native module update for following PR's https://github.com/RevenueCat/purchases-ios/pull/3628 AND https://github.com/RevenueCat/purchases-android/pull/1589
