### PR TITLE
Fix issue with iOS purchaseProduct arguments

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -109,7 +109,6 @@ RCT_REMAP_METHOD(purchaseProduct,
                  type:(NSString *)type
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
                  googleInfo:(NSDictionary *)googleInfo
-                 presentedOfferingIdentifier:(NSString *)presentedOfferingIdentifier
                  presentedOfferingContext:(NSDictionary *)presentedOfferingDictionary
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
## Motivation

Fixes #949

## Description

There was an extra `presentedOfferingIdentifier` in the `RCT_REMAP_METHOD` for `purchaseProduct`
