### PR TITLE
Fix paywall footer dismissal crash

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -25,11 +25,16 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<PaywallFooterVi
             }
 
             private val measureAndLayout = Runnable {
-                measure(
-                    MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
-                )
-                layout(left, top, right, bottom)
+                // It's possible the view has been detached at this point which can cause issues
+                // since the viewModel is not available anymore. We don't really need to remeasure
+                // in this case.
+                if (isAttachedToWindow) {
+                    measure(
+                        MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                        MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+                    )
+                    layout(left, top, right, bottom)
+                }
             }
 
             // This is needed so it measures correctly the size of the children and react native can


### PR DESCRIPTION
This fixes https://github.com/RevenueCat/react-native-purchases/issues/994

Basically when the footer is dismissed within the same view, it triggers a new layout, which since we call a remeasurement with a `post` call, this remeasurement may happen after the view has been removed from the window. This view requires access to the context to be able to obtain the `ViewModel` in the underlying composable, causing a crash.
