### PR TITLE
Setting `proxyURL` should not require configure

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1035,6 +1035,7 @@ describe("Purchases", () => {
       "throwIfIOSPlatform",
       "convertIntToRefundRequestStatus",
       "isConfigured",
+      "setProxyURL"
     ];
     const functionsThatRequireAndroidAndInstance = [
       "syncObserverModeAmazonPurchase",

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -919,11 +919,9 @@ export default class Purchases {
   /**
    * Set this property to your proxy URL before configuring Purchases *only* if you've received a proxy key value
    * from your RevenueCat contact.
-   * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
-   * setting the proxy url.
+   * @returns {Promise<void>} The promise will be rejected if there's an error setting the proxy url.
    */
   public static async setProxyURL(url: string): Promise<void> {
-    await Purchases.throwIfNotConfigured();
     RNPurchases.setProxyURLString(url);
   }
 


### PR DESCRIPTION
Setting a proxy URL doesn't require an instance so we shouldn't be checking if Purchases is configured