### PR TITLE
Fix `purchaseDiscountedPackage`

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -848,7 +848,7 @@ describe("Purchases", () => {
 
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith(
       aPackage.identifier,
-      aPackage.offeringIdentifier,
+      aPackage.presentedOfferingContext,
       null,
       promotionalOfferStub.timestamp.toString(),
       null

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -587,7 +587,7 @@ export default class Purchases {
     }
     return RNPurchases.purchasePackage(
       aPackage.identifier,
-      aPackage.offeringIdentifier,
+      aPackage.presentedOfferingContext,
       null,
       discount.timestamp.toString(),
       null


### PR DESCRIPTION
Fix `purchaseDiscountedPackage` not working and getting:

```
Couldn't find package, {underlyingErrorMessage: , userCancelled: false, message: Couldn't find package, code: 5}, null)
```