### PR TITLE
Make the setProxyURL a promise to wait for the native code to set the proxy URL

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -313,8 +313,13 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
-    public void setProxyURLString(String proxyURLString) {
-        CommonKt.setProxyURLString(proxyURLString);
+    public void setProxyURLString(String proxyURLString, Promise promise) {
+        try {
+            CommonKt.setProxyURLString(proxyURLString);
+            promise.resolve(null); // Resolve the promise with no value
+        } catch (Exception e) {
+            promise.reject("SET_PROXY_URL_ERROR", e); // Reject the promise with an error
+        }
     }
 
     @ReactMethod

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -260,8 +260,16 @@ static void logUnavailablePresentCodeRedemptionSheet() {
 
 #pragma mark - Subscriber Attributes
 
-RCT_EXPORT_METHOD(setProxyURLString:(nullable NSString *)proxyURLString) {
-    [RCCommonFunctionality setProxyURLString:proxyURLString];
+RCT_EXPORT_METHOD(setProxyURLString:(nullable NSString *)proxyURLString
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    @try {
+        [RCCommonFunctionality setProxyURLString:proxyURLString];
+        resolve(nil); // Resolve the promise with no value
+    } @catch (NSException *exception) {
+        NSError *error = [NSError errorWithDomain:@"SET_PROXY_URL_ERROR" code:0 userInfo:@{NSLocalizedDescriptionKey: exception.reason}];
+        reject(@"SET_PROXY_URL_ERROR", exception.reason, error); // Reject the promise with an error
+    }
 }
 
 RCT_EXPORT_METHOD(setAttributes:(NSDictionary *)attributes) {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -922,7 +922,7 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if there's an error setting the proxy url.
    */
   public static async setProxyURL(url: string): Promise<void> {
-    RNPurchases.setProxyURLString(url);
+    return RNPurchases.setProxyURLString(url);
   }
 
   /**


### PR DESCRIPTION
  - [x] A description about what and why you are contributing, even if it's trivial.
  This makes the setProxyURL call return the promise so we can await it before calling configure, as the async nature may mean the native bridge hasn't been called before we continue
