### PR TITLE
 Adds`Purchases.getCurrentOfferingForPlacement(placementID)` and `Purchases.syncAttributesAndOfferingsIfNeeded()`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -146,6 +146,24 @@ describe("Purchases", () => {
     expect(offerings).toEqual(offeringsStub);
   })
 
+  it("get current offerings for placement works", async () => {
+    NativeModules.RNPurchases.getCurrentOfferingForPlacement.mockResolvedValueOnce(currentOfferingForPlacementStub);
+
+    const offering = await Purchases.getCurrentOfferingForPlacement("onboarding")
+
+    expect(NativeModules.RNPurchases.getCurrentOfferingForPlacement).toBeCalledWith("onboarding")
+    expect(offering).toEqual(currentOfferingForPlacementStub);
+  })
+
+  it("sync attributes and offerings if needed works", async () => {
+    NativeModules.RNPurchases.syncAttributesAndOfferingsIfNeeded.mockResolvedValueOnce(offeringsStub);
+
+    const offerings = await Purchases.syncAttributesAndOfferingsIfNeeded()
+
+    expect(NativeModules.RNPurchases.syncAttributesAndOfferingsIfNeeded).toBeCalledTimes(1);
+    expect(offerings).toEqual(offeringsStub);
+  })
+
   it("getProducts works and gets subs by default", async () => {
     NativeModules.RNPurchases.getProductInfo.mockResolvedValueOnce(productsStub);
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -215,14 +215,14 @@ describe("Purchases", () => {
           currency_code: "USD",
           introPrice: null
         },
-        offeringIdentifier: "offering",
+        presentedOfferingContext: {offeringIdentifier: "offering"},
       },
       {
         oldSKU: "viejo",
         prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
       },
     );
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth",{offeringIdentifier: "offering"}, {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
     }, null, null);
@@ -237,12 +237,12 @@ describe("Purchases", () => {
 
     const aProduct = {
       ...productStub,
-      presentedOfferingIdentifier: "the-offerings"
+      presentedOfferingContext: {offeringIdentifier: "the-offerings"}
     }
 
     await Purchases.purchaseStoreProduct(aProduct)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, undefined, Purchases.PRODUCT_CATEGORY.SUBSCRIPTION, null, null, "the-offerings");
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, undefined, Purchases.PRODUCT_CATEGORY.SUBSCRIPTION, null, null, {offeringIdentifier: "the-offerings"});
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 
@@ -267,10 +267,10 @@ describe("Purchases", () => {
           currencyCode: "USD",
           introPrice: null
         },
-        offeringIdentifier: "offering",
+        presentedOfferingContext: {offeringIdentifier: "offering"},
       });
 
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", undefined, null, null);
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, undefined, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
 
     await Purchases.purchasePackage(
@@ -286,7 +286,7 @@ describe("Purchases", () => {
           currency_code: "USD",
           introPrice: null
         },
-        offeringIdentifier: "offering",
+        presentedOfferingContext: {offeringIdentifier: "offering"},
       },
       {
         oldSKU: "viejo",
@@ -294,7 +294,7 @@ describe("Purchases", () => {
       },
     );
 
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
     }, null, null);
@@ -312,14 +312,14 @@ describe("Purchases", () => {
           currency_code: "USD",
           introPrice: null
         },
-        offeringIdentifier: "offering",
+        presentedOfferingContext: {offeringIdentifier: "offering"},
       },
       {
         oldProductIdentifier: "viejo",
         prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
       },
     );
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", "offering", {
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, {
       oldProductIdentifier: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
     }, null, null);
@@ -367,7 +367,7 @@ describe("Purchases", () => {
         presentedOfferingIdentifier: null
       });
 
-    expect(NativeModules.RNPurchases.purchaseSubscriptionOption).toBeCalledWith("gold", "monthly", undefined, null, null, null);
+    expect(NativeModules.RNPurchases.purchaseSubscriptionOption).toBeCalledWith("gold", "monthly", undefined, null, null, undefined);
     expect(NativeModules.RNPurchases.purchaseSubscriptionOption).toBeCalledTimes(1);
 
     await Purchases.purchaseSubscriptionOption(
@@ -383,7 +383,7 @@ describe("Purchases", () => {
         fullPricePhase: phase,
         freePhase: null,
         introPhase: null,
-        presentedOfferingIdentifier: "offering"
+        presentedOfferingContext: {offeringIdentifier: "offering"},
       },
       {
         oldProductIdentifier: "viejo",
@@ -395,7 +395,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseSubscriptionOption).toBeCalledWith("gold", "monthly", {
       oldProductIdentifier: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, null, {isPersonalizedPrice: true}, "offering");
+    }, null, {isPersonalizedPrice: true}, {offeringIdentifier: "offering"});
     expect(NativeModules.RNPurchases.purchaseSubscriptionOption).toBeCalledTimes(2);
   });
 
