### PR TITLE
Fix crash on Paywalls when setting options with null offering

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -60,9 +60,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
     }
 
     private fun setOfferingIdProp(view: T, props: ReadableMap?) {
-        val offeringIdentifier =
-            props?.getDynamic(OPTION_OFFERING)?.asMap()?.getString(OFFERING_IDENTIFIER)
-        offeringIdentifier?.let {
+        props?.getString(OFFERING_IDENTIFIER)?.let {
             setOfferingId(view, it)
         }
     }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -28,6 +28,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
         private const val OPTION_OFFERING = "offering"
         private const val OFFERING_IDENTIFIER = "identifier"
         private const val OPTION_FONT_FAMILY = "fontFamily"
+        private const val OPTION_DISPLAY_CLOSE_BUTTON = "displayCloseButton"
     }
 
     abstract fun setOfferingId(view: T, identifier: String)
@@ -52,21 +53,32 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
 
     @ReactProp(name = PROP_OPTIONS)
     fun setOptions(view: T, options: ReadableMap?) {
-        options?.let { props ->
-            setOfferingIdProp(view, props)
-            setFontFamilyProp(view, props)
-            setDisplayCloseButton(view, props)
+        if (options != null) {
+            setOfferingIdProp(view, options)
+            setFontFamilyProp(view, options)
+            setDisplayCloseButton(view, options)
         }
     }
 
-    private fun setOfferingIdProp(view: T, props: ReadableMap?) {
-        props?.getString(OFFERING_IDENTIFIER)?.let {
+    private fun setOfferingIdProp(view: T, options: ReadableMap?) {
+        val optionsMap = options?.toHashMap()
+        if (optionsMap == null || !optionsMap.containsKey(OPTION_OFFERING)) {
+            return
+        }
+        if (optionsMap[OPTION_OFFERING] == null) {
+            // getDynamic crashes if the value is null, that's why we use props?.toHashMap
+            return
+        }
+        // this is a workaround for the fact that getDynamic doesn't work with null values
+        val offeringIdentifier =
+            options.getDynamic(OPTION_OFFERING)?.asMap()?.getString(OFFERING_IDENTIFIER)
+        offeringIdentifier?.let {
             setOfferingId(view, it)
         }
     }
 
-    private fun setFontFamilyProp(view: T, props: ReadableMap?) {
-        props?.getString(OPTION_FONT_FAMILY)?.let {
+    private fun setFontFamilyProp(view: T, options: ReadableMap?) {
+        options?.getString(OPTION_FONT_FAMILY)?.let {
             FontAssetManager.getFontFamily(fontFamilyName = it, view.resources.assets)?.let {
                 setFontFamily(view, CustomFontProvider(it))
             }
@@ -74,8 +86,8 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
     }
 
     private fun setDisplayCloseButton(view: T, options: ReadableMap) {
-        options.takeIf { it.hasKey("displayCloseButton") }?.let {
-            setDisplayDismissButton(view, it.getBoolean("displayCloseButton"))
+        options.takeIf { it.hasKey(OPTION_DISPLAY_CLOSE_BUTTON) }?.let {
+            setDisplayDismissButton(view, it.getBoolean(OPTION_DISPLAY_CLOSE_BUTTON))
         }
     }
 


### PR DESCRIPTION
Fixes #1153 

![image](https://github.com/user-attachments/assets/b177db82-b01d-4a63-adfe-f528426b60cc)

This was caused by an NPE that was a bit hidden.

I managed to find the stacktrace

![image](https://github.com/user-attachments/assets/65be6347-4f72-47c9-a969-48649ade5e5e)

And noticed that this happens when there are options and offerings is null:
![image](https://github.com/user-attachments/assets/d3c2ff67-f018-43f4-b4b0-90da558040bd)

I think this might have started happening on a recent version of RN, if the internal code changed.