### PR TITLE
Fix Typescript definition of onManagementOptionSelected

### DIFF
--- a/apitesters/customer_center.tsx
+++ b/apitesters/customer_center.tsx
@@ -1,6 +1,6 @@
 import RevenueCatUI from "../react-native-purchases-ui";
 import type { CustomerInfo, PurchasesError, REFUND_REQUEST_STATUS } from "@revenuecat/purchases-typescript-internal";
-import type { CustomerCenterManagementOption } from "../react-native-purchases-ui/src";
+import type { CustomerCenterManagementOption, CustomerCenterManagementOptionEvent } from "../react-native-purchases-ui/src";
 // Basic API validation
 async function checkPresentCustomerCenter() {
   await RevenueCatUI.presentCustomerCenter();
@@ -17,7 +17,7 @@ async function checkWithCallbacks() {
       onRestoreFailed: ({ error }: { error: PurchasesError }) => {},
       onRefundRequestStarted: ({ productIdentifier }: { productIdentifier: string }) => {},
       onRefundRequestCompleted: ({ productIdentifier, refundRequestStatus }: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => {},
-      onManagementOptionSelected: ({ option, url }: { option: CustomerCenterManagementOption; url: string }) => {},
+      onManagementOptionSelected: ({option, url}: CustomerCenterManagementOptionEvent) => {},
     }
   });
 }

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -14,7 +14,7 @@ import Purchases, {
   CustomerInfo,
   PurchasesOfferings,
 } from 'react-native-purchases';
-import RevenueCatUI, { CustomerCenterManagementOption } from 'react-native-purchases-ui';
+import RevenueCatUI, { CustomerCenterManagementOption, CustomerCenterManagementOptionEvent } from 'react-native-purchases-ui';
 
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 
@@ -336,8 +336,12 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
                     onRefundRequestCompleted: ({productIdentifier, refundRequestStatus}: {productIdentifier: string, refundRequestStatus: REFUND_REQUEST_STATUS}) => {
                       console.log('✅ CUSTOMER CENTER - Refund request completed for product:', productIdentifier, 'with status:', refundRequestStatus);
                     },
-                    onManagementOptionSelected: ({option, url}: {option: CustomerCenterManagementOption, url: string}) => {
-                      console.log('🔍 CUSTOMER CENTER - Management option selected:', option, 'with URL:', url);
+                    onManagementOptionSelected: ({option, url}: CustomerCenterManagementOptionEvent) => {
+                      if (option === 'custom_url') {
+                        console.log('🔍 CUSTOMER CENTER - Management option selected:', option, 'with URL:', url);
+                      } else {
+                        console.log('🔍 CUSTOMER CENTER - Management option selected:', option);
+                      }
                     }
                   }
                 });

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -166,6 +166,10 @@ export type CustomerCenterManagementOption =
   | 'unknown'
   | string; // This is to prevent breaking changes when the native SDK adds new options
 
+export type CustomerCenterManagementOptionEvent = 
+  | { option: 'custom_url'; url: string }
+  | { option: Exclude<CustomerCenterManagementOption, 'custom_url'>; url: null };
+
 export interface CustomerCenterCallbacks {
   /**
    * Called when a feedback survey is completed with the selected option ID.
@@ -203,9 +207,11 @@ export interface CustomerCenterCallbacks {
   onRefundRequestCompleted?: ({productIdentifier, refundRequestStatus}: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => void;
 
   /**
-   * Called when a customer center management option is selected with the option ID and URL.
+   * Called when a customer center management option is selected.
+   * For 'custom_url' options, the url parameter will contain the URL.
+   * For all other options, the url parameter will be null.
    */
-  onManagementOptionSelected?: ({option, url}: { option: CustomerCenterManagementOption; url: string }) => void;
+  onManagementOptionSelected?: (event: CustomerCenterManagementOptionEvent) => void;
 }
 
 export interface PresentCustomerCenterParams {
@@ -443,7 +449,7 @@ export default class RevenueCatUI {
       if (callbacks.onManagementOptionSelected) {
         const subscription = customerCenterEventEmitter.addListener(
           'onManagementOptionSelected',
-          (event: { option: CustomerCenterManagementOption; url: string }) => callbacks.onManagementOptionSelected && 
+          (event: CustomerCenterManagementOptionEvent) => callbacks.onManagementOptionSelected && 
             callbacks.onManagementOptionSelected(event)
         );
         subscriptions.push(subscription);


### PR DESCRIPTION
This PR fixes the type definition of the `onManagementOptionSelected` callback to accurately reflect its runtime behavior. While this is technically a breaking change in the type system, I believe this should be considered a bug fix rather than requiring a major version bump.

## Current Problem

The current type definition incorrectly suggests that the `url` parameter is always a string:

```typescript
onManagementOptionSelected: ({option, url}: {option: CustomerCenterManagementOption, url: string}) => void
```

However, this doesn't match the actual runtime behavior in the native implementations:

iOS:
```objective-c
[self sendEventWithName:@"onManagementOptionSelected" body:@{
    @"option": optionID, 
    @"url": url ?: [NSNull null]  // url can be null
}];
```

Android:
```kotlin
override fun onManagementOptionSelectedWrapper(action: String, url: String?) {  // url is nullable
    val params = WritableNativeMap().apply {
        putString("option", action)
        putString("url", url)
    }
    sendEvent("onManagementOptionSelected", params)
}
```

This mismatch between types and runtime behavior can lead to runtime errors when developers assume `url` is always a string based on the type definition.

## Solution

Update the type definition to accurately reflect that `url` is only available for 'custom_url' options:

```typescript
type CustomerCenterManagementOptionEvent = 
  | { option: 'custom_url'; url: string }
  | { option: Exclude<CustomerCenterManagementOption, 'custom_url'>; url: null };

onManagementOptionSelected: (event: CustomerCenterManagementOptionEvent) => void
```

## Why This Isn't a Breaking Change

While this change will cause TypeScript errors in existing code that assumes `url` is always a string, I argue this should be treated as a bug fix rather than a breaking change because:

1. The current type definition is incorrect and doesn't match the actual runtime behavior
2. Code relying on the current type definition could crash at runtime when `url` is null
3. This change doesn't modify any runtime behavior; it only makes the types accurately reflect what's already happening
4. The change helps prevent runtime errors by forcing proper handling of the null case

This is similar to other cases where fixing incorrect type definitions that could lead to runtime errors is considered a bug fix, even if it breaks type checking in existing code. The primary goal of type definitions is to prevent runtime errors, and the current definition fails to do that.

## Migration

For users who need to migrate their code:

```typescript
// Before (unsafe - could crash at runtime)
onManagementOptionSelected: ({option, url}) => {
  console.log(url.toLowerCase()); // Could crash if url is null
}

// After (safe)
onManagementOptionSelected: ({option, url}) => {
  if (option === 'custom_url') {
    console.log(url.toLowerCase()); // TypeScript knows url is string
  } else {
    // TypeScript knows url is null
  }
}
```