### PR TITLE
Refactor magicweather package item

### DIFF
--- a/examples/MagicWeather/src/components/PackageItem/index.js
+++ b/examples/MagicWeather/src/components/PackageItem/index.js
@@ -16,9 +16,9 @@ const PackageItem = ({ purchasePackage, setIsPurchasing }) => {
     setIsPurchasing(true);
 
     try {
-      const { purchaserInfo } = await Purchases.purchasePackage(purchasePackage);
+      const { customerInfo } = await Purchases.purchasePackage(purchasePackage);
 
-      if (typeof purchaserInfo.entitlements.active[ENTITLEMENT_ID] !== 'undefined') {
+      if (typeof customerInfo.entitlements.active[ENTITLEMENT_ID] !== 'undefined') {
         navigation.goBack();
       }
     } catch (e) {

--- a/examples/MagicWeather/src/components/PackageItem/index.js
+++ b/examples/MagicWeather/src/components/PackageItem/index.js
@@ -22,7 +22,7 @@ const PackageItem = ({ purchasePackage, setIsPurchasing }) => {
         navigation.goBack();
       }
     } catch (e) {
-      if (!e.userCancelled) {
+      if (e.code === Purchases.PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR) {
         Alert.alert('Error purchasing package', e.message);
       }
     } finally {

--- a/examples/MagicWeather/src/components/PackageItem/index.js
+++ b/examples/MagicWeather/src/components/PackageItem/index.js
@@ -32,7 +32,7 @@ const PackageItem = ({ purchasePackage, setIsPurchasing }) => {
 
   return (
     <Pressable onPress={onSelection} style={styles.container}>
-      <View style={styles.left}>
+      <View>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.terms}>{description}</Text>
       </View>


### PR DESCRIPTION
General cleanup of the React Native PackageItem component example.

- remove undeclared style
- update the reference to the deprecated property in the catch statement
- replace purchaserInfo with customerInfo as the MakePurchaseResult type returns from the purchasePackage promise
