### PR TITLE
[EXTERNAL] Make the setProxyURL a promise to wait for the native code to set the proxy URL (#1033) contributed by @dangilbert

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -313,8 +313,9 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
-    public void setProxyURLString(String proxyURLString) {
+    public void setProxyURLString(String proxyURLString, Promise promise) {
         CommonKt.setProxyURLString(proxyURLString);
+        promise.resolve(null); // Resolve the promise with no value
     }
 
     @ReactMethod

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -260,8 +260,11 @@ static void logUnavailablePresentCodeRedemptionSheet() {
 
 #pragma mark - Subscriber Attributes
 
-RCT_EXPORT_METHOD(setProxyURLString:(nullable NSString *)proxyURLString) {
+RCT_EXPORT_METHOD(setProxyURLString:(nullable NSString *)proxyURLString
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality setProxyURLString:proxyURLString];
+    resolve(nil); // Resolve the promise with no value
 }
 
 RCT_EXPORT_METHOD(setAttributes:(NSDictionary *)attributes) {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -922,7 +922,7 @@ export default class Purchases {
    * @returns {Promise<void>} The promise will be rejected if there's an error setting the proxy url.
    */
   public static async setProxyURL(url: string): Promise<void> {
-    RNPurchases.setProxyURLString(url);
+    return RNPurchases.setProxyURLString(url);
   }
 
   /**

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -919,7 +919,7 @@ export default class Purchases {
   /**
    * Set this property to your proxy URL before configuring Purchases *only* if you've received a proxy key value
    * from your RevenueCat contact.
-   * @returns {Promise<void>} The promise will be rejected if there's an error setting the proxy url.
+   * @returns {Promise<void>} The promise to be returned after setting the proxy has been completed.
    */
   public static async setProxyURL(url: string): Promise<void> {
     return RNPurchases.setProxyURLString(url);


### PR DESCRIPTION
This makes the setProxyURL call return the promise so we can await it before calling configure, as the async nature may mean the native bridge hasn't been called before we continue

