### PR TITLE
Virtual Currency Balances

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1406,6 +1406,18 @@ describe("Purchases", () => {
         expect(NativeModules.RNPurchases.beginRefundRequestForProductId).toBeCalledTimes(1);
         expect(NativeModules.RNPurchases.beginRefundRequestForProductId).toBeCalledWith("onemonth_freetrial");
       });
+
+      it("correctly parses virtual currency info", async () => {
+        NativeModules.RNPurchases.getCustomerInfo.mockResolvedValueOnce(
+          customerInfoStub
+        );
+
+        const customerInfo = await Purchases.getCustomerInfo();
+
+        expect(NativeModules.RNPurchases.getCustomerInfo).toBeCalledTimes(1);
+        expect(customerInfo.virtualCurrencies.length).toEqual(1);
+        expect(customerInfo.virtualCurrencies["RC_COIN"].balance).toEqual(100);
+      });
     });
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1415,7 +1415,7 @@ describe("Purchases", () => {
         const customerInfo = await Purchases.getCustomerInfo();
 
         expect(NativeModules.RNPurchases.getCustomerInfo).toBeCalledTimes(1);
-        expect(customerInfo.virtualCurrencies.length).toEqual(1);
+        expect(Object.keys(customerInfo.virtualCurrencies).length).toEqual(1);
         expect(customerInfo.virtualCurrencies["RC_COIN"].balance).toEqual(100);
       });
     });

--- a/apitesters/customerInfo.ts
+++ b/apitesters/customerInfo.ts
@@ -3,7 +3,8 @@ import {
   CustomerInfo,
   PurchasesEntitlementInfo,
   PurchasesEntitlementInfos,
-  PurchasesStoreTransaction
+  PurchasesStoreTransaction,
+  PurchasesVirtualCurrencyInfo
 } from "../src";
 
 function checkLoginResult(result: LogInResult) {
@@ -25,6 +26,7 @@ function checkCustomerInfo(info: CustomerInfo) {
   const originalPurchaseDate: string | null = info.originalPurchaseDate;
   const managementURL: string | null = info.managementURL;
   const nonSubscriptionTransactions: PurchasesStoreTransaction[] = info.nonSubscriptionTransactions;
+  const virtualCurrencies: { [virtualCurrencyCode: string]: PurchasesVirtualCurrencyInfo } = info.virtualCurrencies;
 }
 
 function checkEntitlementInfos(infos: PurchasesEntitlementInfos) {

--- a/apitesters/virtualCurrencyInfo.ts
+++ b/apitesters/virtualCurrencyInfo.ts
@@ -1,0 +1,5 @@
+import { PurchasesVirtualCurrencyInfo } from "../src";
+
+function checkVirtualCurrencyInfo(info: PurchasesVirtualCurrencyInfo) {
+  const balance: number = info.balance;
+}

--- a/examples/purchaseTesterTypescript/app/screens/CustomerInfoScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/CustomerInfoScreen.tsx
@@ -4,7 +4,10 @@ import {ScrollView, StyleSheet, Text, useColorScheme, View,} from 'react-native'
 
 import {Colors,} from 'react-native/Libraries/NewAppScreen';
 
-import {CustomerInfo} from 'react-native-purchases';
+import {
+  CustomerInfo,
+  PurchasesVirtualCurrencyInfo,
+} from 'react-native-purchases';
 
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -51,6 +54,17 @@ const InfoTab: React.FC<{
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
 
+  const formatVirtualCurrencies = (
+    virtualCurrencies: {[key: string]: PurchasesVirtualCurrencyInfo}
+  ) => {
+    if (!virtualCurrencies || Object.keys(virtualCurrencies).length === 0) {
+      return 'N/A';
+    }
+    return Object.entries(virtualCurrencies)
+      .map(([code, info]) => `${code}: ${info.balance}`)
+      .join('\n');
+  };
+
   return (
     <ScrollView
         contentInsetAdjustmentBehavior="automatic"
@@ -62,6 +76,7 @@ const InfoTab: React.FC<{
         <Section title='Original Purchase Date' value={customerInfo?.originalPurchaseDate} />
         <Section title='Latest Expiration Date' value={customerInfo?.latestExpirationDate} />
         <Section title='Request Date' value={customerInfo?.requestDate} />
+        <Section title='Virtual Currencies' value={formatVirtualCurrencies(customerInfo?.virtualCurrencies)} />
     </ScrollView>
   );
 };

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -59,7 +59,12 @@ global.customerInfoStub = {
   originalAppUserId: "9AE22FE1-D0A3-4341-85B6-D1D6C24C404A",
   originalApplicationVersion: null,
   requestDate: "2019-12-03T00:47:58.000Z",
-  managementURL: "https://url.com"
+  managementURL: "https://url.com",
+  virtualCurrencies: {
+    RC_COIN: {
+      balance: 100,
+    }
+  },
 };
 global.transactionStub = {
     productIdentifier: "com.revenuecat.purchases_hybrid_common.monthly_19.99_.1_week_intro",


### PR DESCRIPTION
This PR introduces the ability for developers to fetch virtual currency balances in the React Native SDK through the `CustomerInfo` object. Specifically, the PR:
- Adds the virtual currency APIs to the API testers
- Adds a unit test for parsing the VC balance on CustomerInfo
- Adds the virtual currency balances to the CustomerInfo screen in the purchase test

In addition to the automated tests, I also manually tested the virtual currency balances through the purchase tester app on both iOS and Android.

<img width="574" alt="Screenshot 2025-04-01 at 2 47 34 PM" src="https://github.com/user-attachments/assets/d6d78940-e95e-46d2-b776-3b7c23f13e78" />

### Next Steps
Once approved, I'll merge this into `virtual-currency-dev`, and will create a beta release from there.