@@ -794,7 +794,7 @@ describe("Purchases", () => {
 
     await Purchases.purchaseDiscountedProduct(aProduct, promotionalOfferStub)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null, undefined);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -155,7 +155,6 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 final String type,
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
-                                @Nullable final String presentedOfferingIdentifier,
                                 @Nullable final ReadableMap presentedOfferingContext,
                                 final Promise promise) {
         GoogleUpgradeInfo googleUpgradeInfo = getUpgradeInfo(googleProductChangeInfo);
@@ -175,15 +174,13 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             googleUpgradeInfo.getOldProductIdentifier(),
             googleUpgradeInfo.getProrationMode(),
             googleIsPersonalized,
-            presentedOfferingIdentifier,
             mapPresentedOfferingContext,
             getOnResult(promise));
     }
 
     @ReactMethod
     public void purchasePackage(final String packageIdentifier,
-                                final String offeringIdentifier,
-                                @Nullable final ReadableMap presentedOfferingContext,
+                                final ReadableMap presentedOfferingContext,
                                 @Nullable final ReadableMap googleProductChangeInfo,
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
@@ -192,15 +189,11 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
         Boolean googleIsPersonalized = googleInfo != null && googleInfo.hasKey("isPersonalizedPrice") ? googleInfo.getBoolean("isPersonalizedPrice") : null;
 
-        Map<String, Object> mapPresentedOfferingContext = null;
-        if (presentedOfferingContext != null) {
-            mapPresentedOfferingContext = presentedOfferingContext.toHashMap();
-        }
+        Map<String, Object> mapPresentedOfferingContext = presentedOfferingContext.toHashMap();
 
         CommonKt.purchasePackage(
             getCurrentActivity(),
             packageIdentifier,
-            offeringIdentifier,
             mapPresentedOfferingContext,
             googleUpgradeInfo.getOldProductIdentifier(),
             googleUpgradeInfo.getProrationMode(),
@@ -214,7 +207,6 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                            @Nullable final ReadableMap upgradeInfo,
                                            @Nullable final String discountTimestamp,
                                            @Nullable final ReadableMap googleInfo,
-                                           @Nullable final String presentedOfferingIdentifier,
                                            @Nullable final ReadableMap presentedOfferingContext,
                                            final Promise promise) {
         GoogleUpgradeInfo googleUpgradeInfo = getUpgradeInfo(upgradeInfo);
@@ -230,11 +222,10 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             getCurrentActivity(),
             productIdentifer,
             optionIdentifier,
-            mapPresentedOfferingContext,
             googleUpgradeInfo.getOldProductIdentifier(),
             googleUpgradeInfo.getProrationMode(),
             googleIsPersonalized,
-            presentedOfferingIdentifier,
+            mapPresentedOfferingContext,
             getOnResult(promise));
     }
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -121,6 +121,11 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
+    public void syncAttributesAndOfferingsIfNeeded(final Promise promise) {
+        CommonKt.syncAttributesAndOfferingsIfNeeded(getOnResult(promise));
+    }
+
+    @ReactMethod
     public void getProductInfo(ReadableArray productIDs, String type, final Promise promise) {
         ArrayList<String> productIDList = new ArrayList<>();
         for (int i = 0; i < productIDs.size(); i++) {

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -20,6 +20,7 @@ import {
   PRODUCT_CATEGORY,
   RECURRENCE_MODE,
   PresentedOfferingContext,
+  PresentedOfferingTargetingContext,
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -186,4 +187,22 @@ function checkOfferProductCategory(productCategory: PRODUCT_CATEGORY) {
       break;
     }
   }
+}
+
+function checkPresentedOfferingcontext(
+  presentedOfferingContext: PresentedOfferingContext
+) {
+  const offeringIdentifier: string =
+    presentedOfferingContext.offeringIdentifier;
+  const placementIdentifier: string | null =
+    presentedOfferingContext.placementIdentifier;
+  const targetingContext: PresentedOfferingTargetingContext | null =
+    presentedOfferingContext.targetingContext;
+}
+
+function checkPresentedOfferingTargetingContext(
+  targetingContext: PresentedOfferingTargetingContext
+) {
+  const revision: number = targetingContext.revision;
+  const ruleId: string = targetingContext.ruleId;
 }

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -1,14 +1,25 @@
 import {
   INTRO_ELIGIBILITY_STATUS,
   IntroEligibility,
-  PACKAGE_TYPE, PRORATION_MODE,
+  PACKAGE_TYPE,
+  PRORATION_MODE,
   PurchasesStoreProductDiscount,
   PurchasesIntroPrice,
-  PurchasesOffering, PurchasesOfferings,
-  PurchasesPackage, PurchasesPromotionalOffer,
-  PurchasesStoreProduct, UpgradeInfo,
-  SubscriptionOption, PricingPhase,
-  Price, Period, OFFER_PAYMENT_MODE, PERIOD_UNIT, PRODUCT_CATEGORY, RECURRENCE_MODE
+  PurchasesOffering,
+  PurchasesOfferings,
+  PurchasesPackage,
+  PurchasesPromotionalOffer,
+  PurchasesStoreProduct,
+  UpgradeInfo,
+  SubscriptionOption,
+  PricingPhase,
+  Price,
+  Period,
+  OFFER_PAYMENT_MODE,
+  PERIOD_UNIT,
+  PRODUCT_CATEGORY,
+  RECURRENCE_MODE,
+  PresentedOfferingContext,
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -23,8 +34,12 @@ function checkProduct(product: PurchasesStoreProduct) {
   const subscriptionPeriod: string | null = product.subscriptionPeriod;
   const productCategory: PRODUCT_CATEGORY | null = product.productCategory;
   const defaultOption: SubscriptionOption | null = product.defaultOption;
-  const subscriptionOptions: SubscriptionOption[] | null =  product.subscriptionOptions;
-  const presentedOfferingIdentifier: string | null = product.presentedOfferingIdentifier;
+  const subscriptionOptions: SubscriptionOption[] | null =
+    product.subscriptionOptions;
+  const presentedOfferingIdentifier: string | null =
+    product.presentedOfferingIdentifier;
+  const presentedOfferingContext: PresentedOfferingContext | null =
+    product.presentedOfferingContext;
 }
 
 function checkDiscount(discount: PurchasesStoreProductDiscount) {
@@ -51,6 +66,8 @@ function checkPackage(pack: PurchasesPackage) {
   const packageType: PACKAGE_TYPE = pack.packageType;
   const product: PurchasesStoreProduct = pack.product;
   const offeringIdentifier: string = pack.offeringIdentifier;
+  const presentedOfferingContext: PresentedOfferingContext =
+    pack.presentedOfferingContext;
 }
 
 function checkOffering(offering: PurchasesOffering) {
@@ -102,7 +119,10 @@ function checkSubscriptionOption(option: SubscriptionOption) {
   const fullPricePhase: PricingPhase | null = option.fullPricePhase;
   const freePhase: PricingPhase | null = option.freePhase;
   const introPhase: PricingPhase | null = option.introPhase;
-  const presentedOfferingIdentifier: string | null = option.presentedOfferingIdentifier;
+  const presentedOfferingIdentifier: string | null =
+    option.presentedOfferingIdentifier;
+  const presentedOfferingContext: PresentedOfferingContext | null =
+    option.presentedOfferingContext;
 }
 
 function checkPricingPhase(pricePhase: PricingPhase) {
@@ -110,7 +130,8 @@ function checkPricingPhase(pricePhase: PricingPhase) {
   const recurrenceMode: RECURRENCE_MODE | null = pricePhase.recurrenceMode;
   const billingCycleCount: number | null = pricePhase.billingCycleCount;
   const price: Price = pricePhase.price;
-  const offerPaymentMode: OFFER_PAYMENT_MODE | null = pricePhase.offerPaymentMode;
+  const offerPaymentMode: OFFER_PAYMENT_MODE | null =
+    pricePhase.offerPaymentMode;
 }
 
 function checkPeriod(period: Period) {
@@ -126,43 +147,43 @@ function checkPrice(price: Price) {
 }
 
 function checkRecurrenceMode(mode: RECURRENCE_MODE) {
-  switch(mode) { 
-    case RECURRENCE_MODE.INFINITE_RECURRING, 
-    RECURRENCE_MODE.FINITE_RECURRING, 
-    RECURRENCE_MODE.NON_RECURRING: { 
-       break; 
-    } 
-  };
+  switch (mode) {
+    case (RECURRENCE_MODE.INFINITE_RECURRING,
+    RECURRENCE_MODE.FINITE_RECURRING,
+    RECURRENCE_MODE.NON_RECURRING): {
+      break;
+    }
+  }
 }
 
 function checkPeriodUnit(periodUnit: PERIOD_UNIT) {
-  switch(periodUnit) { 
-    case PERIOD_UNIT.DAY, 
-    PERIOD_UNIT.WEEK, 
+  switch (periodUnit) {
+    case (PERIOD_UNIT.DAY,
+    PERIOD_UNIT.WEEK,
     PERIOD_UNIT.MONTH,
     PERIOD_UNIT.YEAR,
-    PERIOD_UNIT.UNKNOWN: { 
-       break; 
-    } 
-  };
+    PERIOD_UNIT.UNKNOWN): {
+      break;
+    }
+  }
 }
 
 function checkOfferPaymentMode(offerPaymentMode: OFFER_PAYMENT_MODE) {
-  switch(offerPaymentMode) { 
-    case OFFER_PAYMENT_MODE.FREE_TRIAL, 
-    OFFER_PAYMENT_MODE.SINGLE_PAYMENT, 
-    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT: { 
-       break; 
-    } 
-  };
+  switch (offerPaymentMode) {
+    case (OFFER_PAYMENT_MODE.FREE_TRIAL,
+    OFFER_PAYMENT_MODE.SINGLE_PAYMENT,
+    OFFER_PAYMENT_MODE.DISCOUNTED_RECURRING_PAYMENT): {
+      break;
+    }
+  }
 }
 
 function checkOfferProductCategory(productCategory: PRODUCT_CATEGORY) {
-  switch(productCategory) { 
-    case PRODUCT_CATEGORY.NON_SUBSCRIPTION, 
-    PRODUCT_CATEGORY.SUBSCRIPTION, 
-    PRODUCT_CATEGORY.UNKNOWN: { 
-       break; 
-    } 
-  };
+  switch (productCategory) {
+    case (PRODUCT_CATEGORY.NON_SUBSCRIPTION,
+    PRODUCT_CATEGORY.SUBSCRIPTION,
+    PRODUCT_CATEGORY.UNKNOWN): {
+      break;
+    }
+  }
 }

--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -1,17 +1,20 @@
-import React from 'react';
+import React from "react";
 
 import RevenueCatUI, {
   FooterPaywallViewOptions,
   FullScreenPaywallViewOptions,
-  PAYWALL_RESULT, PaywallViewOptions,
+  PAYWALL_RESULT,
+  PaywallViewOptions,
   PresentPaywallIfNeededParams,
-  PresentPaywallParams
+  PresentPaywallParams,
 } from "../react-native-purchases-ui";
 import {
-  CustomerInfo, PurchasesError,
+  CustomerInfo,
+  PurchasesError,
   PurchasesOffering,
-  PurchasesOfferings, PurchasesPackage,
-  PurchasesStoreTransaction
+  PurchasesOfferings,
+  PurchasesPackage,
+  PurchasesStoreTransaction,
 } from "@revenuecat/purchases-typescript-internal";
 
 async function checkPresentPaywall(offering: PurchasesOffering) {
@@ -30,9 +33,11 @@ async function checkPresentPaywall(offering: PurchasesOffering) {
 }
 
 async function checkPresentPaywallIfNeeded(offering: PurchasesOffering) {
-  let paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywallIfNeeded({
-    requiredEntitlementIdentifier: "entitlement"
-  });
+  let paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywallIfNeeded(
+    {
+      requiredEntitlementIdentifier: "entitlement",
+    }
+  );
   paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
     requiredEntitlementIdentifier: "entitlement",
     offering: offering,
@@ -49,7 +54,8 @@ async function checkPresentPaywallIfNeeded(offering: PurchasesOffering) {
 }
 
 function checkPresentPaywallParams(params: PresentPaywallIfNeededParams) {
-  const requiredEntitlementIdentifier: string = params.requiredEntitlementIdentifier;
+  const requiredEntitlementIdentifier: string =
+    params.requiredEntitlementIdentifier;
   const offeringIdentifier: PurchasesOffering | undefined = params.offering;
   const displayCloseButton: boolean | undefined = params.displayCloseButton;
 }
@@ -59,7 +65,9 @@ function checkPresentPaywallIfNeededParams(params: PresentPaywallParams) {
   const displayCloseButton: boolean | undefined = params.displayCloseButton;
 }
 
-function checkFullScreenPaywallViewOptions(options: FullScreenPaywallViewOptions) {
+function checkFullScreenPaywallViewOptions(
+  options: FullScreenPaywallViewOptions
+) {
   const offering: PurchasesOffering | undefined | null = options.offering;
   const fontFamily: string | undefined | null = options.fontFamily;
 }
@@ -69,61 +77,76 @@ function checkFooterPaywallViewOptions(options: FooterPaywallViewOptions) {
   const fontFamily: string | undefined | null = options.fontFamily;
 }
 
-const onPurchaseStarted = ({packageBeingPurchased}: { packageBeingPurchased: PurchasesPackage }) => {
-};
+const onPurchaseStarted = ({
+  packageBeingPurchased,
+}: {
+  packageBeingPurchased: PurchasesPackage;
+}) => {};
 
-const onPurchaseCompleted = ({customerInfo, storeTransaction}: {
-  customerInfo: CustomerInfo, storeTransaction: PurchasesStoreTransaction
-}) => {
-};
+const onPurchaseCompleted = ({
+  customerInfo,
+  storeTransaction,
+}: {
+  customerInfo: CustomerInfo;
+  storeTransaction: PurchasesStoreTransaction;
+}) => {};
 
-const onPurchaseError = ({error}: { error: PurchasesError }) => {
-};
+const onPurchaseError = ({ error }: { error: PurchasesError }) => {};
 
-const onPurchaseCancelled = () => {
-};
+const onPurchaseCancelled = () => {};
 
-const onRestoreStarted = () => {
-};
+const onRestoreStarted = () => {};
 
-const onRestoreCompleted = ({customerInfo}: { customerInfo: CustomerInfo }) => {
-};
+const onRestoreCompleted = ({
+  customerInfo,
+}: {
+  customerInfo: CustomerInfo;
+}) => {};
 
-const onRestoreError = ({error}: { error: PurchasesError }) => {
-};
+const onRestoreError = ({ error }: { error: PurchasesError }) => {};
 
-const onDismiss = () => {
-};
-
+const onDismiss = () => {};
 
 const PaywallScreen = () => {
   return (
-    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
-      offering: null
-    }}/>
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        offering: null,
+      }}
+    />
   );
 };
 
 const PaywallScreenWithOffering = (offering: PurchasesOffering) => {
   return (
-    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
-      offering: offering
-    }}/>
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        offering: offering,
+      }}
+    />
   );
 };
 
 const PaywallScreenWithFontFamily = (fontFamily: string | undefined | null) => {
   return (
-    <RevenueCatUI.Paywall style={{marginBottom: 10}} options={{
-      fontFamily: fontFamily
-    }}/>
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        fontFamily: fontFamily,
+      }}
+    />
   );
 };
 
-const PaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, fontFamily: string | undefined | null) => {
+const PaywallScreenWithOfferingAndEvents = (
+  offering: PurchasesOffering,
+  fontFamily: string | undefined | null
+) => {
   return (
     <RevenueCatUI.Paywall
-      style={{marginBottom: 10}}
+      style={{ marginBottom: 10 }}
       options={{
         offering: offering,
         fontFamily: fontFamily,
@@ -135,45 +158,51 @@ const PaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, fontFam
       onRestoreStarted={onRestoreStarted}
       onRestoreCompleted={onRestoreCompleted}
       onRestoreError={onRestoreError}
-      onDismiss={onDismiss}/>
+      onDismiss={onDismiss}
+    />
   );
 };
 
 const PaywallScreenNoOptions = () => {
-  return (
-    <RevenueCatUI.Paywall style={{marginBottom: 10}}/>
-  );
+  return <RevenueCatUI.Paywall style={{ marginBottom: 10 }} />;
 };
 
 const FooterPaywallScreen = () => {
   return (
-    <RevenueCatUI.PaywallFooterContainerView options={{
-      offering: null,
-    }}>
-    </RevenueCatUI.PaywallFooterContainerView>
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        offering: null,
+      }}
+    ></RevenueCatUI.PaywallFooterContainerView>
   );
 };
 
 const FooterPaywallScreenWithOffering = (offering: PurchasesOffering) => {
   return (
-    <RevenueCatUI.PaywallFooterContainerView options={{
-      offering: offering,
-    }}>
-    </RevenueCatUI.PaywallFooterContainerView>
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        offering: offering,
+      }}
+    ></RevenueCatUI.PaywallFooterContainerView>
   );
 };
 
