### PR TITLE
Remove usage of RCTEventEmitter in Android

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -86,15 +86,13 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         themedReactContext: ThemedReactContext,
         view: View
     ) = object : PaywallListenerWrapper() {
-        private val surfaceId = view.surfaceId
-        private val viewId = view.id
-
         override fun onPurchaseStarted(rcPackage: Map<String, Any?>) {
             val event = OnPurchaseStartedEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId, rcPackage
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
+                rcPackage
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onPurchaseCompleted(
@@ -102,55 +100,55 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
             storeTransaction: Map<String, Any?>
         ) {
             val event = OnPurchaseCompletedEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
                 customerInfo,
                 storeTransaction
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onPurchaseError(error: Map<String, Any?>) {
             val event = OnPurchaseErrorEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
                 error
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onPurchaseCancelled() {
             val event = OnPurchaseCancelledEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onRestoreStarted() {
             val event = OnRestoreStartedEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onRestoreCompleted(customerInfo: Map<String, Any?>) {
             val event = OnRestoreCompletedEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
                 customerInfo,
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
         override fun onRestoreError(error: Map<String, Any?>) {
             val event = OnRestoreErrorEvent(
-                surfaceId = surfaceId,
-                viewTag = viewId,
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
                 error,
             )
-            emitEvent(themedReactContext, viewId, event)
+            emitEvent(themedReactContext, view.id, event)
         }
 
     }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -81,8 +81,6 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         }
     }
 
-    // TODO: RCTEventEmitter is deprecated, and RCTModernEventEmitter should be used instead
-    // but documentation is not clear on how to use it so keeping this for now
     internal fun createPaywallListenerWrapper(
         themedReactContext: ThemedReactContext,
         view: View
@@ -125,10 +123,8 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
     internal fun getDismissHandler(
         themedReactContext: ThemedReactContext,
         view: T
-    ): (() -> Unit) {
-        return {
-            emitEvent(themedReactContext, view.id, OnDismissEvent())
-        }
+    ): (() -> Unit) = {
+        emitEvent(themedReactContext, view.id, OnDismissEvent())
     }
 
     private fun MapBuilder.Builder<String, Any>.putEvent(

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -60,7 +60,8 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
     }
 
     private fun setOfferingIdProp(view: T, props: ReadableMap?) {
-        val offeringIdentifier = props?.getDynamic(OPTION_OFFERING)?.asMap()?.getString(OFFERING_IDENTIFIER)
+        val offeringIdentifier =
+            props?.getDynamic(OPTION_OFFERING)?.asMap()?.getString(OFFERING_IDENTIFIER)
         offeringIdentifier?.let {
             setOfferingId(view, it)
         }
@@ -85,46 +86,81 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         themedReactContext: ThemedReactContext,
         view: View
     ) = object : PaywallListenerWrapper() {
+        private val surfaceId = view.surfaceId
+        private val viewId = view.id
 
         override fun onPurchaseStarted(rcPackage: Map<String, Any?>) {
-            emitEvent(themedReactContext, view.id, OnPurchaseStartedEvent(rcPackage))
+            val event = OnPurchaseStartedEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId, rcPackage
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onPurchaseCompleted(
             customerInfo: Map<String, Any?>,
             storeTransaction: Map<String, Any?>
         ) {
-            val event = OnPurchaseCompletedEvent(customerInfo, storeTransaction)
-            emitEvent(themedReactContext, view.id, event)
+            val event = OnPurchaseCompletedEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+                customerInfo,
+                storeTransaction
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onPurchaseError(error: Map<String, Any?>) {
-            emitEvent(themedReactContext, view.id, OnPurchaseErrorEvent(error))
+            val event = OnPurchaseErrorEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+                error
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onPurchaseCancelled() {
-            emitEvent(themedReactContext, view.id, OnPurchaseCancelledEvent())
+            val event = OnPurchaseCancelledEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onRestoreStarted() {
-            emitEvent(themedReactContext, view.id, OnRestoreStartedEvent())
+            val event = OnRestoreStartedEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onRestoreCompleted(customerInfo: Map<String, Any?>) {
-            emitEvent(themedReactContext, view.id, OnRestoreCompletedEvent(customerInfo))
+            val event = OnRestoreCompletedEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+                customerInfo,
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
         override fun onRestoreError(error: Map<String, Any?>) {
-            emitEvent(themedReactContext, view.id, OnRestoreErrorEvent(error))
+            val event = OnRestoreErrorEvent(
+                surfaceId = surfaceId,
+                viewTag = viewId,
+                error,
+            )
+            emitEvent(themedReactContext, viewId, event)
         }
 
     }
 
     internal fun getDismissHandler(
         themedReactContext: ThemedReactContext,
-        view: T
+        view: View,
     ): (() -> Unit) = {
-        emitEvent(themedReactContext, view.id, OnDismissEvent())
+        val event = OnDismissEvent(view.surfaceId, view.id)
+        emitEvent(themedReactContext, view.id, event)
     }
 
     private fun MapBuilder.Builder<String, Any>.putEvent(
@@ -146,7 +182,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         viewId: Int,
         event: Event<*>,
     ) {
-        UIManagerHelper.getEventDispatcherForReactTag(context, viewId)?.dispatchEvent(event)
+        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, viewId)
+        eventDispatcher?.dispatchEvent(event)
     }
-
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.react.ui
 
-enum class PaywallEventName(val eventName: String) {
+internal enum class PaywallEventName(val eventName: String) {
     ON_PURCHASE_STARTED("onPurchaseStarted"),
     ON_PURCHASE_COMPLETED("onPurchaseCompleted"),
     ON_PURCHASE_ERROR("onPurchaseError"),
@@ -11,7 +11,7 @@ enum class PaywallEventName(val eventName: String) {
     ON_DISMISS("onDismiss");
 }
 
-enum class PaywallEventKey(val key: String) {
+internal enum class PaywallEventKey(val key: String) {
     PACKAGE("packageBeingPurchased"),
     CUSTOMER_INFO("customerInfo"),
     STORE_TRANSACTION("storeTransaction"),

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
@@ -1,6 +1,6 @@
 package com.revenuecat.purchases.react.ui
 
-internal enum class PaywallEvent(val eventName: String) {
+enum class PaywallEventName(val eventName: String) {
     ON_PURCHASE_STARTED("onPurchaseStarted"),
     ON_PURCHASE_COMPLETED("onPurchaseCompleted"),
     ON_PURCHASE_ERROR("onPurchaseError"),
@@ -11,7 +11,7 @@ internal enum class PaywallEvent(val eventName: String) {
     ON_DISMISS("onDismiss");
 }
 
-internal enum class PaywallEventKey(val key: String) {
+enum class PaywallEventKey(val key: String) {
     PACKAGE("packageBeingPurchased"),
     CUSTOMER_INFO("customerInfo"),
     STORE_TRANSACTION("storeTransaction"),

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -2,7 +2,6 @@ package com.revenuecat.purchases.react.ui
 
 import androidx.core.view.children
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.react.ui
 
 import androidx.core.view.children
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
@@ -55,9 +56,9 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterVi
                     }
                 }
             }
-        }.also {
-            it.setPaywallListener(createPaywallListenerWrapper(themedReactContext, it))
-            it.setDismissHandler(getDismissHandler(themedReactContext, it))
+        }.also { view ->
+            view.setPaywallListener(createPaywallListenerWrapper(themedReactContext, view))
+            view.setDismissHandler(getDismissHandler(themedReactContext, view))
         }
     }
 

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -5,6 +5,7 @@ import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIP
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 
+
 @OptIn(ExperimentalPreviewRevenueCatUIPurchasesAPI::class)
 internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
 
@@ -17,9 +18,9 @@ internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
     }
 
     override fun createViewInstance(themedReactContext: ThemedReactContext): PaywallView {
-        return PaywallView(themedReactContext).also {
-            it.setPaywallListener(createPaywallListenerWrapper(themedReactContext, it))
-            it.setDismissHandler(getDismissHandler(themedReactContext, it))
+        return PaywallView(themedReactContext).also { view ->
+            view.setPaywallListener(createPaywallListenerWrapper(themedReactContext, view))
+            view.setDismissHandler(getDismissHandler(themedReactContext, view))
         }
     }
 

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/ViewExtensions.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/ViewExtensions.kt
@@ -1,0 +1,7 @@
+package com.revenuecat.purchases.react.ui
+
+import android.view.View
+import com.facebook.react.uimanager.UIManagerHelper
+
+internal val View.surfaceId
+    get() = UIManagerHelper.getSurfaceId(this)

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnDismissEvent(
+internal class OnDismissEvent(
     surfaceId: Int,
     viewTag: Int,
 ) : PaywallEvent<OnDismissEvent>(surfaceId, viewTag) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnDismissEvent : PaywallEvent<OnDismissEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_DISMISS
+
+    override fun getPayload() = null
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnDismissEvent.kt
@@ -1,9 +1,13 @@
 package com.revenuecat.purchases.react.ui.events
 
+import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnDismissEvent : PaywallEvent<OnDismissEvent>() {
+class OnDismissEvent(
+    surfaceId: Int,
+    viewTag: Int,
+) : PaywallEvent<OnDismissEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_DISMISS
 
-    override fun getPayload() = null
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> = emptyMap()
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnPurchaseCancelledEvent : PaywallEvent<OnPurchaseCancelledEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_CANCELLED
+
+    override fun getPayload() = null
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
@@ -1,9 +1,13 @@
 package com.revenuecat.purchases.react.ui.events
 
+import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnPurchaseCancelledEvent : PaywallEvent<OnPurchaseCancelledEvent>() {
+class OnPurchaseCancelledEvent(
+    surfaceId: Int,
+    viewTag: Int,
+) : PaywallEvent<OnPurchaseCancelledEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_CANCELLED
 
-    override fun getPayload() = null
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> = emptyMap()
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCancelledEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnPurchaseCancelledEvent(
+internal class OnPurchaseCancelledEvent(
     surfaceId: Int,
     viewTag: Int,
 ) : PaywallEvent<OnPurchaseCancelledEvent>(surfaceId, viewTag) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnPurchaseCompletedEvent(
+internal class OnPurchaseCompletedEvent(
     surfaceId: Int,
     viewTag: Int,
     private val customerInfo: Map<String, Any?>,

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
@@ -4,9 +4,11 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
 class OnPurchaseCompletedEvent(
+    surfaceId: Int,
+    viewTag: Int,
     private val customerInfo: Map<String, Any?>,
     private val storeTransaction: Map<String, Any?>
-) : PaywallEvent<OnPurchaseCompletedEvent>() {
+) : PaywallEvent<OnPurchaseCompletedEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_COMPLETED
 
     override fun getPayload() = mapOf(

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseCompletedEvent.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnPurchaseCompletedEvent(
+    private val customerInfo: Map<String, Any?>,
+    private val storeTransaction: Map<String, Any?>
+) : PaywallEvent<OnPurchaseCompletedEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_COMPLETED
+
+    override fun getPayload() = mapOf(
+        PaywallEventKey.CUSTOMER_INFO to customerInfo,
+        PaywallEventKey.STORE_TRANSACTION to storeTransaction
+    )
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
@@ -4,8 +4,10 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
 class OnPurchaseErrorEvent(
+    surfaceId: Int,
+    viewTag: Int,
     private val error: Map<String, Any?>
-) : PaywallEvent<OnPurchaseErrorEvent>() {
+) : PaywallEvent<OnPurchaseErrorEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_ERROR
 
     override fun getPayload() = mapOf(PaywallEventKey.ERROR to error)

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnPurchaseErrorEvent(
+internal class OnPurchaseErrorEvent(
     surfaceId: Int,
     viewTag: Int,
     private val error: Map<String, Any?>

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseErrorEvent.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnPurchaseErrorEvent(
+    private val error: Map<String, Any?>
+) : PaywallEvent<OnPurchaseErrorEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_ERROR
+
+    override fun getPayload() = mapOf(PaywallEventKey.ERROR to error)
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnPurchaseStartedEvent(
+internal class OnPurchaseStartedEvent(
     surfaceId: Int,
     viewTag: Int,
     private val packageMap: Map<String, Any?>

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnPurchaseStartedEvent(
+    private val packageMap: Map<String, Any?>
+) : PaywallEvent<OnPurchaseStartedEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_STARTED
+
+    override fun getPayload() = mapOf(
+        PaywallEventKey.PACKAGE to packageMap,
+    )
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnPurchaseStartedEvent.kt
@@ -4,8 +4,10 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
 class OnPurchaseStartedEvent(
+    surfaceId: Int,
+    viewTag: Int,
     private val packageMap: Map<String, Any?>
-) : PaywallEvent<OnPurchaseStartedEvent>() {
+) : PaywallEvent<OnPurchaseStartedEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_PURCHASE_STARTED
 
     override fun getPayload() = mapOf(

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
@@ -4,8 +4,10 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
 class OnRestoreCompletedEvent(
+    surfaceId: Int,
+    viewTag: Int,
     private val customerInfo: Map<String, Any?>,
-) : PaywallEvent<OnRestoreCompletedEvent>() {
+) : PaywallEvent<OnRestoreCompletedEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_COMPLETED
 
     override fun getPayload() = mapOf(PaywallEventKey.CUSTOMER_INFO to customerInfo)

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnRestoreCompletedEvent(
+internal class OnRestoreCompletedEvent(
     surfaceId: Int,
     viewTag: Int,
     private val customerInfo: Map<String, Any?>,

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreCompletedEvent.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnRestoreCompletedEvent(
+    private val customerInfo: Map<String, Any?>,
+) : PaywallEvent<OnRestoreCompletedEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_COMPLETED
+
+    override fun getPayload() = mapOf(PaywallEventKey.CUSTOMER_INFO to customerInfo)
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnRestoreErrorEvent(
+internal class OnRestoreErrorEvent(
     surfaceId: Int,
     viewTag: Int,
     private val error: Map<String, Any?>

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
@@ -1,0 +1,12 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnRestoreErrorEvent(
+    private val error: Map<String, Any?>
+) : PaywallEvent<OnRestoreErrorEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_ERROR
+
+    override fun getPayload() = mapOf(PaywallEventKey.ERROR to error)
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreErrorEvent.kt
@@ -4,8 +4,10 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
 class OnRestoreErrorEvent(
+    surfaceId: Int,
+    viewTag: Int,
     private val error: Map<String, Any?>
-) : PaywallEvent<OnRestoreErrorEvent>() {
+) : PaywallEvent<OnRestoreErrorEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_ERROR
 
     override fun getPayload() = mapOf(PaywallEventKey.ERROR to error)

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
@@ -1,9 +1,13 @@
 package com.revenuecat.purchases.react.ui.events
 
+import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnRestoreStartedEvent : PaywallEvent<OnRestoreStartedEvent>() {
+class OnRestoreStartedEvent(
+    surfaceId: Int,
+    viewTag: Int,
+) : PaywallEvent<OnRestoreStartedEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_STARTED
 
-    override fun getPayload() = null
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> = emptyMap()
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
@@ -1,0 +1,9 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+class OnRestoreStartedEvent : PaywallEvent<OnRestoreStartedEvent>() {
+    override fun getPaywallEventName() = PaywallEventName.ON_RESTORE_STARTED
+
+    override fun getPayload() = null
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnRestoreStartedEvent.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.react.ui.events
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
-class OnRestoreStartedEvent(
+internal class OnRestoreStartedEvent(
     surfaceId: Int,
     viewTag: Int,
 ) : PaywallEvent<OnRestoreStartedEvent>(surfaceId, viewTag) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
@@ -7,18 +7,21 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 import com.revenuecat.purchases.react.ui.RNPurchasesConverters
 
-abstract class PaywallEvent<T> : Event<PaywallEvent<T>>() {
+abstract class PaywallEvent<T>(
+    surfaceId: Int,
+    viewTag: Int,
+) : Event<PaywallEvent<T>>(surfaceId, viewTag) {
 
     abstract fun getPaywallEventName(): PaywallEventName
 
-    abstract fun getPayload(): Map<PaywallEventKey, Map<String, Any?>>?
+    abstract fun getPayload(): Map<PaywallEventKey, Map<String, Any?>>
 
     override fun getEventName(): String {
         return getPaywallEventName().eventName
     }
 
-    override fun getEventData(): WritableMap? {
-        val convertedPayload = getPayload()?.let { payload ->
+    override fun getEventData(): WritableMap {
+        val convertedPayload = getPayload().let { payload ->
             WritableNativeMap().apply {
                 payload.forEach { (key, value) ->
                     putMap(key.key, RNPurchasesConverters.convertMapToWriteableMap(value))

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
@@ -7,7 +7,7 @@ import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 import com.revenuecat.purchases.react.ui.RNPurchasesConverters
 
-abstract class PaywallEvent<T>(
+internal abstract class PaywallEvent<T>(
     surfaceId: Int,
     viewTag: Int,
 ) : Event<PaywallEvent<T>>(surfaceId, viewTag) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/PaywallEvent.kt
@@ -1,0 +1,31 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.uimanager.events.Event
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+import com.revenuecat.purchases.react.ui.RNPurchasesConverters
+
+abstract class PaywallEvent<T> : Event<PaywallEvent<T>>() {
+
+    abstract fun getPaywallEventName(): PaywallEventName
+
+    abstract fun getPayload(): Map<PaywallEventKey, Map<String, Any?>>?
+
+    override fun getEventName(): String {
+        return getPaywallEventName().eventName
+    }
+
+    override fun getEventData(): WritableMap? {
+        val convertedPayload = getPayload()?.let { payload ->
+            WritableNativeMap().apply {
+                payload.forEach { (key, value) ->
+                    putMap(key.key, RNPurchasesConverters.convertMapToWriteableMap(value))
+                }
+            }
+        }
+
+        return convertedPayload
+    }
+}


### PR DESCRIPTION
I've been trying against 0.74 RC with Bridgeless mode and the library doesn't work well on Android. The reason is that the library is using the deprecated RCTEventEmitter.

This PR https://github.com/DylanVann/react-native-fast-image/pull/1032 is an example of another plugin making the same change