### PR TITLE
[EXTERNAL] Correctly sets RevenueCatUI podspec platform to `13.0` to fix compatibility issue (#1246) via @rgomezp

### DIFF
--- a/react-native-purchases-ui/RNPaywalls.podspec
+++ b/react-native-purchases-ui/RNPaywalls.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.authors      = package['author']
   spec.homepage     = "https://github.com/RevenueCat/react-native-purchases"
   spec.license      = package['license']
-  spec.platform     = :ios, "11.0"
+  spec.platform     = :ios, "13.4"
 
   spec.source       = { :git => "https://github.com/RevenueCat/react-native-purchases.git" }
   spec.source_files = "ios/**/*.{h,m,swift}"

--- a/react-native-purchases-ui/RNPaywalls.podspec
+++ b/react-native-purchases-ui/RNPaywalls.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.authors      = package['author']
   spec.homepage     = "https://github.com/RevenueCat/react-native-purchases"
   spec.license      = package['license']
-  spec.platform     = :ios, "13.4"
+  spec.platform     = :ios, "13.0"
 
   spec.source       = { :git => "https://github.com/RevenueCat/react-native-purchases.git" }
   spec.source_files = "ios/**/*.{h,m,swift}"


### PR DESCRIPTION

Contributed by @rgomezp in #1246. Original description below.
  
---------

Fixes #1148 

When installing both `react-native-purchases` and `react-native-purchases-ui` we get a build issue due to the platform targets not lining up.

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.
  
  No unit tests
