### PR TITLE
Add some logs on sizing of the PaywallViewWrapper

### DIFF
--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -40,7 +40,7 @@ API_AVAILABLE(ios(15.0))
 
 - (void)reactSetFrame:(CGRect)frame
 {
-    NSLog(@"reactSetFrame: %@", NSStringFromCGRect(frame));
+    NSLog(@"RNPaywalls - reactSetFrame: %@", NSStringFromCGRect(frame));
 
     [super reactSetFrame: frame];
 }
@@ -49,7 +49,7 @@ API_AVAILABLE(ios(15.0))
     [super layoutSubviews];
 
     CGSize size = self.bounds.size;
-    NSLog(@"Size on layoutSubviews: %@", NSStringFromCGSize(size));
+    NSLog(@"RNPaywalls - Size on layoutSubviews: %@", NSStringFromCGSize(size));
 
     // Need to wait for this view to be in the hierarchy to look for the parent UIVC.
     // This is required to add a SwiftUI `UIHostingController` to the hierarchy in a way that allows
@@ -62,7 +62,7 @@ API_AVAILABLE(ios(15.0))
             [self addSubview:self.paywallViewController.view];
             [self.paywallViewController didMoveToParentViewController:parentController];
 
-            NSLog(@"Activating constraints");
+            NSLog(@"RNPaywalls - Activating constraints");
             [NSLayoutConstraint activateConstraints:@[
                 [self.paywallViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
                 [self.paywallViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
@@ -144,7 +144,7 @@ didFailRestoringWithErrorDictionary:(NSDictionary *)errorDictionary API_AVAILABL
 }
 
 - (void)paywallViewController:(RCPaywallViewController *)controller didChangeSizeTo:(CGSize)size API_AVAILABLE(ios(15.0)) {
-    NSLog(@"Paywall view wrapper did change size to: %@", NSStringFromCGSize(size));
+    NSLog(@"RNPaywalls - Paywall view wrapper did change size to: %@", NSStringFromCGSize(size));
 }
 
 @end

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -7,6 +7,7 @@
 
 #import "PaywallViewWrapper.h"
 #import "UIView+Extensions.h"
+#import "UIView+React.h"
 
 @import PurchasesHybridCommonUI;
 @import RevenueCatUI;
@@ -36,8 +37,19 @@ API_AVAILABLE(ios(15.0))
     return self;
 }
 
+
+- (void)reactSetFrame:(CGRect)frame
+{
+    NSLog(@"reactSetFrame: %@", NSStringFromCGRect(frame));
+
+    [super reactSetFrame: frame];
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
+
+    CGSize size = self.bounds.size;
+    NSLog(@"Size on layoutSubviews: %@", NSStringFromCGSize(size));
 
     // Need to wait for this view to be in the hierarchy to look for the parent UIVC.
     // This is required to add a SwiftUI `UIHostingController` to the hierarchy in a way that allows
@@ -50,6 +62,7 @@ API_AVAILABLE(ios(15.0))
             [self addSubview:self.paywallViewController.view];
             [self.paywallViewController didMoveToParentViewController:parentController];
 
+            NSLog(@"Activating constraints");
             [NSLayoutConstraint activateConstraints:@[
                 [self.paywallViewController.view.topAnchor constraintEqualToAnchor:self.topAnchor],
                 [self.paywallViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
@@ -128,6 +141,10 @@ didFailRestoringWithErrorDictionary:(NSDictionary *)errorDictionary API_AVAILABL
 
 - (void)paywallViewControllerWasDismissed:(RCPaywallViewController *)controller API_AVAILABLE(ios(15.0)) {
     self.onDismiss(nil);
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller didChangeSizeTo:(CGSize)size API_AVAILABLE(ios(15.0)) {
+    NSLog(@"Paywall view wrapper did change size to: %@", NSStringFromCGSize(size));
 }
 
 @end


### PR DESCRIPTION
Hoping this will help with https://github.com/RevenueCat/react-native-purchases/issues/914

My theory is that for some reason the JS size of the view is 0, but the iOS view is being rendered.