### PR TITLE
Refine StoreKitVersion logging in configure function

### DIFF
--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -269,7 +269,7 @@ export default class Purchases {
       if (storeKitVersionToUse === STOREKIT_VERSION.DEFAULT) {
         // tslint:disable-next-line:no-console
         console.warn(
-          "Warning: You should provide the specific StoreKit version you're using in your implementation when configuring PurchasesAreCompletedByMyApp, and not rely on the DEFAULT."
+          "Warning: You should provide the specific StoreKit version you're using in your implementation when configuring PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP, and not rely on the DEFAULT."
         );
       }
     }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -253,13 +253,23 @@ export default class Purchases {
       purchasesCompletedByToUse = PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP;
       storeKitVersionToUse = purchasesAreCompletedBy.storeKitVersion;
 
-      if (storeKitVersionToUse !== storeKitVersion) {
+      if (
+        storeKitVersion !== STOREKIT_VERSION.DEFAULT &&
+        storeKitVersionToUse !== storeKitVersion
+      ) {
         // Typically, console messages aren't used in TS libraries, but in this case it's worth calling out the difference in
         // StoreKit versions, and since the difference isn't possible farther down the call chain, we should go ahead
         // and log it here.
         // tslint:disable-next-line:no-console
         console.warn(
           "Warning: The storeKitVersion in purchasesAreCompletedBy does not match the function's storeKitVersion parameter. We will use the value found in purchasesAreCompletedBy."
+        );
+      }
+
+      if (storeKitVersionToUse === STOREKIT_VERSION.DEFAULT) {
+        // tslint:disable-next-line:no-console
+        console.warn(
+          "Warning: You should provide the specific StoreKit version you're using in your implementation when configuring PurchasesAreCompletedByMyApp, and not rely on the DEFAULT."
         );
       }
     }


### PR DESCRIPTION
This PR refines the logging related to the `storeKitVersion` in the `configure()` function. Specifically, it:
- Only logs a message about the storeKitVersions being passed conflicting if the `storeKitVersion` param is not the default value. This should prevent confusion in the event that a developer passes in a `PurchasesAreCompletedByMyApp` but doesn't pass in a `storeKitVersion` param
- If the `storeKitVersion` passed into `PurchasesAreCompletedByMyApp` is the default value, it logs a warning letting the developer know that they should provide a specific `storeKitVersion` that matches what they're using in their StoreKit implementation.