### PR TITLE
replace syncObserverModeAmazonPurchase with syncAmazonPurchase

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -757,6 +757,69 @@ describe("Purchases", () => {
     }
   })
 
+  it("syncAmazonPurchase works for android", async () => {
+    Platform.OS = "android";
+
+    await Purchases.syncAmazonPurchase(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    );
+
+    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledTimes(1);
+    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledWith(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    );
+  });
+
+  it("syncAmazonPurchase throws UninitializedError if called before configuring", async () => {
+    Platform.OS = "android";
+
+    NativeModules.RNPurchases.isConfigured.mockResolvedValue(false);
+
+    const expected = new Purchases.UninitializedPurchasesError();
+
+    await Purchases.syncAmazonPurchase(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    )
+      .then(() => {
+        fail(`${allPropertyNames[i]} should have failed`);
+      })
+      .catch((error) => {
+        expect(error.name).toEqual(expected.name);
+        expect(error.message).toEqual(expected.message);
+      });
+  });
+
+  it("syncAmazonPurchase throws UnsupportedPlatformError for ios", async () => {
+    Platform.OS = "ios";
+
+    try {
+      await Purchases.syncAmazonPurchase(
+        "productID_test",
+        "receiptID_test",
+        "amazonUserID_test",
+        "isoCurrencyCode_test",
+        3.4
+      );
+      fail("expected error");
+    } catch (error) {
+      if (!(error instanceof UnsupportedPlatformError)) {
+        fail("expected UnsupportedPlatformException");
+      }
+    }
+  });
+
   it("checkTrialOrIntroductoryPriceEligibility works", async () => {
     await Purchases.checkTrialOrIntroductoryPriceEligibility(["monthly"])
 
@@ -1041,6 +1104,7 @@ describe("Purchases", () => {
       "isPurchasesAreCompletedByMyApp",
     ];
     const functionsThatRequireAndroidAndInstance = [
+      "syncAmazonPurchase",
       "syncObserverModeAmazonPurchase",
     ];
     const expected = new Purchases.UninitializedPurchasesError();

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -694,6 +694,69 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.syncPurchases).toBeCalledTimes(1);
   })
 
