### PR TITLE
Support Fetching and Redeeming Win-Back Offers on Custom Paywall

### DIFF
--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -349,6 +349,9 @@ async function checkFetchAndPurchaseWinBackOffersForProduct(
   product: PurchasesStoreProduct
 ): Promise<MakePurchaseResult> {
   const offers = await Purchases.getEligibleWinBackOffersForProduct(product);
+  if (!offers || offers.length === 0) {
+    throw new Error("No eligible win-back offers available for the product.");
+  }
   return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
 }
 
@@ -356,5 +359,8 @@ async function checkFetchAndPurchaseWinBackOffersForPackage(
   aPackage: PurchasesPackage
 ): Promise<MakePurchaseResult> {
   const offers = await Purchases.getEligibleWinBackOffersForPackage(aPackage);
+  if (!offers || offers.length === 0) {
+    throw new Error("No eligible win-back offers available for the package.");
+  }
   return await Purchases.purchasePackageWithWinBackOffer(aPackage, offers[0]);
 }

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -344,3 +344,17 @@ async function checkSyncObserverModeAmazonPurchase(
     price
   );
 }
+
+async function checkFetchAndPurchaseWinBackOffersForProduct(
+  product: PurchasesStoreProduct
+): Promise<MakePurchaseResult> {
+  const offers = await Purchases.getEligibleWinBackOffersForProduct(product);
+  return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
+}
+
+async function checkFetchAndPurchaseWinBackOffersForPackage(
+  aPackage: PurchasesPackage
+): Promise<MakePurchaseResult> {
+  const offers = await Purchases.getEligibleWinBackOffersForPackage(aPackage);
+  return await Purchases.purchasePackageWithWinBackOffer(aPackage, offers[0]);
+}

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -349,7 +349,8 @@ async function checkFetchAndPurchaseWinBackOffersForProduct(
   product: PurchasesStoreProduct
 ): Promise<MakePurchaseResult> {
   const offers = await Purchases.getEligibleWinBackOffersForProduct(product);
-  if (!offers || offers.length === 0) {
+
+  if (!offers || offers.length < 1) {
     throw new Error("No eligible win-back offers available for the product.");
   }
   return await Purchases.purchaseProductWithWinBackOffer(product, offers[0]);
@@ -359,7 +360,8 @@ async function checkFetchAndPurchaseWinBackOffersForPackage(
   aPackage: PurchasesPackage
 ): Promise<MakePurchaseResult> {
   const offers = await Purchases.getEligibleWinBackOffersForPackage(aPackage);
-  if (!offers || offers.length === 0) {
+
+  if (!offers || offers.length < 1) {
     throw new Error("No eligible win-back offers available for the package.");
   }
   return await Purchases.purchasePackageWithWinBackOffer(aPackage, offers[0]);

--- a/examples/purchaseTesterTypescript/App.tsx
+++ b/examples/purchaseTesterTypescript/App.tsx
@@ -21,6 +21,7 @@ import CustomerInfoScreen from './app/screens/CustomerInfoScreen';
 import OfferingDetailScreen from './app/screens/OfferingDetailScreen';
 import PaywallScreen from './app/screens/PaywallScreen';
 import FooterPaywallScreen from "./app/screens/FooterPaywallScreen";
+import WinBackTestingScreen from "./app/screens/WinBackTestingScreen";
 
 import APIKeys from './app/APIKeys';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -80,6 +81,7 @@ const App = () => {
           <Stack.Screen name="OfferingDetail" component={OfferingDetailScreen} />
           <Stack.Screen name="Paywall" component={PaywallScreen} />
           <Stack.Screen name="FooterPaywall" component={FooterPaywallScreen} />
+          <Stack.Screen name="WinBackTesting" component={WinBackTestingScreen} />
         </Stack.Navigator>
       </NavigationContainer>
     );

--- a/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
+++ b/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
@@ -1,4 +1,4 @@
-import {CustomerInfo, PurchasesOffering} from 'react-native-purchases';
+import { CustomerInfo, PurchasesOffering } from 'react-native-purchases';
 
 type RootStackParamList = {
   Home: undefined;

--- a/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
+++ b/examples/purchaseTesterTypescript/app/RootStackParamList.tsx
@@ -1,11 +1,15 @@
-import { CustomerInfo, PurchasesOffering } from 'react-native-purchases';
+import {CustomerInfo, PurchasesOffering} from 'react-native-purchases';
 
 type RootStackParamList = {
   Home: undefined;
   CustomerInfo: {appUserID: String | null, customerInfo: CustomerInfo | null};
   OfferingDetail: {offering: PurchasesOffering | null};
-  Paywall: {offering: PurchasesOffering | null, fontFamily?: string | null};
-  FooterPaywall: {offering: PurchasesOffering | null, fontFamily?: string | null};
+  WinBackTesting: {};
+  Paywall: {offering: PurchasesOffering | null; fontFamily?: string | null};
+  FooterPaywall: {
+    offering: PurchasesOffering | null;
+    fontFamily?: string | null;
+  };
 };
 
 export default RootStackParamList;

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -292,6 +292,14 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
             <Text style={styles.otherActions}>Present paywall</Text>
           </TouchableOpacity>
         </View>
+
+        <Divider />
+        <View>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('WinBackTesting', {})}>
+            <Text style={styles.otherActions}>Win-Back Offer Testing</Text>
+          </TouchableOpacity>
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/examples/purchaseTesterTypescript/app/screens/WinBackTestingScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/WinBackTestingScreen.tsx
@@ -1,0 +1,315 @@
+import React, {useEffect, useState} from 'react';
+import {
+  Button,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {Colors} from 'react-native/Libraries/NewAppScreen';
+import Purchases, {
+  PurchasesPackage,
+  PurchasesStoreProduct,
+  PurchasesWinBackOffer,
+} from 'react-native-purchases';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import RootStackParamList from '../RootStackParamList';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'WinBackTesting'>;
+
+const WinBackTestingScreen: React.FC = () => {
+  const [product, setProduct] = useState<PurchasesStoreProduct>();
+  const [productWinBackOffers, setProductWinBackOffers] = useState<
+    PurchasesWinBackOffer[]
+  >([]);
+  const [aPackage, setPackage] = useState<PurchasesPackage>();
+  const [packageWinBackOffers, setPackageWinBackOffers] = useState<
+    PurchasesWinBackOffer[]
+  >([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProduct = async () => {
+    try {
+      const products = await Purchases.getProducts(['winbackTesting']);
+      if (products.length > 0) {
+        setProduct(products[0]);
+      } else {
+        setError('No products available');
+      }
+    } catch (err) {
+      setError('Failed to fetch products: ' + (err as Error).message);
+    }
+  };
+
+  const purchaseProduct = async (product: PurchasesStoreProduct) => {
+    try {
+      const purchaseResult = await Purchases.purchaseStoreProduct(product);
+      console.log('Purchase successful:', purchaseResult);
+    } catch (err) {
+      console.error('Purchase failed:', err);
+    }
+  };
+
+  const fetchEligibleWinBackOffersForProduct = async (
+    product: PurchasesStoreProduct,
+  ) => {
+    try {
+      const offers = await Purchases.getEligibleWinBackOffersForProduct(
+        product,
+      );
+      if (offers) {
+        setProductWinBackOffers(offers); // Store win-back offers
+      } else {
+        setProductWinBackOffers([]); // Clear if no offers
+      }
+    } catch (err) {
+      console.error('Error fetching win-back offers:', err);
+      setProductWinBackOffers([]);
+    }
+  };
+
+  const fetchEligibleWinBackOffersForPackage = async (
+    aPackage: PurchasesPackage,
+  ) => {
+    try {
+      const offers = await Purchases.getEligibleWinBackOffersForPackage(
+        aPackage,
+      );
+      if (offers) {
+        setPackageWinBackOffers(offers); // Store win-back offers
+      } else {
+        setPackageWinBackOffers([]); // Clear if no offers
+      }
+    } catch (err) {
+      console.error('Error fetching win-back offers:', err);
+      setPackageWinBackOffers([]);
+    }
+  };
+
+  const purchaseWinBackOfferForProduct = async (
+    product: PurchasesStoreProduct,
+    offer: PurchasesWinBackOffer,
+  ) => {
+    try {
+      const result = await Purchases.purchaseProductWithWinBackOffer(
+        product,
+        offer,
+      );
+      console.log('Win-Back Offer purchase successful:', result);
+    } catch (err) {
+      console.error('Win-Back Offer purchase failed:', err);
+    }
+  };
+
+  const fetchPackage = async () => {
+    const currentOffering = (await Purchases.getOfferings()).current;
+    const monthlyPackage = currentOffering?.availablePackages.find(
+      pkg => pkg.identifier === '$rc_monthly',
+    );
+
+    if (monthlyPackage) {
+      setPackage(monthlyPackage);
+    }
+  };
+
+  const purchasePackage = async (aPackage: PurchasesPackage) => {
+    try {
+      const purchaseResult = await Purchases.purchasePackage(aPackage);
+      console.log('Purchase successful:', purchaseResult);
+    } catch (err) {
+      console.error('Purchase failed:', err);
+    }
+  };
+
+  const purchaseWinBackOfferForPackage = async (
+    aPackage: PurchasesPackage,
+    offer: PurchasesWinBackOffer,
+  ) => {
+    try {
+      const result = await Purchases.purchasePackageWithWinBackOffer(
+        aPackage,
+        offer,
+      );
+      console.log('Win-Back Offer purchase successful:', result);
+    } catch (err) {
+      console.error('Win-Back Offer purchase failed:', err);
+    }
+  };
+
+  return (
+    <ScrollView>
+      <Text>
+        Use this screen to fetch eligible win-back offers, purchase products
+        without a win-back offer, and purchase products with an eligible
+        win-back offer.
+      </Text>
+      <Text>
+        This test relies on products and offers defined in the SKConfig file, so
+        be sure to launch the PurchaseTester app from Xcode with the SKConfig
+        file configured.
+      </Text>
+
+      <Button title="Fetch Product" onPress={fetchProduct} />
+
+      {error && <Text style={{color: 'red'}}>{error}</Text>}
+
+      {product && (
+        <View style={styles.productContainer}>
+          <Text style={styles.productTitle}>{product.title}</Text>
+          <Text>{product.description}</Text>
+          <Text>{product.priceString}</Text>
+          <TouchableOpacity
+            style={styles.purchaseButton}
+            onPress={() => purchaseProduct(product)}>
+            <Text style={styles.purchaseButtonText}>Purchase</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.getEligibleWinBackOffersButton}
+            onPress={() => fetchEligibleWinBackOffersForProduct(product)}>
+            <Text style={styles.purchaseButtonText}>
+              Fetch Eligible Win-Back Offers for this Product
+            </Text>
+          </TouchableOpacity>
+
+          {productWinBackOffers.length > 0 && (
+            <View style={styles.winBackContainer}>
+              <Text style={styles.winBackTitle}>
+                Win-Back Offers for Product:
+              </Text>
+              {productWinBackOffers.map((offer, index) => (
+                <View key={index} style={styles.winBackOffer}>
+                  <Text>Identifier: {offer.identifier}</Text>
+                  <Text>Price: {offer.priceString}</Text>
+                  <Text>Cycles: {offer.cycles}</Text>
+                  <Text>Period: {offer.period}</Text>
+                  <Text>Period Unit: {offer.periodUnit}</Text>
+                  <Text>
+                    Period Number of Units: {offer.periodNumberOfUnits}
+                  </Text>
+
+                  <TouchableOpacity
+                    style={styles.purchaseWinBackButton}
+                    onPress={() =>
+                      purchaseWinBackOfferForProduct(product, offer)
+                    }>
+                    <Text style={styles.purchaseWinBackButtonText}>
+                      Purchase Win-Back Offer
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
+
+      <Button title="Fetch Package" onPress={fetchPackage} />
+      {aPackage && (
+        <View style={styles.productContainer}>
+          <Text style={styles.productTitle}>{aPackage.identifier}</Text>
+          <Text>{aPackage.product.description}</Text>
+          <Text>{aPackage.product.priceString}</Text>
+
+          <TouchableOpacity
+            style={styles.purchaseButton}
+            onPress={() => purchasePackage(aPackage)}>
+            <Text style={styles.purchaseButtonText}>Purchase</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.getEligibleWinBackOffersButton}
+            onPress={() => fetchEligibleWinBackOffersForPackage(aPackage)}>
+            <Text style={styles.purchaseButtonText}>
+              Fetch Eligible Win-Back Offers for this Package
+            </Text>
+          </TouchableOpacity>
+
+          {packageWinBackOffers.map((offer, index) => (
+            <View key={index} style={styles.winBackOffer}>
+              <Text>Identifier: {offer.identifier}</Text>
+              <Text>Price: {offer.priceString}</Text>
+              <Text>Cycles: {offer.cycles}</Text>
+              <Text>Period: {offer.period}</Text>
+              <Text>Period Unit: {offer.periodUnit}</Text>
+              <Text>Period Number of Units: {offer.periodNumberOfUnits}</Text>
+
+              <TouchableOpacity
+                style={styles.purchaseWinBackButton}
+                onPress={() => purchaseWinBackOfferForPackage(aPackage, offer)}>
+                <Text style={styles.purchaseWinBackButtonText}>
+                  Purchase Win-Back Offer
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  productContainer: {
+    marginTop: 16,
+    padding: 16,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+  productTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  purchaseButton: {
+    marginTop: 10,
+    backgroundColor: 'lightcoral',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  getEligibleWinBackOffersButton: {
+    marginTop: 10,
+    backgroundColor: 'blue',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  purchaseButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+  winBackContainer: {
+    marginTop: 16,
+    padding: 16,
+    borderColor: '#cccccc',
+    borderWidth: 1,
+    borderRadius: 8,
+    backgroundColor: '#f9f9f9',
+  },
+  winBackTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  winBackOffer: {
+    marginBottom: 10,
+  },
+  purchaseWinBackButton: {
+    marginTop: 10,
+    backgroundColor: 'green',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  purchaseWinBackButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+});
+
+export default WinBackTestingScreen;

--- a/examples/purchaseTesterTypescript/ios/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
+++ b/examples/purchaseTesterTypescript/ios/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
@@ -60,6 +60,9 @@
             ReferencedContainer = "container:PurchaseTester.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../RevenueCast_PurchaseTesterTypescriptConfiguration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/examples/purchaseTesterTypescript/ios/RevenueCast_PurchaseTesterTypescriptConfiguration.storekit
+++ b/examples/purchaseTesterTypescript/ios/RevenueCast_PurchaseTesterTypescriptConfiguration.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "3B56BC8C",
   "nonRenewingSubscriptions" : [
 
@@ -51,7 +61,60 @@
     }
   ],
   "settings" : {
-
+    "_compatibilityTimeRate" : {
+      "3" : 6
+    },
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ],
+    "_timeRate" : 1002
   },
   "subscriptionGroups" : [
     {
@@ -63,6 +126,9 @@
       "subscriptions" : [
         {
           "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
 
           ],
           "displayPrice" : "",
@@ -81,10 +147,16 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Test Increase 29.99 -> 49.99",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
 
           ],
           "displayPrice" : "",
@@ -103,13 +175,19 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Monthly $10.99",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         },
         {
           "adHocOffers" : [
 
           ],
-          "displayPrice" : "",
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "9D3DBCD0",
@@ -125,10 +203,23 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Monthly $4.99, 1-week free",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "36CBE933",
+              "isEligible" : true,
+              "offerID" : "winback.1w0",
+              "paymentMode" : "free",
+              "referenceName" : "1w0",
+              "subscriptionPeriod" : "P1W"
+            }
+          ]
         },
         {
           "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
 
           ],
           "displayPrice" : "",
@@ -147,7 +238,45 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Annual $39.99, 2-weeks free",
           "subscriptionGroupID" : "D833F705",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "20B5D81E",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Testing winback offers",
+              "displayName" : "Winback Test Product",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "winbackTesting",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Winback Testing Product",
+          "subscriptionGroupID" : "D833F705",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+            {
+              "internalID" : "D324A8BC",
+              "isEligible" : true,
+              "offerID" : "winback.1m0",
+              "paymentMode" : "free",
+              "referenceName" : "1m0 Winback",
+              "subscriptionPeriod" : "P1M"
+            }
+          ]
         }
       ]
     },
@@ -160,6 +289,9 @@
       "subscriptions" : [
         {
           "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
 
           ],
           "displayPrice" : "",
@@ -178,13 +310,16 @@
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Annual $39.99, 1-week free",
           "subscriptionGroupID" : "CAB34497",
-          "type" : "RecurringSubscription"
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
         }
       ]
     }
   ],
   "version" : {
-    "major" : 1,
-    "minor" : 1
+    "major" : 4,
+    "minor" : 0
   }
 }

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -264,10 +264,7 @@ RCT_EXPORT_METHOD(eligibleWinBackOffersForProductIdentifier:(nonnull NSString *)
             }
         }];
     } else {
-        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
-        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
-                                                    code:RCUnsupportedError
-                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
         reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
     }
 }
@@ -281,10 +278,7 @@ RCT_EXPORT_METHOD(purchaseProductWithWinBackOffer:(nonnull NSString *)productID
                                 winBackOfferID:winBackOfferID
                                completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
     } else {
-        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
-        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
-                                                    code:RCUnsupportedError
-                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
         reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
     }
 }
@@ -300,10 +294,7 @@ RCT_EXPORT_METHOD(purchasePackageWithWinBackOffer:(nonnull NSString *)packageID
                                 winBackOfferID:winBackOfferID
                                completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
     } else {
-        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
-        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
-                                                    code:RCUnsupportedError
-                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
         reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
     }
 }
@@ -506,10 +497,7 @@ RCT_EXPORT_METHOD(recordPurchaseForProductID:(nonnull NSString *)productID
                                                completion:[self getResponseCompletionBlockWithResolve:resolve
                                                                                                reject:reject]];
     } else {
-        NSString* description = @"Tried to handle transaction made by your app, but this functionality is only available on iOS 15.0 or greater.";
-        NSError* error = [[NSError alloc] initWithDomain: RCPurchasesErrorCodeDomain
-                                                    code: RCUnsupportedError
-                                                userInfo: @{NSLocalizedDescriptionKey : description}];
+        NSError *error = [self createUnsupportedErrorWithDescription:@"Tried to handle transaction made by your app, but this functionality is only available on iOS 15.0 or greater."];
         reject([NSString stringWithFormat:@"%ld", (long) error.code], [error localizedDescription], error);
     }
 }
@@ -563,6 +551,12 @@ readyForPromotedProduct:(RCStoreProduct *)product
             [self rejectPromiseWithBlock:reject error:error];
         }
     };
+}
+
+- (NSError *)createUnsupportedErrorWithDescription:(NSString *)description {
+    return [[NSError alloc] initWithDomain:RCPurchasesErrorCodeDomain
+                                      code:RCUnsupportedError
+                                  userInfo:@{NSLocalizedDescriptionKey : description}];
 }
 
 - (NSString *)platformFlavor {

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -246,6 +246,69 @@ static void logUnavailablePresentCodeRedemptionSheet() {
     NSLog(@"[Purchases] Warning: tried to present codeRedemptionSheet, but it's only available on iOS 14.0 or greater.");
 }
 
+#pragma mark - Win-Back getOfferings
+RCT_EXPORT_METHOD(eligibleWinBackOffersForProductIdentifier:(nonnull NSString *)productID
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
+        [RCCommonFunctionality eligibleWinBackOffersForProductIdentifier:productID
+                                                         completionBlock:^(NSArray<NSDictionary *> * _Nullable offers, RCErrorContainer * _Nullable errorContainer) {
+            if (errorContainer) {
+                reject(
+                    [NSString stringWithFormat:@"%ld", (long)errorContainer.code],
+                    errorContainer.message,
+                    errorContainer.error
+                );
+            } else {
+                resolve(offers ?: @[]);
+            }
+        }];
+    } else {
+        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
+        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
+                                                    code:RCUnsupportedError
+                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
+    }
+}
+
+RCT_EXPORT_METHOD(purchaseProductWithWinBackOffer:(nonnull NSString *)productID
+                                   winBackOfferID:(nonnull NSString *)winBackOfferID
+                                          resolve:(RCTPromiseResolveBlock)resolve
+                                           reject:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
+        [RCCommonFunctionality purchaseProduct:productID
+                                winBackOfferID:winBackOfferID
+                               completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
+    } else {
+        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
+        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
+                                                    code:RCUnsupportedError
+                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
+    }
+}
+
+RCT_EXPORT_METHOD(purchasePackageWithWinBackOffer:(nonnull NSString *)packageID
+                         presentedOfferingContext:(NSDictionary *)presentedOfferingContext
+                                   winBackOfferID:(nonnull NSString *)winBackOfferID
+                                          resolve:(RCTPromiseResolveBlock)resolve
+                                           reject:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
+        [RCCommonFunctionality purchasePackage:packageID
+                      presentedOfferingContext:presentedOfferingContext
+                                winBackOfferID:winBackOfferID
+                               completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
+    } else {
+        NSString *description = @"iOS win-back offers are only available on iOS 18.0 or greater.";
+        NSError *error = [[NSError alloc] initWithDomain:@"RCPurchasesErrorCodeDomain"
+                                                    code:RCUnsupportedError
+                                                userInfo:@{NSLocalizedDescriptionKey: description}];
+        reject([NSString stringWithFormat:@"%ld", (long)error.code], [error localizedDescription], error);
+    }
+}
+
+
 #pragma mark - Subscriber Attributes
 
 RCT_EXPORT_METHOD(setProxyURLString:(nullable NSString *)proxyURLString

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -910,14 +910,13 @@ export default class Purchases {
    * iOS only. Use this function to retrieve the `PurchasesPromotionalOffer` for a given `PurchasesPackage`.
    *
    * @param product The `PurchasesStoreProduct` the user intends to purchase.
-   * @param discount The `PurchasesStoreProductDiscount` to apply to the product.
-   * @returns { Promise<PurchasesPromotionalOffer> } Returns when the `PurchasesPaymentDiscount` is returned.
+   * @returns { Promise<[PurchasesWinBackOffer]> } Returns an array of win-back offers that the subscriber is eligible for.
    * Null is returned for Android and incompatible iOS versions. The promise will be rejected if configure has not been
    * called yet or if there's an error getting the payment discount.
    */
   public static async getEligibleWinBackOffersForProduct(
     product: PurchasesStoreProduct
-  ): Promise<PurchasesWinBackOffer | undefined> {
+  ): Promise<[PurchasesWinBackOffer] | undefined> {
     await Purchases.throwIfNotConfigured();
     if (Platform.OS === "android") {
       return Promise.resolve(undefined);
@@ -931,15 +930,14 @@ export default class Purchases {
   /**
    * iOS only. Use this function to retrieve the `PurchasesPromotionalOffer` for a given `PurchasesPackage`.
    *
-   * @param product The `PurchasesStoreProduct` the user intends to purchase.
-   * @param discount The `PurchasesStoreProductDiscount` to apply to the product.
-   * @returns { Promise<PurchasesPromotionalOffer> } Returns when the `PurchasesPaymentDiscount` is returned.
+   * @param aPackage The `PurchasesPackage` the user intends to purchase.
+   * @returns { Promise<[PurchasesWinBackOffer]> } Returns an array of win-back offers that the subscriber is eligible for.
    * Null is returned for Android and incompatible iOS versions. The promise will be rejected if configure has not been
    * called yet or if there's an error getting the payment discount.
    */
   public static async getEligibleWinBackOffersForPackage(
     aPackage: PurchasesPackage
-  ): Promise<PurchasesWinBackOffer | undefined> {
+  ): Promise<[PurchasesWinBackOffer] | undefined> {
     await Purchases.throwIfNotConfigured();
     if (Platform.OS === "android") {
       return Promise.resolve(undefined);

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -907,7 +907,8 @@ export default class Purchases {
   }
 
   /**
-   * iOS only. Use this function to retrieve the `PurchasesPromotionalOffer` for a given `PurchasesPackage`.
+   * iOS only. Use this function to retrieve the eligible `PurchasesWinBackOffer`s that a subscriber
+   * is eligible for for a given `PurchasesProduct`.
    *
    * @param product The `PurchasesStoreProduct` the user intends to purchase.
    * @returns { Promise<[PurchasesWinBackOffer]> } Returns an array of win-back offers that the subscriber is eligible for.
@@ -928,7 +929,8 @@ export default class Purchases {
   }
 
   /**
-   * iOS only. Use this function to retrieve the `PurchasesPromotionalOffer` for a given `PurchasesPackage`.
+   * iOS only. Use this function to retrieve the eligible `PurchasesWinBackOffer`s that a subscriber
+   * is eligible for for a given `PurchasesPackage`.
    *
    * @param aPackage The `PurchasesPackage` the user intends to purchase.
    * @returns { Promise<[PurchasesWinBackOffer]> } Returns an array of win-back offers that the subscriber is eligible for.


### PR DESCRIPTION
This PR exposes four new functions to allow developers to fetch & redeem win-back offers that a subscriber is eligible for in their custom paywalls. These functions only function on iOS 18.0+ and require StoreKit 2 to be used.

### Fetching Eligible Win-Back Offers
```typescript
public static async getEligibleWinBackOffersForProduct(
    product: PurchasesStoreProduct
  ): Promise<[PurchasesWinBackOffer] | undefined>

public static async getEligibleWinBackOffersForPackage(
    aPackage: PurchasesPackage
  ): Promise<[PurchasesWinBackOffer] | undefined>
```

### Redeeming Win-Back Offers
```typescript
public static async purchaseProductWithWinBackOffer(
    product: PurchasesStoreProduct,
    winBackOffer: PurchasesWinBackOffer
  ): Promise<MakePurchaseResult>

public static async purchasePackageWithWinBackOffer(
    aPackage: PurchasesPackage,
    winBackOffer: PurchasesWinBackOffer
  ): Promise<MakePurchaseResult>
```

### Other Changes
The PurchaseTester app was updated with a new screen to support testing these flows

### Testing
All flows were tested manually through the new screen in the PurchaseTester app.
