### PR TITLE
Use ReactContext instead of ThemedReactContext in PaywallFooterViewManager

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.react.ui
 
 import androidx.core.view.children
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
@@ -48,8 +49,8 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterVi
                 val finalWidth = maxWidth.coerceAtLeast(suggestedMinimumWidth)
                 val finalHeight = maxHeight.coerceAtLeast(suggestedMinimumHeight)
                 setMeasuredDimension(finalWidth, finalHeight)
-                (context as? ThemedReactContext)?.let { themedReactContext ->
-                    themedReactContext.runOnNativeModulesQueueThread {
+                (context.applicationContext as? ReactContext)?.let { context ->
+                    context.runOnNativeModulesQueueThread {
                         themedReactContext.getNativeModule(UIManagerModule::class.java)
                             ?.updateNodeSize(id, finalWidth, finalHeight)
                     }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.react.ui
 
 import androidx.core.view.children
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
@@ -49,8 +48,8 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterVi
                 val finalWidth = maxWidth.coerceAtLeast(suggestedMinimumWidth)
                 val finalHeight = maxHeight.coerceAtLeast(suggestedMinimumHeight)
                 setMeasuredDimension(finalWidth, finalHeight)
-                (context.applicationContext as? ReactContext)?.let { context ->
-                    context.runOnNativeModulesQueueThread {
+                (context as? ThemedReactContext)?.reactApplicationContext?.let { themedReactContext ->
+                    themedReactContext.runOnNativeModulesQueueThread {
                         themedReactContext.getNativeModule(UIManagerModule::class.java)
                             ?.updateNodeSize(id, finalWidth, finalHeight)
                     }


### PR DESCRIPTION
`ThemedReactContext` is broken in the new architecture. This fix suggested by @cortinico prevents a crash in the new architecture. The behavior is the same

The PaywallFooter is still broken and `themedReactContext.getNativeModule(UIManagerModule::class.java)` is throwing 

```
com.facebook.react.bridge.ReactNoCrashBridgeNotAllowedSoftException: getNativeModule(UIManagerModule.class) cannot be called when the bridge is disabled
```