+  it("syncObserverModeAmazonPurchase works for android", async () => {
+    Platform.OS = "android";
+
+    await Purchases.syncObserverModeAmazonPurchase(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    );
+
+    expect(NativeModules.RNPurchases.syncObserverModeAmazonPurchase).toBeCalledTimes(1);
+    expect(NativeModules.RNPurchases.syncObserverModeAmazonPurchase).toBeCalledWith(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    );
+  });
+
+  it("syncObserverModeAmazonPurchase throws UninitializedError if called before configuring", async () => {
+    Platform.OS = "android";
+
+    NativeModules.RNPurchases.isConfigured.mockResolvedValue(false);
+
+    const expected = new Purchases.UninitializedPurchasesError();
+
+    await Purchases.syncObserverModeAmazonPurchase(
+      "productID_test",
+      "receiptID_test",
+      "amazonUserID_test",
+      "isoCurrencyCode_test",
+      3.4
+    )
+      .then(() => {
+        fail(`${allPropertyNames[i]} should have failed`);
+      })
+      .catch((error) => {
+        expect(error.name).toEqual(expected.name);
+        expect(error.message).toEqual(expected.message);
+      });
+  });
+
+  it("syncObserverModeAmazonPurchase throws UnsupportedPlatformError for ios", async () => {
+    Platform.OS = "ios";
+
+    try {
+      await Purchases.syncObserverModeAmazonPurchase(
+        "productID_test",
+        "receiptID_test",
+        "amazonUserID_test",
+        "isoCurrencyCode_test",
+        3.4
+      );
+      fail("expected error");
+    } catch (error) {
+      if (!(error instanceof UnsupportedPlatformError)) {
+        fail("expected UnsupportedPlatformException");
+      }
+    }
+  });
+
   it("syncAmazonPurchase works for android", async () => {
     Platform.OS = "android";
 
@@ -714,91 +777,6 @@ describe("Purchases", () => {
       3.4
     );
   })
-
-  it("syncAmazonPurchase throws UninitializedError if called before configuring", async () => {
-    Platform.OS = "android";
-
-    NativeModules.RNPurchases.isConfigured.mockResolvedValue(false);
-
-    const expected = new Purchases.UninitializedPurchasesError();
-
-    await Purchases.syncAmazonPurchase(
-      "productID_test",
-      "receiptID_test",
-      "amazonUserID_test",
-      "isoCurrencyCode_test",
-      3.4
-    )
-      .then(() => {
-        fail(`${allPropertyNames[i]} should have failed`);
-      })
-      .catch((error) => {
-        expect(error.name).toEqual(expected.name);
-        expect(error.message).toEqual(expected.message);
-      });
-  });
-
-
-  it("syncAmazonPurchase throws UnsupportedPlatformError for ios", async () => {
-    Platform.OS = "ios";
-
-    try {
-      await Purchases.syncAmazonPurchase(
-        "productID_test",
-        "receiptID_test",
-        "amazonUserID_test",
-        "isoCurrencyCode_test",
-        3.4
-      );
-      fail("expected error");
-    } catch (error) {
-      if (!(error instanceof UnsupportedPlatformError)) {
-        fail("expected UnsupportedPlatformException");
-      }
-    }
-  });
-
-  it("syncObserverModeAmazonPurchase calls syncAmazonPurchase", async () => {
-    Platform.OS = "android";
-
-    await Purchases.syncObserverModeAmazonPurchase(
-      "productID_test",
-      "receiptID_test",
-      "amazonUserID_test",
-      "isoCurrencyCode_test",
-      3.4
-    );
-
-    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledTimes(1);
-    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledWith(
-      "productID_test",
-      "receiptID_test",
-      "amazonUserID_test",
-      "isoCurrencyCode_test",
-      3.4
-    );
-  });
-
-  it("syncAmazonPurchase works for android", async () => {
-    Platform.OS = "android";
-
-    await Purchases.syncAmazonPurchase(
-      "productID_test",
-      "receiptID_test",
-      "amazonUserID_test",
-      "isoCurrencyCode_test",
-      3.4
-    );
-
-    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledTimes(1);
-    expect(NativeModules.RNPurchases.syncAmazonPurchase).toBeCalledWith(
-      "productID_test",
-      "receiptID_test",
-      "amazonUserID_test",
-      "isoCurrencyCode_test",
-      3.4
-    );
-  });
 
   it("syncAmazonPurchase throws UninitializedError if called before configuring", async () => {
     Platform.OS = "android";
@@ -1128,7 +1106,6 @@ describe("Purchases", () => {
     const functionsThatRequireAndroidAndInstance = [
       "syncAmazonPurchase",
       "syncObserverModeAmazonPurchase",
-      "syncAmazonPurchase",
     ];
     const expected = new Purchases.UninitializedPurchasesError();
     for (let i = 0; i < allPropertyNames.length; i++) {

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -459,12 +459,21 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
+    public void syncAmazonPurchase(String productID, String receiptID,
+                                               String amazonUserID, String isoCurrencyCode,
+                                               Double price, final Promise promise) {
+      Purchases.getSharedInstance().syncAmazonPurchase(productID, receiptID,
+        amazonUserID, isoCurrencyCode, price);
+      promise.resolve(null);
+    }
+
+    @Deprecated // Use syncAmazonPurchase instead
+    @ReactMethod
     public void syncObserverModeAmazonPurchase(String productID, String receiptID,
                                                String amazonUserID, String isoCurrencyCode,
                                                Double price, final Promise promise) {
-      Purchases.getSharedInstance().syncObserverModeAmazonPurchase(productID, receiptID,
-        amazonUserID, isoCurrencyCode, price);
-      promise.resolve(null);
+    
+      syncAmazonPurchase(productID, receiptID, amazonUserID, isoCurrencyCode, price, promise);
     }
 
     @ReactMethod

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -776,6 +776,7 @@ NativeModules.RNPurchases = {
   logIn: jest.fn(),
   logOut: jest.fn(),
   syncPurchases: jest.fn(),
+  syncAmazonPurchase: jest.fn(),
   syncObserverModeAmazonPurchase: jest.fn(),
   purchaseProduct: jest.fn(),
   purchasePackage: jest.fn(),

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -245,7 +245,8 @@ export default class Purchases {
       throw new Error("appUserID needs to be a string");
     }
 
-    let purchasesCompletedByToUse: PURCHASES_ARE_COMPLETED_BY_TYPE = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT;
+    let purchasesCompletedByToUse: PURCHASES_ARE_COMPLETED_BY_TYPE =
+      PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT;
     let storeKitVersionToUse = storeKitVersion;
 
     if (Purchases.isPurchasesAreCompletedByMyApp(purchasesAreCompletedBy)) {
@@ -734,6 +735,40 @@ export default class Purchases {
   }
 
   /**
+   * This method will send a purchase to the RevenueCat backend. This function should only be called if you are
+   * in Amazon observer mode or performing a client side migration of your current users to RevenueCat.
+   *
+   * The receipt IDs are cached if successfully posted so they are not posted more than once.
+   *
+   * @param {string} productID Product ID associated to the purchase.
+   * @param {string} receiptID ReceiptId that represents the Amazon purchase.
+   * @param {string} amazonUserID Amazon's userID. This parameter will be ignored when syncing a Google purchase.
+   * @param {(string|null|undefined)} isoCurrencyCode Product's currency code in ISO 4217 format.
+   * @param {(number|null|undefined)} price Product's price.
+   * @returns {Promise<void>} The promise will be rejected if configure has not been called yet or if there's an error
+   * syncing purchases.
+   */
+  public static async syncAmazonPurchase(
+    productID: string,
+    receiptID: string,
+    amazonUserID: string,
+    isoCurrencyCode?: string | null,
+    price?: number | null
+  ): Promise<void> {
+    await Purchases.throwIfIOSPlatform();
+    await Purchases.throwIfNotConfigured();
+    RNPurchases.syncAmazonPurchase(
+      productID,
+      receiptID,
+      amazonUserID,
+      isoCurrencyCode,
+      price
+    );
+  }
+
+  /**
+   * @deprecated, use syncAmazonPurchase instead.
+   *
    * This method will send a purchase to the RevenueCat backend. This function should only be called if you are
    * in Amazon observer mode or performing a client side migration of your current users to RevenueCat.
    *


### PR DESCRIPTION
Somehow, deprecating the syncObserverModeAmazonPurchase function broke the getPromotionalOffer tests. I redid the changes here and got them working :D