### PR TITLE
Update to latest android major

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -578,10 +578,10 @@ describe("Purchases", () => {
     const defaultVerificationMode = "DISABLED"
 
     Purchases.configure({apiKey: "key", appUserID: "user"});
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false, true, defaultVerificationMode);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, undefined, false, false, true, defaultVerificationMode, false);
 
     Purchases.configure({apiKey: "key", appUserID: "user", observerMode: true});
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false, false, true, defaultVerificationMode);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, undefined, false, false, true, defaultVerificationMode, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -590,7 +590,7 @@ describe("Purchases", () => {
       userDefaultsSuiteName: "suite name",
       usesStoreKit2IfAvailable: true
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suite name", true, false, true, defaultVerificationMode);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", false, "suite name", true, false, true, defaultVerificationMode, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -600,9 +600,10 @@ describe("Purchases", () => {
       usesStoreKit2IfAvailable: true,
       useAmazon: true,
       shouldShowInAppMessagesAutomatically: true,
-      entitlementVerificationMode: Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+      entitlementVerificationMode: Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
+      pendingTransactionsForPrepaidPlansEnabled: true
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true, Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, true, Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL, true);
 
     Purchases.configure({
       apiKey: "key",
@@ -613,7 +614,7 @@ describe("Purchases", () => {
       useAmazon: true,
       shouldShowInAppMessagesAutomatically: false
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, false, defaultVerificationMode);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", true, "suite name", true, true, false, defaultVerificationMode, false);
 
     expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(5);
   })

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 android.useAndroidX=true
-Purchases_kotlinVersion=1.7.21
-Purchases_compileSdkVersion=28
-Purchases_targetSdkVersion=28
-Purchases_minSdkVersion=19
+Purchases_kotlinVersion=1.8.22
+Purchases_compileSdkVersion=34
+Purchases_targetSdkVersion=34
+Purchases_minSdkVersion=21

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -86,7 +86,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                boolean observerMode, @Nullable String userDefaultsSuiteName,
                                @Nullable Boolean usesStoreKit2IfAvailable, boolean useAmazon,
                                boolean shouldShowInAppMessagesAutomatically,
-                               @Nullable String entitlementVerificationMode) {
+                               @Nullable String entitlementVerificationMode,
+                               boolean pendingTransactionsForPrepaidPlansEnabled) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         Store store = Store.PLAY_STORE;
         if (useAmazon) {
@@ -101,7 +102,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             store,
             new DangerousSettings(),
             shouldShowInAppMessagesAutomatically,
-            entitlementVerificationMode
+            entitlementVerificationMode,
+            pendingTransactionsForPrepaidPlansEnabled
         );
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(this);
     }

--- a/apitesters/offerings.ts
+++ b/apitesters/offerings.ts
@@ -21,6 +21,7 @@ import {
   RECURRENCE_MODE,
   PresentedOfferingContext,
   PresentedOfferingTargetingContext,
+  InstallmentsInfo,
 } from "../dist";
 
 function checkProduct(product: PurchasesStoreProduct) {
@@ -124,6 +125,15 @@ function checkSubscriptionOption(option: SubscriptionOption) {
     option.presentedOfferingIdentifier;
   const presentedOfferingContext: PresentedOfferingContext | null =
     option.presentedOfferingContext;
+  const installmentsInfo: InstallmentsInfo | null =
+    option.installmentsInfo;
+}
+
+function checkInstallmentsInfo(installmentsInfo: InstallmentsInfo) {
+  const commitmentPaymentsCount: number =
+    installmentsInfo.commitmentPaymentsCount;
+  const renewalCommitmentPaymentsCount: number =
+    installmentsInfo.renewalCommitmentPaymentsCount;
 }
 
 function checkPricingPhase(pricePhase: PricingPhase) {

--- a/examples/purchaseTesterTypescript/App.tsx
+++ b/examples/purchaseTesterTypescript/App.tsx
@@ -42,9 +42,18 @@ const App = () => {
     if (Platform.OS == "android") {
       const useAmazon = false;
       if (useAmazon) {
-        Purchases.configure({apiKey: APIKeys.amazon, useAmazon: true, entitlementVerificationMode: verificationMode});
+        Purchases.configure({
+          apiKey: APIKeys.amazon,
+          useAmazon: true,
+          entitlementVerificationMode: verificationMode,
+          pendingTransactionsForPrepaidPlansEnabled: true
+        });
       } else {
-        Purchases.configure({apiKey: APIKeys.google, entitlementVerificationMode: verificationMode});
+        Purchases.configure({
+          apiKey: APIKeys.google,
+          entitlementVerificationMode: verificationMode,
+          pendingTransactionsForPrepaidPlansEnabled: true
+        });
       }
     } else {
       Purchases.configure({apiKey: APIKeys.apple, entitlementVerificationMode: verificationMode});

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -44,7 +44,8 @@ RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                   usesStoreKit2IfAvailable:(BOOL)usesStoreKit2IfAvailable
                   useAmazon:(BOOL)useAmazon
                   shouldShowInAppMessagesAutomatically:(BOOL)shouldShowInAppMessagesAutomatically
-                  entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode) {
+                  entitlementVerificationMode:(nullable NSString *)entitlementVerificationMode,
+                  pendingTransactionsForPrepaidPlansEnabled:(BOOL)pendingTransactionsForPrepaidPlansEnabled) {
     RCPurchases *purchases = [RCPurchases configureWithAPIKey:apiKey
                                                     appUserID:appUserID
                                       purchasesAreCompletedBy:(observerMode ? RCPurchasesAreCompletedByMyApp : RCPurchasesAreCompletedByRevenueCat)

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -193,6 +193,7 @@ export default class Purchases {
    * @param {String?} userDefaultsSuiteName An optional string. iOS-only, will be ignored for Android.
    * Set this if you would like the RevenueCat SDK to store its preferences in a different NSUserDefaults suite, otherwise it will use standardUserDefaults.
    * Default is null, which will make the SDK use standardUserDefaults.
+   * @param {boolean} [pendingTransactionsForPrepaidPlansEnabled=false] An optional boolean. Android-only. Set this to TRUE to enable pending transactions for prepaid subscriptions in Google Play.
    */
   public static configure({
     apiKey,
@@ -203,6 +204,7 @@ export default class Purchases {
     useAmazon = false,
     shouldShowInAppMessagesAutomatically = true,
     entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED,
+    pendingTransactionsForPrepaidPlansEnabled = false,
   }: PurchasesConfiguration): void {
     if (apiKey === undefined || typeof apiKey !== "string") {
       throw new Error(
@@ -226,7 +228,8 @@ export default class Purchases {
       usesStoreKit2IfAvailable,
       useAmazon,
       shouldShowInAppMessagesAutomatically,
-      entitlementVerificationMode
+      entitlementVerificationMode,
+      pendingTransactionsForPrepaidPlansEnabled
     );
   }
 


### PR DESCRIPTION
This is based on these changes in PHC: https://github.com/RevenueCat/purchases-hybrid-common/pull/859 which need to be deployed first.

This updates to the latest changes in the android major that include:
- Adds `installmentsInfo` to `SubscriptionOption`
- Adds `pendingTransactionsForPrepaidPlansEnabled` to `configure` method.
- Updates minSdk to 21