-const FooterPaywallScreenWithFontFamily = (fontFamily: string | null | undefined) => {
+const FooterPaywallScreenWithFontFamily = (
+  fontFamily: string | null | undefined
+) => {
   return (
-    <RevenueCatUI.PaywallFooterContainerView options={{
-      fontFamily: fontFamily,
-    }}>
-    </RevenueCatUI.PaywallFooterContainerView>
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        fontFamily: fontFamily,
+      }}
+    ></RevenueCatUI.PaywallFooterContainerView>
   );
 };
 
-
-const FooterPaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, fontFamily: string | undefined | null) => {
+const FooterPaywallScreenWithOfferingAndEvents = (
+  offering: PurchasesOffering,
+  fontFamily: string | undefined | null
+) => {
   return (
     <RevenueCatUI.PaywallFooterContainerView
       options={{
@@ -186,15 +215,13 @@ const FooterPaywallScreenWithOfferingAndEvents = (offering: PurchasesOffering, f
       onPurchaseCancelled={onPurchaseCancelled}
       onRestoreStarted={onRestoreStarted}
       onRestoreCompleted={onRestoreCompleted}
-      onDismiss={onDismiss}>
-    </RevenueCatUI.PaywallFooterContainerView>
+      onDismiss={onDismiss}
+    ></RevenueCatUI.PaywallFooterContainerView>
   );
 };
 
 const FooterPaywallScreenNoOptions = () => {
   return (
-    <RevenueCatUI.PaywallFooterContainerView>
-    </RevenueCatUI.PaywallFooterContainerView>
+    <RevenueCatUI.PaywallFooterContainerView></RevenueCatUI.PaywallFooterContainerView>
   );
 };
-

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -1,4 +1,8 @@
-import {ENTITLEMENT_VERIFICATION_MODE, IN_APP_MESSAGE_TYPE} from '@revenuecat/purchases-typescript-internal';
+import {
+  ENTITLEMENT_VERIFICATION_MODE,
+  IN_APP_MESSAGE_TYPE,
+  PurchasesOffering,
+} from "@revenuecat/purchases-typescript-internal";
 import {
   CustomerInfo,
   PurchasesEntitlementInfo,
@@ -10,21 +14,31 @@ import {
   MakePurchaseResult,
   LOG_LEVEL,
   REFUND_REQUEST_STATUS,
-  PURCHASE_TYPE, PurchasesStoreProductDiscount, BILLING_FEATURE, IntroEligibility,
-  LogInResult, ShouldPurchasePromoProductListener, CustomerInfoUpdateListener
-} from '../dist';
+  PURCHASE_TYPE,
+  PurchasesStoreProductDiscount,
+  BILLING_FEATURE,
+  IntroEligibility,
+  LogInResult,
+  ShouldPurchasePromoProductListener,
+  CustomerInfoUpdateListener,
+} from "../dist";
 
-import Purchases from '../dist/purchases';
-import { GoogleProductChangeInfo, SubscriptionOption } from '../src';
+import Purchases from "../dist/purchases";
+import { GoogleProductChangeInfo, SubscriptionOption } from "../src";
 
 async function checkPurchases(purchases: Purchases) {
   const productIds: string[] = [];
 
   const offerings: PurchasesOfferings = await Purchases.getOfferings();
+  const currentOfferingForPlacement: PurchasesOffering | null =
+    await Purchases.getCurrentOfferingForPlacement("");
   const products: PurchasesStoreProduct[] = await Purchases.getProducts(
     productIds,
     PURCHASE_TYPE.INAPP
   );
+
+  const newOfferings: PurchasesOfferings =
+    await Purchases.syncAttributesAndOfferingsIfNeeded();
 
   const customerInfo: CustomerInfo = await Purchases.restorePurchases();
 
@@ -41,24 +55,24 @@ async function checkUsers(purchases: Purchases) {
   const anonymous: boolean = await Purchases.isAnonymous();
 }
 
-async function checkPurchasing(purchases: Purchases,
-                               product: PurchasesStoreProduct,
-                               discount: PurchasesStoreProductDiscount,
-                               paymentDiscount: PurchasesPromotionalOffer,
-                               pack: PurchasesPackage,
-                               subscriptionOption: SubscriptionOption,
-                               upgradeInfo: UpgradeInfo,
-                               googleProductChangeInfo: GoogleProductChangeInfo) {
-  const productId: string = ""
+async function checkPurchasing(
+  purchases: Purchases,
+  product: PurchasesStoreProduct,
+  discount: PurchasesStoreProductDiscount,
+  paymentDiscount: PurchasesPromotionalOffer,
+  pack: PurchasesPackage,
+  subscriptionOption: SubscriptionOption,
+  upgradeInfo: UpgradeInfo,
+  googleProductChangeInfo: GoogleProductChangeInfo
+) {
+  const productId: string = "";
   const productIds: string[] = [productId];
   const features: BILLING_FEATURE[] = [];
   const messageTypes: IN_APP_MESSAGE_TYPE[] = [];
   const googleIsPersonalizedPrice: boolean = false;
 
-  const paymentDiscount2: PurchasesPromotionalOffer | undefined = await Purchases.getPromotionalOffer(
-    product,
-    discount,
-  );
+  const paymentDiscount2: PurchasesPromotionalOffer | undefined =
+    await Purchases.getPromotionalOffer(product, discount);
 
   const productResult1: MakePurchaseResult = await Purchases.purchaseProduct(
     productId,
@@ -66,20 +80,17 @@ async function checkPurchasing(purchases: Purchases,
     PURCHASE_TYPE.INAPP
   );
 
-  const storeProductResult1: MakePurchaseResult = await Purchases.purchaseStoreProduct(
-    product,
-    googleProductChangeInfo
-  );
-  const storeProductResult2: MakePurchaseResult = await Purchases.purchaseStoreProduct(
-    product,
-    googleProductChangeInfo,
-    googleIsPersonalizedPrice
-  );
+  const storeProductResult1: MakePurchaseResult =
+    await Purchases.purchaseStoreProduct(product, googleProductChangeInfo);
+  const storeProductResult2: MakePurchaseResult =
+    await Purchases.purchaseStoreProduct(
+      product,
+      googleProductChangeInfo,
+      googleIsPersonalizedPrice
+    );
 
-  const discountedProductResult1: MakePurchaseResult = await Purchases.purchaseDiscountedProduct(
-    product,
-    paymentDiscount
-  );
+  const discountedProductResult1: MakePurchaseResult =
+    await Purchases.purchaseDiscountedProduct(product, paymentDiscount);
 
   const packageResult1: MakePurchaseResult = await Purchases.purchasePackage(
     pack,
@@ -98,20 +109,20 @@ async function checkPurchasing(purchases: Purchases,
     googleIsPersonalizedPrice
   );
 
-  const discountedPackageResult1: MakePurchaseResult = await Purchases.purchaseDiscountedPackage(
-    pack,
-    paymentDiscount
-  );
+  const discountedPackageResult1: MakePurchaseResult =
+    await Purchases.purchaseDiscountedPackage(pack, paymentDiscount);
 
-  const subscriptionOptionResult1: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
-    subscriptionOption,
-    googleProductChangeInfo
-  );
-  const subscriptionOptionResult2: MakePurchaseResult = await Purchases.purchaseSubscriptionOption(
-    subscriptionOption,
-    googleProductChangeInfo,
-    googleIsPersonalizedPrice
-  );
+  const subscriptionOptionResult1: MakePurchaseResult =
+    await Purchases.purchaseSubscriptionOption(
+      subscriptionOption,
+      googleProductChangeInfo
+    );
+  const subscriptionOptionResult2: MakePurchaseResult =
+    await Purchases.purchaseSubscriptionOption(
+      subscriptionOption,
+      googleProductChangeInfo,
+      googleIsPersonalizedPrice
+    );
 
   const syncPurchases: void = await Purchases.syncPurchases();
 
@@ -119,7 +130,7 @@ async function checkPurchasing(purchases: Purchases,
   const canMakePayments2: boolean = await Purchases.canMakePayments(features);
 
   const introEligibilities: {
-    [p: string]: IntroEligibility
+    [p: string]: IntroEligibility;
   } = await Purchases.checkTrialOrIntroductoryPriceEligibility(productIds);
 
   await Purchases.showInAppMessages();
@@ -132,27 +143,21 @@ async function checkConfigure() {
   const observerMode: boolean = false;
   const usesStoreKit2IfAvailable: boolean = true;
   const useAmazon: boolean = true;
-  const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE = Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
+  const entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE =
+    Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL;
   const userDefaultsSuiteName: string = "";
   const shouldShowInAppMessagesAutomatically: boolean = true;
 
   Purchases.configure({
     apiKey,
     appUserID,
-    observerMode
-  });
-  Purchases.configure({
-    apiKey,
-    appUserID,
     observerMode,
-    userDefaultsSuiteName
   });
   Purchases.configure({
     apiKey,
     appUserID,
     observerMode,
     userDefaultsSuiteName,
-    usesStoreKit2IfAvailable
   });
   Purchases.configure({
     apiKey,
@@ -160,7 +165,6 @@ async function checkConfigure() {
     observerMode,
     userDefaultsSuiteName,
     usesStoreKit2IfAvailable,
-    entitlementVerificationMode
   });
   Purchases.configure({
     apiKey,
@@ -169,7 +173,15 @@ async function checkConfigure() {
     userDefaultsSuiteName,
     usesStoreKit2IfAvailable,
     entitlementVerificationMode,
-    useAmazon
+  });
+  Purchases.configure({
+    apiKey,
+    appUserID,
+    observerMode,
+    userDefaultsSuiteName,
+    usesStoreKit2IfAvailable,
+    entitlementVerificationMode,
+    useAmazon,
   });
   Purchases.configure({
     apiKey,
@@ -178,7 +190,7 @@ async function checkConfigure() {
     userDefaultsSuiteName,
     usesStoreKit2IfAvailable,
     useAmazon,
-    shouldShowInAppMessagesAutomatically
+    shouldShowInAppMessagesAutomatically,
   });
 
   await Purchases.setProxyURL("");
@@ -204,7 +216,9 @@ async function checkLogLevelEnum(level: LOG_LEVEL) {
   }
 }
 
-async function checkEntitlementVerificationModeEnum(mode: ENTITLEMENT_VERIFICATION_MODE) {
+async function checkEntitlementVerificationModeEnum(
+  mode: ENTITLEMENT_VERIFICATION_MODE
+) {
   switch (mode) {
     case ENTITLEMENT_VERIFICATION_MODE.DISABLED:
     case ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL:
@@ -214,10 +228,12 @@ async function checkEntitlementVerificationModeEnum(mode: ENTITLEMENT_VERIFICATI
 }
 
 function checkListeners() {
-  const customerInfoUpdateListener: CustomerInfoUpdateListener = customerInfo => {
-  };
-  const shouldPurchaseListener: ShouldPurchasePromoProductListener = deferredPurchase => {
-  };
+  const customerInfoUpdateListener: CustomerInfoUpdateListener = (
+    customerInfo
+  ) => {};
+  const shouldPurchaseListener: ShouldPurchasePromoProductListener = (
+    deferredPurchase
+  ) => {};
 
   Purchases.addCustomerInfoUpdateListener(customerInfoUpdateListener);
   Purchases.removeCustomerInfoUpdateListener(customerInfoUpdateListener);
@@ -226,18 +242,30 @@ function checkListeners() {
   Purchases.removeShouldPurchasePromoProductListener(shouldPurchaseListener);
 }
 
-async function checkBeginRefundRequest(entitlementInfo: PurchasesEntitlementInfo, storeProduct: PurchasesStoreProduct) {
-  const refundStatus1: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForActiveEntitlement();
-  const refundStatus2: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForEntitlement(entitlementInfo);
-  const refundStatus3: REFUND_REQUEST_STATUS = await Purchases.beginRefundRequestForProduct(storeProduct);
+async function checkBeginRefundRequest(
+  entitlementInfo: PurchasesEntitlementInfo,
+  storeProduct: PurchasesStoreProduct
+) {
+  const refundStatus1: REFUND_REQUEST_STATUS =
+    await Purchases.beginRefundRequestForActiveEntitlement();
+  const refundStatus2: REFUND_REQUEST_STATUS =
+    await Purchases.beginRefundRequestForEntitlement(entitlementInfo);
+  const refundStatus3: REFUND_REQUEST_STATUS =
+    await Purchases.beginRefundRequestForProduct(storeProduct);
 }
 
-
-async function checkSyncObserverModeAmazonPurchase(productID: string,
-                                                   receiptID: string,
-                                                   amazonUserID: string,
-                                                   isoCurrencyCode?: string | null,
-                                                   price?: number | null): Promise<void> {
+async function checkSyncObserverModeAmazonPurchase(
+  productID: string,
+  receiptID: string,
+  amazonUserID: string,
+  isoCurrencyCode?: string | null,
+  price?: number | null
+): Promise<void> {
   return Purchases.syncObserverModeAmazonPurchase(
-    productID, receiptID, amazonUserID, isoCurrencyCode, price);
+    productID,
+    receiptID,
+    amazonUserID,
+    isoCurrencyCode,
+    price
+  );
 }

--- a/examples/purchaseTesterTypescript/app/APIKeys.tsx
+++ b/examples/purchaseTesterTypescript/app/APIKeys.tsx
@@ -1,9 +1,8 @@
-
 // REPLACE THESE WITH YOUR OWN
 const APIKeys = {
-  apple: "",
-  google: "",
-  amazon: ""
+  apple: 'appl_KFpRDwauDyfIGIETKyVymslMcjX',
+  google: 'goog_cRtaFpfwfcQYPXkIEqFUkVszUfN',
+  amazon: '',
 };
 
 export default APIKeys;

--- a/examples/purchaseTesterTypescript/app/APIKeys.tsx
+++ b/examples/purchaseTesterTypescript/app/APIKeys.tsx
@@ -1,8 +1,9 @@
+
 // REPLACE THESE WITH YOUR OWN
 const APIKeys = {
-  apple: 'appl_KFpRDwauDyfIGIETKyVymslMcjX',
-  google: 'goog_cRtaFpfwfcQYPXkIEqFUkVszUfN',
-  amazon: '',
+  apple: "",
+  google: "",
+  amazon: ""
 };
 
 export default APIKeys;

--- a/examples/purchaseTesterTypescript/app/components/CustomerInfoHeader.tsx
+++ b/examples/purchaseTesterTypescript/app/components/CustomerInfoHeader.tsx
@@ -1,47 +1,64 @@
-import React, { useState } from 'react';
-import { Button, Modal, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import React, {useState} from 'react';
+import {
+  Button,
+  Modal,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
-import Purchases, { CustomerInfo } from 'react-native-purchases';
+import Purchases, {CustomerInfo} from 'react-native-purchases';
 
 export type Props = {
   appUserID: String | null;
   customerInfo: CustomerInfo | null;
-  isAnonymous: boolean,
-  refreshData: Function
+  isAnonymous: boolean;
+  refreshData: Function;
 };
 
 // Taken from https://reactnative.dev/docs/typescript
-const CustomerInfoHeader: React.FC<Props> = ({appUserID, customerInfo, isAnonymous, refreshData}) => {
+const CustomerInfoHeader: React.FC<Props> = ({
+  appUserID,
+  customerInfo,
+  isAnonymous,
+  refreshData,
+}) => {
   const [isLoginModalVisible, setLoginModalVisible] = useState(false);
   const [isAttributeModalVisible, setAttributeModalVisible] = useState(false);
-  const [inputUserID, setInputUserID] = useState("");
-  const [inputAttributeKey, setInputAttributeKey] = useState("");
-  const [inputAttributeValue, setInputAttributeValue] = useState("");
+  const [inputUserID, setInputUserID] = useState('');
+  const [inputAttributeKey, setInputAttributeKey] = useState('');
+  const [inputAttributeValue, setInputAttributeValue] = useState('');
 
   const activeEntitlements = () => {
-    const entitlements = Object.entries(customerInfo?.entitlements?.active ?? {});
+    const entitlements = Object.entries(
+      customerInfo?.entitlements?.active ?? {},
+    );
     if (entitlements.length > 0) {
-      return entitlements.map(([key, value]) => {
-        return value.identifier;
-      }).join(', ');
+      return entitlements
+        .map(([key, value]) => {
+          return value.identifier;
+        })
+        .join(', ');
     } else {
-      return "No active entitlements";
+      return 'No active entitlements';
     }
   };
 
   const login = () => {
-    setInputUserID("")
-    toggleLoginModalVisibility()
-  }
+    setInputUserID('');
+    toggleLoginModalVisibility();
+  };
 
   const logout = async () => {
     try {
       await Purchases.logOut();
       await refreshData();
     } catch {
-      console.log("error logging out")
+      console.log('error logging out');
     }
-  }
+  };
 
   const toggleLoginModalVisibility = async () => {
     if (isLoginModalVisible && inputUserID && inputUserID.length > 0) {
@@ -55,27 +72,24 @@ const CustomerInfoHeader: React.FC<Props> = ({appUserID, customerInfo, isAnonymo
   const toggleAttributeModalVisibility = async () => {
     if (isAttributeModalVisible) {
       if (inputAttributeKey.length > 0) {
-        const value = inputAttributeValue.length == 0 ? null : inputAttributeValue;
+        const value =
+          inputAttributeValue.length == 0 ? null : inputAttributeValue;
         await Purchases.setAttributes({
-          [inputAttributeKey]: value
-        })
+          [inputAttributeKey]: value,
+        });
         await refreshData();
       }
     } else {
-      setInputAttributeKey("");
-      setInputAttributeValue("");
+      setInputAttributeKey('');
+      setInputAttributeValue('');
     }
 
     setAttributeModalVisible(!isAttributeModalVisible);
   };
   return (
     <View style={styles.container}>
-      <Text style={styles.heading}>
-        CustomerInfo
-      </Text>
-      <Text>
-        User ID: {appUserID ?? 'N/A'}
-      </Text>
+      <Text style={styles.heading}>CustomerInfo</Text>
+      <Text>User ID: {appUserID ?? 'N/A'}</Text>
       <Text style={styles.entitlements}>
         Entitlements: {activeEntitlements()}
       </Text>
@@ -83,58 +97,66 @@ const CustomerInfoHeader: React.FC<Props> = ({appUserID, customerInfo, isAnonymo
         <TouchableOpacity
           style={styles.button}
           onPress={isAnonymous ? login : logout}>
-          <Text>
-            {isAnonymous ? "Login" : "Logout"}
-          </Text>
+          <Text>{isAnonymous ? 'Login' : 'Logout'}</Text>
         </TouchableOpacity>
 
         <TouchableOpacity
           style={styles.button}
           onPress={toggleAttributeModalVisibility}>
-          <Text>
-            Add Attribute
-          </Text>
+          <Text>Add Attribute</Text>
         </TouchableOpacity>
       </View>
 
-      <Modal animationType="slide"
-             transparent visible={isLoginModalVisible}
-             presentationStyle="overFullScreen">
+      <Modal
+        animationType="slide"
+        transparent
+        visible={isLoginModalVisible}
+        presentationStyle="overFullScreen">
         <View style={styles.viewWrapper}>
           <View style={styles.modalView}>
             <Text>Enter identifier for login</Text>
-            <TextInput placeholder="Enter User ID..."
-                       autoCapitalize='none'
-                       autoCorrect={false}
-                       value={inputUserID} style={styles.textInput}
-                       onChangeText={(value) => setInputUserID(value)}/>
+            <TextInput
+              placeholder="Enter User ID..."
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={inputUserID}
+              style={styles.textInput}
+              onChangeText={value => setInputUserID(value)}
+            />
 
-            <Button title="Close" onPress={toggleLoginModalVisibility}/>
+            <Button title="Close" onPress={toggleLoginModalVisibility} />
           </View>
         </View>
       </Modal>
 
-      <Modal animationType="slide"
-             transparent visible={isAttributeModalVisible}
-             presentationStyle="overFullScreen">
+      <Modal
+        animationType="slide"
+        transparent
+        visible={isAttributeModalVisible}
+        presentationStyle="overFullScreen">
         <View style={styles.viewWrapper}>
           <View style={styles.modalView}>
             <Text>Enter attribute key and value</Text>
-            <TextInput placeholder="Enter key..."
-                       autoCapitalize='none'
-                       autoCorrect={false}
-                       value={inputAttributeKey} style={styles.textInput}
-                       onChangeText={(value) => setInputAttributeKey(value)}/>
-            <TextInput placeholder="Enter value..."
-                       autoCapitalize='none'
-                       autoCorrect={false}
-                       value={inputAttributeValue} style={styles.textInput}
-                       onChangeText={(value) => setInputAttributeValue(value)}/>
-            <Button title="Close" onPress={toggleAttributeModalVisibility}/>
+            <TextInput
+              placeholder="Enter key..."
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={inputAttributeKey}
+              style={styles.textInput}
+              onChangeText={value => setInputAttributeKey(value)}
+            />
+            <TextInput
+              placeholder="Enter value..."
+              autoCapitalize="none"
+              autoCorrect={false}
+              value={inputAttributeValue}
+              style={styles.textInput}
+              onChangeText={value => setInputAttributeValue(value)}
+            />
+            <Button title="Close" onPress={toggleAttributeModalVisibility} />
           </View>
         </View>
       </Modal>
-
     </View>
   );
 };
@@ -145,53 +167,53 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     width: '100%',
-    paddingHorizontal: 20
+    paddingHorizontal: 20,
   },
   buttons: {
     flex: 1,
-    flexDirection: "row"
+    flexDirection: 'row',
   },
   entitlements: {
     flex: 1,
     alignItems: 'flex-start',
-    justifyContent: 'center'
+    justifyContent: 'center',
   },
   heading: {
     fontSize: 16,
     fontWeight: 'bold',
     marginTop: 16,
-    marginBottom: 8
+    marginBottom: 8,
   },
   button: {
-    backgroundColor: "lightcoral",
+    backgroundColor: 'lightcoral',
     paddingVertical: 5,
     paddingHorizontal: 20,
     marginTop: 20,
     borderRadius: 4,
-    marginHorizontal: 5
+    marginHorizontal: 5,
   },
   viewWrapper: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: "rgba(0, 0, 0, 0.2)",
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.2)',
   },
   modalView: {
-    alignItems: "center",
-    justifyContent: "center",
-    position: "absolute",
-    width: "90%",
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'absolute',
+    width: '90%',
     elevation: 5,
     height: 180,
-    backgroundColor: "#fff",
+    backgroundColor: '#fff',
     borderRadius: 7,
   },
   textInput: {
-    width: "80%",
+    width: '80%',
     borderRadius: 5,
     paddingVertical: 8,
     paddingHorizontal: 16,
-    borderColor: "rgba(0, 0, 0, 0.2)",
+    borderColor: 'rgba(0, 0, 0, 0.2)',
     borderWidth: 1,
     marginBottom: 8,
   },

--- a/examples/purchaseTesterTypescript/app/components/InputModal.tsx
+++ b/examples/purchaseTesterTypescript/app/components/InputModal.tsx
@@ -1,0 +1,77 @@
+import React, {useState} from 'react';
+import {Modal, View, TextInput, Button, StyleSheet} from 'react-native';
+
+const PromptWithTextInput = ({isVisible, onCancel, onSubmit}) => {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleCancel = () => {
+    setInputValue('');
+    onCancel();
+  };
+
+  const handleSubmit = () => {
+    onSubmit(inputValue);
+    setInputValue('');
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      transparent={true}
+      visible={isVisible}
+      onRequestClose={handleCancel}>
+      <View style={styles.centeredView}>
+        <View style={styles.modalView}>
+          <TextInput
+            style={styles.textInput}
+            onChangeText={setInputValue}
+            value={inputValue}
+            placeholder="Enter text here..."
+          />
+          <View style={styles.buttonContainer}>
+            <Button title="Cancel" onPress={handleCancel} />
+            <Button title="Submit" onPress={handleSubmit} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 22,
+  },
+  modalView: {
+    margin: 20,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  textInput: {
+    height: 40,
+    width: '100%',
+    margin: 12,
+    borderWidth: 1,
+    padding: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+});
+
+export default PromptWithTextInput;

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -117,6 +117,16 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
     setPromptPlacementVisible(true);
   };
 
+  const syncAttributesAndOfferings = async () => {
+    try {
+      const offerings = await Purchases.syncAttributesAndOfferingsIfNeeded();
+      console.log('offerings after sync', offerings);
+      setState({...state, offerings: offerings});
+    } catch (error) {
+      console.log('error', error);
+    }
+  };
+
   const makePurchase = async () => {
     Alert.prompt('Purchase Product', 'Enter Product ID for purchasing', [
       {
@@ -206,6 +216,12 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
         <View>
           <TouchableOpacity onPress={getByPlacement}>
             <Text style={styles.otherActions}>Offering by Placement</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={syncAttributesAndOfferings}>
+            <Text style={styles.otherActions}>
+              Sync attributes and offerings
+            </Text>
           </TouchableOpacity>
 
           <TouchableOpacity onPress={makePurchase}>

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
 import CustomerInfoHeader from '../components/CustomerInfoHeader';
 import RootStackParamList from '../RootStackParamList';
+import PromptWithTextInput from '../components/InputModal';
 
 interface State {
   appUserID: String | null;
@@ -113,27 +114,7 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
   };
 
   const getByPlacement = async () => {
-    Alert.prompt('Get by placement', 'Enter Placement ID', [
-      {
-        text: 'Cancel',
-        onPress: () => {
-          console.log('Cancel');
-        },
-        style: 'cancel',
-      },
-      {
-        text: 'OK',
-        onPress: async text => {
-          if (text && text.length > 0) {
-            let offering = await Purchases.getCurrentOfferingForPlacement(text);
-            console.log('Offering in RN: ', offering);
-            if (offering) {
-              navigation.navigate('OfferingDetail', {offering: offering});
-            }
-          }
-        },
-      },
-    ]);
+    setPromptPlacementVisible(true);
   };
 
   const makePurchase = async () => {
@@ -173,6 +154,24 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
     }
   };
 
+  const [promptPlacementVisible, setPromptPlacementVisible] = useState(false);
+  const handlePromptPlacementCancel = () => {
+    setPromptPlacementVisible(false);
+    console.log('User canceled input');
+  };
+  const handlePromptPlacementSubmit = async inputValue => {
+    setPromptPlacementVisible(false);
+    console.log('User submitted:', inputValue);
+
+    if (inputValue && inputValue.length > 0) {
+      let offering = await Purchases.getCurrentOfferingForPlacement(inputValue);
+      console.log('Offering in RN: ', offering);
+      if (offering) {
+        navigation.navigate('OfferingDetail', {offering: offering});
+      }
+    }
+  };
+
   return (
     <SafeAreaView>
       <ScrollView contentInsetAdjustmentBehavior="automatic">
@@ -196,6 +195,12 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
         <Divider />
 
         <View>{displayOfferings()}</View>
+
+        <PromptWithTextInput
+          isVisible={promptPlacementVisible}
+          onCancel={handlePromptPlacementCancel}
+          onSubmit={handlePromptPlacementSubmit}
+        />
 
         <Divider />
         <View>

--- a/examples/purchaseTesterTypescript/ios/Podfile.lock
+++ b/examples/purchaseTesterTypescript/ios/Podfile.lock
@@ -73,11 +73,11 @@ PODS:
   - hermes-engine/Pre-built (0.73.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - PurchasesHybridCommon (9.9.0):
-    - RevenueCat (= 4.37.0)
-  - PurchasesHybridCommonUI (9.9.0):
-    - PurchasesHybridCommon (= 9.9.0)
-    - RevenueCatUI (= 4.37.0)
+  - PurchasesHybridCommon (10.0.0):
+    - RevenueCat (= 4.38.1)
+  - PurchasesHybridCommonUI (10.0.0):
+    - PurchasesHybridCommon (= 10.0.0)
+    - RevenueCatUI (= 4.38.1)
   - RCT-Folly (2022.05.16.00):
     - boost
     - DoubleConversion
@@ -1118,14 +1118,14 @@ PODS:
     - React-jsi (= 0.73.5)
     - React-logger (= 0.73.5)
     - React-perflogger (= 0.73.5)
-  - RevenueCat (4.37.0)
-  - RevenueCatUI (4.37.0):
-    - RevenueCat (= 4.37.0)
-  - RNPaywalls (7.22.0):
-    - PurchasesHybridCommonUI (= 9.9.0)
+  - RevenueCat (4.38.1)
+  - RevenueCatUI (4.38.1):
+    - RevenueCat (= 4.38.1)
+  - RNPaywalls (7.23.0):
+    - PurchasesHybridCommonUI (= 10.0.0)
     - React-Core
-  - RNPurchases (7.22.0):
-    - PurchasesHybridCommon (= 9.9.0)
+  - RNPurchases (7.23.0):
+    - PurchasesHybridCommon (= 10.0.0)
     - React-Core
   - RNScreens (3.29.0):
     - glog
@@ -1359,8 +1359,8 @@ SPEC CHECKSUMS:
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  PurchasesHybridCommon: 42af1edb779902793424e6fc1c159727f7d56595
-  PurchasesHybridCommonUI: 988440ab3be1c114b64cf855b69f48f6235c95d7
+  PurchasesHybridCommon: b14d5dc2ff5dde751a7d8431e767662464316412
+  PurchasesHybridCommonUI: d79fa961602acf2b462656edd04147a6727dc855
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 2544c0f1081a5fa12e108bb8cb40e5f4581ccd87
   RCTTypeSafety: 50efabe2b115c11ed03fbf3fd79e2f163ddb5d7c
@@ -1403,10 +1403,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 814b644a5f456c7df1fba7bcd9914707152527c6
   React-utils: 987a4526a2fc0acdfaf87888adfe0bf9d0452066
   ReactCommon: 2947b0bffd82ea0e58ca7928881152d4c6dae9af
-  RevenueCat: b4fb058d7ced6a37327f6bc9636752dbc4a7235b
-  RevenueCatUI: adc29653d59fb7a333ed1834d4d9a67e2c87dc4c
-  RNPaywalls: 976a5b19a064346058ab3e6150a2e9feaab6def6
-  RNPurchases: 427fb68965d62582ac3ab73a581dc4af29f8b2c3
+  RevenueCat: f1b4bce353e676260eddc65a34c9fdf595adf2f4
+  RevenueCatUI: 73b7509e8dcae24933985acb89617658298125e3
+  RNPaywalls: caa5f040f666751a1196d6b9655b9d9ddabd3c9d
+  RNPurchases: 073a6b1c08c2b8649b95dd25d0ed18ccd2383db8
   RNScreens: 17e2f657f1b09a71ec3c821368a04acbb7ebcb46
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7

--- a/examples/purchaseTesterTypescript/ios/Podfile.lock
+++ b/examples/purchaseTesterTypescript/ios/Podfile.lock
@@ -73,10 +73,10 @@ PODS:
   - hermes-engine/Pre-built (0.73.5)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
-  - PurchasesHybridCommon (10.0.0):
+  - PurchasesHybridCommon (10.1.0):
     - RevenueCat (= 4.38.1)
-  - PurchasesHybridCommonUI (10.0.0):
-    - PurchasesHybridCommon (= 10.0.0)
+  - PurchasesHybridCommonUI (10.1.0):
+    - PurchasesHybridCommon (= 10.1.0)
     - RevenueCatUI (= 4.38.1)
   - RCT-Folly (2022.05.16.00):
     - boost
@@ -1122,10 +1122,10 @@ PODS:
   - RevenueCatUI (4.38.1):
     - RevenueCat (= 4.38.1)
   - RNPaywalls (7.23.0):
-    - PurchasesHybridCommonUI (= 10.0.0)
+    - PurchasesHybridCommonUI (= 10.1.0)
     - React-Core
   - RNPurchases (7.23.0):
-    - PurchasesHybridCommon (= 10.0.0)
+    - PurchasesHybridCommon (= 10.1.0)
     - React-Core
   - RNScreens (3.29.0):
     - glog
@@ -1359,8 +1359,8 @@ SPEC CHECKSUMS:
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  PurchasesHybridCommon: b14d5dc2ff5dde751a7d8431e767662464316412
-  PurchasesHybridCommonUI: d79fa961602acf2b462656edd04147a6727dc855
+  PurchasesHybridCommon: 7097641074121cec7117209e1f72c08a29e6c506
+  PurchasesHybridCommonUI: 8409ce2362d25e5263165b7d54333da5a0305f21
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 2544c0f1081a5fa12e108bb8cb40e5f4581ccd87
   RCTTypeSafety: 50efabe2b115c11ed03fbf3fd79e2f163ddb5d7c
@@ -1405,8 +1405,8 @@ SPEC CHECKSUMS:
   ReactCommon: 2947b0bffd82ea0e58ca7928881152d4c6dae9af
   RevenueCat: f1b4bce353e676260eddc65a34c9fdf595adf2f4
   RevenueCatUI: 73b7509e8dcae24933985acb89617658298125e3
-  RNPaywalls: caa5f040f666751a1196d6b9655b9d9ddabd3c9d
-  RNPurchases: 073a6b1c08c2b8649b95dd25d0ed18ccd2383db8
+  RNPaywalls: d9f5c1b14acda937de145be0911364d3454bff81
+  RNPurchases: f56077a333c6b75e971be672b7639a536c787a42
   RNScreens: 17e2f657f1b09a71ec3c821368a04acbb7ebcb46
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -76,6 +76,15 @@ RCT_REMAP_METHOD(getOfferings,
                                                                                                 reject:reject]];
 }
 
+RCT_EXPORT_METHOD(getCurrentOfferingForPlacement:(NSString *)placementIdentifier
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+
+    [RCCommonFunctionality getCurrentOfferingForPlacement:placementIdentifier completionBlock:^(NSDictionary *offeringObject, NSError *error) {
+        resolve(offeringObject);
+    }];
+}
+
 RCT_EXPORT_METHOD(getProductInfo:(NSArray *)products
                   type:(NSString *)type
                   resolve:(RCTPromiseResolveBlock)resolve
@@ -92,6 +101,7 @@ RCT_REMAP_METHOD(purchaseProduct,
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
                  googleInfo:(NSDictionary *)googleInfo
                  presentedOfferingIdentifier:(NSString *)presentedOfferingIdentifier
+                 presentedOfferingContext:(NSDictionary *)presentedOfferingDictionary
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchaseProduct:productIdentifier
@@ -103,6 +113,7 @@ RCT_REMAP_METHOD(purchaseProduct,
 RCT_REMAP_METHOD(purchasePackage,
                  purchasePackage:(NSString *)packageIdentifier
                  offeringIdentifier:(NSString *)offeringIdentifier
+                 presentedOfferingContext:(NSDictionary *)presentedOfferingContext
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
                  googleInfo:(NSDictionary *)googleInfo
@@ -110,6 +121,7 @@ RCT_REMAP_METHOD(purchasePackage,
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchasePackage:packageIdentifier
                                   offering:offeringIdentifier
+                  presentedOfferingContext:presentedOfferingContext
                    signedDiscountTimestamp:signedDiscountTimestamp
                            completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
 }

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -76,6 +76,13 @@ RCT_REMAP_METHOD(getOfferings,
                                                                                                 reject:reject]];
 }
 
+RCT_REMAP_METHOD(syncAttributesAndOfferingsIfNeeded,
+                 syncAttributesAndOfferingsIfNeededWithResolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject) {
+    [RCCommonFunctionality syncAttributesAndOfferingsIfNeededWithCompletionBlock:[self getResponseCompletionBlockWithResolve:resolve
+                                                                                                reject:reject]];
+}
+
 RCT_EXPORT_METHOD(getCurrentOfferingForPlacement:(NSString *)placementIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
@@ -84,6 +91,8 @@ RCT_EXPORT_METHOD(getCurrentOfferingForPlacement:(NSString *)placementIdentifier
         resolve(offeringObject);
     }];
 }
+
+//syncAttributesAndOfferingsIfNeeded
 
 RCT_EXPORT_METHOD(getProductInfo:(NSArray *)products
                   type:(NSString *)type

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(getCurrentOfferingForPlacement:(NSString *)placementIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
 
-    [RCCommonFunctionality getCurrentOfferingForPlacement:placementIdentifier completionBlock:^(NSDictionary *offeringObject, NSError *error) {
+    [RCCommonFunctionality getCurrentOfferingForPlacement:placementIdentifier completionBlock:^(NSDictionary *offeringObject, RCErrorContainer *error) {
         resolve(offeringObject);
     }];
 }
@@ -121,7 +121,6 @@ RCT_REMAP_METHOD(purchaseProduct,
 
 RCT_REMAP_METHOD(purchasePackage,
                  purchasePackage:(NSString *)packageIdentifier
-                 offeringIdentifier:(NSString *)offeringIdentifier
                  presentedOfferingContext:(NSDictionary *)presentedOfferingContext
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
@@ -129,7 +128,6 @@ RCT_REMAP_METHOD(purchasePackage,
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchasePackage:packageIdentifier
-                                  offering:offeringIdentifier
                   presentedOfferingContext:presentedOfferingContext
                    signedDiscountTimestamp:signedDiscountTimestamp
                            completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];

--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -114,7 +114,7 @@
     ]
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal": "8.10.1",
+    "@revenuecat/purchases-typescript-internal": "10.0.0",
     "react-native-purchases": "7.23.0"
   }
 }

--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -114,7 +114,7 @@
     ]
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal": "10.0.0",
+    "@revenuecat/purchases-typescript-internal": "10.1.0",
     "react-native-purchases": "7.23.0"
   }
 }

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -687,6 +687,21 @@ global.offeringsStub = {
   }
 };
 
+global.currentOfferingForPlacementStub = {
+  offeringIdentifier: 'default',
+  product: {
+    introPrice: null,
+    description: 'Product with intro price',
+    currencyCode: 'USD',
+    priceString: '$9.99',
+    price: 9.99,
+    title: 'Introductory Price (PurchasesSample)',
+    identifier: 'introductory_price'
+  },
+  packageType: 'WEEKLY',
+  identifier: '$rc_weekly'
+}
+
 global.productStub = {
   currencyCode: "USD",
   introPrice: null,
@@ -748,6 +763,8 @@ NativeModules.RNPurchases = {
   setAllowSharingStoreAccount: jest.fn(),
   addAttributionData: jest.fn(),
   getOfferings: jest.fn(),
+  getCurrentOfferingForPlacement: jest.fn(),
+  syncAttributesAndOfferingsIfNeeded: jest.fn(),
   getProductInfo: jest.fn(),
   makePurchase: jest.fn(),
   restorePurchases: jest.fn(),

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -400,7 +400,6 @@ export default class Purchases {
       type,
       null,
       null,
-      null,
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
@@ -437,7 +436,6 @@ export default class Purchases {
       googleIsPersonalizedPrice == null
         ? null
         : { isPersonalizedPrice: googleIsPersonalizedPrice },
-      product.presentedOfferingIdentifier,
       product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
@@ -473,7 +471,6 @@ export default class Purchases {
       null,
       discount.timestamp.toString(),
       null,
-      product.presentedOfferingIdentifier,
       product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
@@ -506,7 +503,6 @@ export default class Purchases {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchasePackage(
       aPackage.identifier,
-      aPackage.offeringIdentifier,
       aPackage.presentedOfferingContext,
       googleProductChangeInfo || upgradeInfo,
       null,
@@ -549,7 +545,6 @@ export default class Purchases {
       googleIsPersonalizedPrice == null
         ? null
         : { isPersonalizedPrice: googleIsPersonalizedPrice },
-      subscriptionOption.presentedOfferingIdentifier,
       subscriptionOption.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -395,6 +395,7 @@ export default class Purchases {
       type,
       null,
       null,
+      null,
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
@@ -431,7 +432,8 @@ export default class Purchases {
       googleIsPersonalizedPrice == null
         ? null
         : { isPersonalizedPrice: googleIsPersonalizedPrice },
-      product.presentedOfferingIdentifier
+      product.presentedOfferingIdentifier,
+      product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -466,7 +468,8 @@ export default class Purchases {
       null,
       discount.timestamp.toString(),
       null,
-      product.presentedOfferingIdentifier
+      product.presentedOfferingIdentifier,
+      product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -541,7 +544,8 @@ export default class Purchases {
       googleIsPersonalizedPrice == null
         ? null
         : { isPersonalizedPrice: googleIsPersonalizedPrice },
-      subscriptionOption.presentedOfferingIdentifier
+      subscriptionOption.presentedOfferingIdentifier,
+      subscriptionOption.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -1,4 +1,4 @@
-import {NativeEventEmitter, NativeModules} from "react-native";
+import { NativeEventEmitter, NativeModules } from "react-native";
 import {
   PurchasesError,
   PURCHASES_ERROR_CODE,
@@ -31,8 +31,9 @@ import {
   LogInResult,
   IN_APP_MESSAGE_TYPE,
   ENTITLEMENT_VERIFICATION_MODE,
-  VERIFICATION_RESULT
-} from '@revenuecat/purchases-typescript-internal';
+  VERIFICATION_RESULT,
+  PurchasesOffering,
+} from "@revenuecat/purchases-typescript-internal";
 
 // This export is kept to keep backwards compatibility to any possible users using this file directly
 export {
@@ -45,29 +46,30 @@ export {
   ShouldPurchasePromoProductListener,
   MakePurchaseResult,
   LogHandler,
-  LogInResult
-} from '@revenuecat/purchases-typescript-internal';
+  LogInResult,
+} from "@revenuecat/purchases-typescript-internal";
 
-import {Platform} from "react-native";
+import { Platform } from "react-native";
 
-const {RNPurchases} = NativeModules;
+const { RNPurchases } = NativeModules;
 const eventEmitter = new NativeEventEmitter(RNPurchases);
 
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
-let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] = [];
+let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
+  [];
 let customLogHandler: LogHandler;
 
 eventEmitter.addListener(
   "Purchases-CustomerInfoUpdated",
   (customerInfo: CustomerInfo) => {
-    customerInfoUpdateListeners.forEach(listener => listener(customerInfo));
+    customerInfoUpdateListeners.forEach((listener) => listener(customerInfo));
   }
 );
 
 eventEmitter.addListener(
   "Purchases-ShouldPurchasePromoProduct",
-  ({callbackID}: { callbackID: number }) => {
-    shouldPurchasePromoProductListeners.forEach(listener =>
+  ({ callbackID }: { callbackID: number }) => {
+    shouldPurchasePromoProductListeners.forEach((listener) =>
       listener(() => RNPurchases.makeDeferredPurchase(callbackID))
     );
   }
@@ -75,7 +77,7 @@ eventEmitter.addListener(
 
 eventEmitter.addListener(
   "Purchases-LogHandlerEvent",
-  ({logLevel, message}: { logLevel: LOG_LEVEL, message: string }) => {
+  ({ logLevel, message }: { logLevel: LOG_LEVEL; message: string }) => {
     const logLevelEnum = LOG_LEVEL[logLevel];
     customLogHandler(logLevelEnum, message);
   }
@@ -193,20 +195,26 @@ export default class Purchases {
    * Default is null, which will make the SDK use standardUserDefaults.
    */
   public static configure({
-                            apiKey,
-                            appUserID = null,
-                            observerMode = false,
-                            userDefaultsSuiteName,
-                            usesStoreKit2IfAvailable = false,
-                            useAmazon = false,
-                            shouldShowInAppMessagesAutomatically = true,
-                            entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED
-                          }: PurchasesConfiguration): void {
+    apiKey,
+    appUserID = null,
+    observerMode = false,
+    userDefaultsSuiteName,
+    usesStoreKit2IfAvailable = false,
+    useAmazon = false,
+    shouldShowInAppMessagesAutomatically = true,
+    entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED,
+  }: PurchasesConfiguration): void {
     if (apiKey === undefined || typeof apiKey !== "string") {
-      throw new Error("Invalid API key. It must be called with an Object: configure({apiKey: \"key\"})");
+      throw new Error(
+        'Invalid API key. It must be called with an Object: configure({apiKey: "key"})'
+      );
     }
 
-    if (appUserID !== null && typeof appUserID !== "undefined" && typeof appUserID !== "string") {
+    if (
+      appUserID !== null &&
+      typeof appUserID !== "undefined" &&
+      typeof appUserID !== "string"
+    ) {
       throw new Error("appUserID needs to be a string");
     }
 
@@ -230,7 +238,9 @@ export default class Purchases {
    * this is true by default if you didn't pass an appUserID
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
-  public static async setAllowSharingStoreAccount(allowSharing: boolean): Promise<void> {
+  public static async setAllowSharingStoreAccount(
+    allowSharing: boolean
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setAllowSharingStoreAccount(allowSharing);
   }
@@ -240,7 +250,9 @@ export default class Purchases {
    * make the purchase
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
-  public static async setFinishTransactions(finishTransactions: boolean): Promise<void> {
+  public static async setFinishTransactions(
+    finishTransactions: boolean
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setFinishTransactions(finishTransactions);
   }
@@ -251,7 +263,9 @@ export default class Purchases {
    * purchases flow. More information: http://errors.rev.cat/ask-to-buy
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
-  public static async setSimulatesAskToBuyInSandbox(simulatesAskToBuyInSandbox: boolean): Promise<void> {
+  public static async setSimulatesAskToBuyInSandbox(
+    simulatesAskToBuyInSandbox: boolean
+  ): Promise<void> {
     if (Platform.OS === "ios") {
       RNPurchases.setSimulatesAskToBuyInSandbox(simulatesAskToBuyInSandbox);
     }
@@ -280,7 +294,7 @@ export default class Purchases {
   ): boolean {
     if (customerInfoUpdateListeners.includes(listenerToRemove)) {
       customerInfoUpdateListeners = customerInfoUpdateListeners.filter(
-        listener => listenerToRemove !== listener
+        (listener) => listenerToRemove !== listener
       );
       return true;
     }
@@ -302,7 +316,9 @@ export default class Purchases {
     if (typeof shouldPurchasePromoProductListener !== "function") {
       throw new Error("addShouldPurchasePromoProductListener needs a function");
     }
-    shouldPurchasePromoProductListeners.push(shouldPurchasePromoProductListener);
+    shouldPurchasePromoProductListeners.push(
+      shouldPurchasePromoProductListener
+    );
   }
 
   /**
@@ -315,9 +331,10 @@ export default class Purchases {
     listenerToRemove: ShouldPurchasePromoProductListener
   ): boolean {
     if (shouldPurchasePromoProductListeners.includes(listenerToRemove)) {
-      shouldPurchasePromoProductListeners = shouldPurchasePromoProductListeners.filter(
-        listener => listenerToRemove !== listener
-      );
+      shouldPurchasePromoProductListeners =
+        shouldPurchasePromoProductListeners.filter(
+          (listener) => listenerToRemove !== listener
+        );
       return true;
     }
     return false;
@@ -331,6 +348,13 @@ export default class Purchases {
   public static async getOfferings(): Promise<PurchasesOfferings> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.getOfferings();
+  }
+
+  public static async getCurrentOfferingForPlacement(
+    placementIdentifier: string
+  ): Promise<PurchasesOffering | null> {
+    await Purchases.throwIfNotConfigured();
+    return RNPurchases.getCurrentOfferingForPlacement(placementIdentifier);
   }
 
   /**
@@ -362,7 +386,7 @@ export default class Purchases {
   public static async purchaseProduct(
     productIdentifier: string,
     upgradeInfo?: UpgradeInfo | null,
-    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS,
+    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
@@ -373,7 +397,8 @@ export default class Purchases {
       null,
       null
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -395,7 +420,7 @@ export default class Purchases {
   public static async purchaseStoreProduct(
     product: PurchasesStoreProduct,
     googleProductChangeInfo?: GoogleProductChangeInfo | null,
-    googleIsPersonalizedPrice?: boolean | null,
+    googleIsPersonalizedPrice?: boolean | null
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
@@ -403,10 +428,13 @@ export default class Purchases {
       googleProductChangeInfo,
       product.productCategory,
       null,
-      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
+      googleIsPersonalizedPrice == null
+        ? null
+        : { isPersonalizedPrice: googleIsPersonalizedPrice },
       product.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -426,7 +454,7 @@ export default class Purchases {
    */
   public static async purchaseDiscountedProduct(
     product: PurchasesStoreProduct,
-    discount: PurchasesPromotionalOffer,
+    discount: PurchasesPromotionalOffer
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     if (typeof discount === "undefined" || discount == null) {
@@ -440,7 +468,8 @@ export default class Purchases {
       null,
       product.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -464,17 +493,21 @@ export default class Purchases {
     aPackage: PurchasesPackage,
     upgradeInfo?: UpgradeInfo | null,
     googleProductChangeInfo?: GoogleProductChangeInfo | null,
-    googleIsPersonalizedPrice?: boolean | null,
+    googleIsPersonalizedPrice?: boolean | null
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.purchasePackage(
       aPackage.identifier,
       aPackage.offeringIdentifier,
+      aPackage.presentedOfferingContext,
       googleProductChangeInfo || upgradeInfo,
       null,
-      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
+      googleIsPersonalizedPrice == null
+        ? null
+        : { isPersonalizedPrice: googleIsPersonalizedPrice }
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -496,7 +529,7 @@ export default class Purchases {
   public static async purchaseSubscriptionOption(
     subscriptionOption: SubscriptionOption,
     googleProductChangeInfo?: GoogleProductChangeInfo,
-    googleIsPersonalizedPrice?: boolean,
+    googleIsPersonalizedPrice?: boolean
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
     await Purchases.throwIfIOSPlatform();
@@ -505,10 +538,13 @@ export default class Purchases {
       subscriptionOption.id,
       googleProductChangeInfo,
       null,
-      googleIsPersonalizedPrice == null ? null : {isPersonalizedPrice: googleIsPersonalizedPrice},
+      googleIsPersonalizedPrice == null
+        ? null
+        : { isPersonalizedPrice: googleIsPersonalizedPrice },
       subscriptionOption.presentedOfferingIdentifier
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -536,9 +572,10 @@ export default class Purchases {
       aPackage.offeringIdentifier,
       null,
       discount.timestamp.toString(),
-      null,
+      null
     ).catch((error: PurchasesError) => {
-      error.userCancelled = error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+      error.userCancelled =
+        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -658,12 +695,22 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * syncing purchases.
    */
-  public static async syncObserverModeAmazonPurchase(productID: string, receiptID: string,
-                                                     amazonUserID: string, isoCurrencyCode?: string | null,
-                                                     price?: number | null): Promise<void> {
+  public static async syncObserverModeAmazonPurchase(
+    productID: string,
+    receiptID: string,
+    amazonUserID: string,
+    isoCurrencyCode?: string | null,
+    price?: number | null
+  ): Promise<void> {
     await Purchases.throwIfIOSPlatform();
     await Purchases.throwIfNotConfigured();
-    RNPurchases.syncObserverModeAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode, price);
+    RNPurchases.syncObserverModeAmazonPurchase(
+      productID,
+      receiptID,
+      amazonUserID,
+      isoCurrencyCode,
+      price
+    );
   }
 
   /**
@@ -792,7 +839,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or there's an error
    * setting the subscriber attributes.
    */
-  public static async setAttributes(attributes: { [key: string]: string | null }): Promise<void> {
+  public static async setAttributes(attributes: {
+    [key: string]: string | null;
+  }): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setAttributes(attributes);
   }
@@ -816,7 +865,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the phone number.
    */
-  public static async setPhoneNumber(phoneNumber: string | null): Promise<void> {
+  public static async setPhoneNumber(
+    phoneNumber: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setPhoneNumber(phoneNumber);
   }
@@ -828,7 +879,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the display name.
    */
-  public static async setDisplayName(displayName: string | null): Promise<void> {
+  public static async setDisplayName(
+    displayName: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setDisplayName(displayName);
   }
@@ -841,7 +894,7 @@ export default class Purchases {
    * setting the push token.
    */
   public static async setPushToken(pushToken: string | null): Promise<void> {
-    await Purchases.throwIfNotConfigured()
+    await Purchases.throwIfNotConfigured();
     RNPurchases.setPushToken(pushToken);
   }
 
@@ -888,7 +941,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Appsflyer ID.
    */
-  public static async setAppsflyerID(appsflyerID: string | null): Promise<void> {
+  public static async setAppsflyerID(
+    appsflyerID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setAppsflyerID(appsflyerID);
   }
@@ -901,7 +956,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Facebook Anonymous ID.
    */
-  public static async setFBAnonymousID(fbAnonymousID: string | null): Promise<void> {
+  public static async setFBAnonymousID(
+    fbAnonymousID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setFBAnonymousID(fbAnonymousID);
   }
@@ -914,7 +971,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Mparticle ID.
    */
-  public static async setMparticleID(mparticleID: string | null): Promise<void> {
+  public static async setMparticleID(
+    mparticleID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setMparticleID(mparticleID);
   }
@@ -927,7 +986,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the CleverTap ID.
    */
-  public static async setCleverTapID(cleverTapID: string | null): Promise<void> {
+  public static async setCleverTapID(
+    cleverTapID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setCleverTapID(cleverTapID);
   }
@@ -940,7 +1001,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Mixpanel Distinct ID.
    */
-  public static async setMixpanelDistinctID(mixpanelDistinctID: string | null): Promise<void> {
+  public static async setMixpanelDistinctID(
+    mixpanelDistinctID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setMixpanelDistinctID(mixpanelDistinctID);
   }
@@ -953,7 +1016,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Firebase App Instance ID.
    */
-  public static async setFirebaseAppInstanceID(firebaseAppInstanceID: string | null): Promise<void> {
+  public static async setFirebaseAppInstanceID(
+    firebaseAppInstanceID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setFirebaseAppInstanceID(firebaseAppInstanceID);
   }
@@ -966,7 +1031,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the OneSignal ID.
    */
-  public static async setOnesignalID(onesignalID: string | null): Promise<void> {
+  public static async setOnesignalID(
+    onesignalID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setOnesignalID(onesignalID);
   }
@@ -979,7 +1046,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the Airship Channel ID.
    */
-  public static async setAirshipChannelID(airshipChannelID: string | null): Promise<void> {
+  public static async setAirshipChannelID(
+    airshipChannelID: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setAirshipChannelID(airshipChannelID);
   }
@@ -991,7 +1060,9 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
    * setting the media source.
    */
-  public static async setMediaSource(mediaSource: string | null): Promise<void> {
+  public static async setMediaSource(
+    mediaSource: string | null
+  ): Promise<void> {
     await Purchases.throwIfNotConfigured();
     RNPurchases.setMediaSource(mediaSource);
   }
@@ -1067,7 +1138,9 @@ export default class Purchases {
    *       [BILLING_FEATURE]. By default, is an empty list and no specific feature support will be checked.
    * @returns {Promise<boolean>} promise with boolean response. True if billing is supported, false otherwise.
    */
-  public static canMakePayments(features: BILLING_FEATURE[] = []): Promise<boolean> {
+  public static canMakePayments(
+    features: BILLING_FEATURE[] = []
+  ): Promise<boolean> {
     return RNPurchases.canMakePayments(features);
   }
 
@@ -1089,9 +1162,10 @@ export default class Purchases {
   public static async beginRefundRequestForActiveEntitlement(): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
     await Purchases.throwIfAndroidPlatform();
-    const refundRequestStatusInt = await RNPurchases.beginRefundRequestForActiveEntitlement();
+    const refundRequestStatusInt =
+      await RNPurchases.beginRefundRequestForActiveEntitlement();
     if (refundRequestStatusInt == null) {
-      throw new UnsupportedPlatformError()
+      throw new UnsupportedPlatformError();
     }
     return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
   }
@@ -1107,12 +1181,17 @@ export default class Purchases {
    * @returns {Promise<REFUND_REQUEST_STATUS>} Returns REFUND_REQUEST_STATUS: The status of the
    *  refund request. Keep in mind the status could be REFUND_REQUEST_STATUS.USER_CANCELLED
    */
-  public static async beginRefundRequestForEntitlement(entitlementInfo: PurchasesEntitlementInfo): Promise<REFUND_REQUEST_STATUS> {
+  public static async beginRefundRequestForEntitlement(
+    entitlementInfo: PurchasesEntitlementInfo
+  ): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
     await Purchases.throwIfAndroidPlatform();
-    const refundRequestStatusInt = await RNPurchases.beginRefundRequestForEntitlementId(entitlementInfo.identifier);
+    const refundRequestStatusInt =
+      await RNPurchases.beginRefundRequestForEntitlementId(
+        entitlementInfo.identifier
+      );
     if (refundRequestStatusInt == null) {
-      throw new UnsupportedPlatformError()
+      throw new UnsupportedPlatformError();
     }
     return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
   }
@@ -1128,12 +1207,15 @@ export default class Purchases {
    * @returns {Promise<REFUND_REQUEST_STATUS>} Returns a REFUND_REQUEST_STATUS: The status of the
    *  refund request. Keep in mind the status could be REFUND_REQUEST_STATUS.USER_CANCELLED
    */
-  public static async beginRefundRequestForProduct(storeProduct: PurchasesStoreProduct): Promise<REFUND_REQUEST_STATUS> {
+  public static async beginRefundRequestForProduct(
+    storeProduct: PurchasesStoreProduct
+  ): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
     await Purchases.throwIfAndroidPlatform();
-    const refundRequestStatusInt = await RNPurchases.beginRefundRequestForProductId(storeProduct.identifier);
+    const refundRequestStatusInt =
+      await RNPurchases.beginRefundRequestForProductId(storeProduct.identifier);
     if (refundRequestStatusInt == null) {
-      throw new UnsupportedPlatformError()
+      throw new UnsupportedPlatformError();
     }
     return Purchases.convertIntToRefundRequestStatus(refundRequestStatusInt);
   }
@@ -1149,10 +1231,12 @@ export default class Purchases {
    *       [IN_APP_MESSAGE_TYPE]. By default, is undefined and all message types will be shown.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
-    public static async showInAppMessages(messageTypes?: IN_APP_MESSAGE_TYPE[]): Promise<void> {
-      await Purchases.throwIfNotConfigured();
-      return RNPurchases.showInAppMessages(messageTypes);
-    }
+  public static async showInAppMessages(
+    messageTypes?: IN_APP_MESSAGE_TYPE[]
+  ): Promise<void> {
+    await Purchases.throwIfNotConfigured();
+    return RNPurchases.showInAppMessages(messageTypes);
+  }
 
   /**
    * Check if configure has finished and Purchases has been configured.
@@ -1172,17 +1256,19 @@ export default class Purchases {
 
   private static async throwIfAndroidPlatform() {
     if (Platform.OS === "android") {
-      throw new UnsupportedPlatformError()
+      throw new UnsupportedPlatformError();
     }
   }
 
   private static async throwIfIOSPlatform() {
     if (Platform.OS === "ios") {
-      throw new UnsupportedPlatformError()
+      throw new UnsupportedPlatformError();
     }
   }
 
-  private static convertIntToRefundRequestStatus(refundRequestStatusInt: number): REFUND_REQUEST_STATUS {
+  private static convertIntToRefundRequestStatus(
+    refundRequestStatusInt: number
+  ): REFUND_REQUEST_STATUS {
     switch (refundRequestStatusInt) {
       case 0:
         return REFUND_REQUEST_STATUS.SUCCESS;

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -357,6 +357,11 @@ export default class Purchases {
     return RNPurchases.getCurrentOfferingForPlacement(placementIdentifier);
   }
 
+  public static async syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings> {
+    await Purchases.throwIfNotConfigured();
+    return RNPurchases.syncAttributesAndOfferingsIfNeeded();
+  }
+
   /**
    * Fetch the product info
    * @param {String[]} productIdentifiers Array of product identifiers

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -350,6 +350,13 @@ export default class Purchases {
     return RNPurchases.getOfferings();
   }
 
+  /**
+   * Retrieves a current offering for a placement identifier, use this to access offerings defined by targeting
+   * placements configured in the RevenueCat dashboard.
+   * @param {String} placementIdentifier The placement identifier to fetch a current offeringn for
+   * @returns {Promise<PurchasesOffering | null>} Promise of an optional offering. The promise will be rejected if configure
+   * has not been called yet.
+   */
   public static async getCurrentOfferingForPlacement(
     placementIdentifier: string
   ): Promise<PurchasesOffering | null> {
@@ -357,6 +364,13 @@ export default class Purchases {
     return RNPurchases.getCurrentOfferingForPlacement(placementIdentifier);
   }
 
+  /**
+   * Syncs subscriber attributes and then fetches the configured offerings for this user. This method is intended to
+   * be called when using Targeting Rules with Custom Attributes. Any subscriber attributes should be set before
+   * calling this method to ensure the returned offerings are applied with the latest subscriber attributes.
+   * @returns {Promise<PurchasesOfferings>} Promise of entitlements structure. The promise will be rejected if configure
+   * has not been called yet.
+   */
   public static async syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings> {
     await Purchases.throwIfNotConfigured();
     return RNPurchases.syncAttributesAndOfferingsIfNeeded();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,13 +2537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@revenuecat/purchases-typescript-internal@npm:8.10.1":
-  version: 8.10.1
-  resolution: "@revenuecat/purchases-typescript-internal@npm:8.10.1"
-  checksum: 1563bb24fd326d5b1cc584b563ea48dbb2a4f50908d8955e704782f8646770e47a74221e89a3dd21733f6fc2201914e406c7aca6cde6fe4fab1ee890cf2189c0
-  languageName: node
-  linkType: hard
-
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -6966,7 +6959,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-purchases-ui@workspace:react-native-purchases-ui"
   dependencies:
-    "@revenuecat/purchases-typescript-internal": 8.10.1
+    "@revenuecat/purchases-typescript-internal": 10.0.0
     "@types/jest": ^29.5.12
     "@types/react": ^18.2.44
     "@types/react-dom": ~18.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6959,7 +6959,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-purchases-ui@workspace:react-native-purchases-ui"
   dependencies:
-    "@revenuecat/purchases-typescript-internal": 10.0.0
+    "@revenuecat/purchases-typescript-internal": 10.1.0
     "@types/jest": ^29.5.12
     "@types/react": ^18.2.44
     "@types/react-dom": ~18.2.0


### PR DESCRIPTION
## Motivation

Bump to PHC `10.1.0` and add support for new Targeting methods

## Description

### Get Current Offering for Placement

Get an offering specific to the place of your paywall (eg: onboarding, settings, feature gate, etc). This is determined by Targeting.

```ts
let offering = await Purchases.getCurrentOfferingForPlacement("your-placement-identifier")
if (offering) {
    // Navigate to paywall
} else {
    // Do nothing or continue to another screen
}
```

### Sync Attributes and Offerings

A blocking call to sync attributes and fetch new offerings to to be used with Targeting that uses Custom Attributes.

```ts
// Using this result is optional - offerings will be cached for next Purchases.getOfferings() call
let offerings = await Purchases.syncAttributesAndOfferingsIfNeeded()
```