### PR TITLE
feat: Implement JS-only mock SDK for Expo Go

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,3 +49,37 @@ Make sure the Android device doesn't have any app with the same package name you
 ---
 
 Make sure your Android emulator has play services and you're logged in
+
+---
+
+### Expo Go Mock Mode
+
+For a streamlined development experience in JavaScript-only environments, particularly **Expo Go**, the RevenueCat SDK includes a mock mode.
+
+**Automatic Activation in Expo Go:**
+This mock mode is **enabled automatically** when the SDK detects it is running within the Expo Go client environment. This means no manual setup is required to use the mock SDK when you are developing and testing your app with Expo Go.
+
+**Manual Activation with Global Flag:**
+You can also manually enable the mock mode in other JavaScript-only environments (or for specific testing scenarios outside of Expo Go detection) by setting a global variable *before* the RevenueCat SDK is imported:
+
+```javascript
+global.__EXPO_GO_MOCK_REVENUECAT__ = true;
+```
+
+If this flag is set to `true`, mock mode will be enabled even if an Expo Go environment is not detected. Note that if Expo Go *is* detected, mock mode will be active regardless of this flag's value (due to the automatic activation).
+
+**Behavior in Mock Mode:**
+When mock mode is active (either automatically via Expo Go detection or manually via the global flag):
+
+*   **Core SDK (`react-native-purchases`):**
+    *   All API calls will return sensible mock data (e.g., mock CustomerInfo, Offerings).
+    *   No actual native purchasing modules will be called, preventing errors in environments where native code is not available or fully built.
+*   **UI SDK (`react-native-purchases-ui`):**
+    *   The `Paywall` component will render a placeholder UI instead of the native paywall.
+    *   This placeholder allows you to simulate:
+        *   A successful purchase.
+        *   A cancelled purchase or an error.
+        *   A restore operation.
+    *   Methods like `presentPaywall()` will log their invocation but will not display a separate modal in mock mode; testing the visual paywall flow should be done using the `<Paywall />` component.
+
+This setup allows you to test your RevenueCat integration's logic, API calls, and purchase/restore flows within Expo Go without needing to create a custom development build immediately.

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     ]
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal": "13.32.0"
+    "@revenuecat/purchases-typescript-internal": "13.32.0",
+    "expo-constants": "~16.0.2"
   }
 }

--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -52,6 +52,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {
+    "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.12",
     "@types/react": "^18.2.44",
     "@types/react-dom": "~18.2.0",
@@ -115,6 +116,7 @@
   },
   "dependencies": {
     "@revenuecat/purchases-typescript-internal": "13.32.0",
-    "react-native-purchases": "8.10.1"
+    "react-native-purchases": "8.10.1",
+    "expo-constants": "~16.0.2"
   }
 }

--- a/react-native-purchases-ui/src/RevenueCatUIMock.tsx
+++ b/react-native-purchases-ui/src/RevenueCatUIMock.tsx
@@ -1,0 +1,465 @@
+import React, { ReactNode } from 'react';
+import { View, Text, StyleSheet, StyleProp, ViewStyle, TouchableOpacity } from 'react-native'; // Removed Modal, Button
+import {
+  PAYWALL_RESULT,
+  CustomerInfo,
+  PurchasesError,
+  PurchasesOffering,
+  PurchasesPackage,
+  PurchasesStoreTransaction,
+  REFUND_REQUEST_STATUS,
+  VERIFICATION_RESULT,
+  PURCHASES_ERROR_CODE, // Added for mockPurchasesErrorPlaceholder
+  PRODUCT_CATEGORY, // Added for mockPackage
+  PACKAGE_TYPE, // Added for mockPackage
+} from '@revenuecat/purchases-typescript-internal';
+import Purchases from 'react-native-purchases'; // To use the potentially mocked Purchases module
+
+// Replicating prop types from react-native-purchases-ui/src/index.tsx
+// as they are not exported directly for reuse.
+
+export interface PresentPaywallParams {
+  displayCloseButton?: boolean;
+  offering?: PurchasesOffering;
+  fontFamily?: string | null;
+}
+
+export type PresentPaywallIfNeededParams = PresentPaywallParams & {
+  requiredEntitlementIdentifier: string;
+};
+
+export interface PaywallViewOptions {
+  offering?: PurchasesOffering | null;
+  fontFamily?: string | null;
+}
+
+export interface FullScreenPaywallViewOptions extends PaywallViewOptions {
+  displayCloseButton?: boolean | false;
+}
+
+export interface FooterPaywallViewOptions extends PaywallViewOptions {
+  // Future properties can be added here
+}
+
+export type FullScreenPaywallViewProps = {
+  style?: StyleProp<ViewStyle>;
+  children?: ReactNode;
+  options?: FullScreenPaywallViewOptions;
+  onPurchaseStarted?: ({ packageBeingPurchased }: { packageBeingPurchased: PurchasesPackage }) => void;
+  onPurchaseCompleted?: ({
+                           customerInfo,
+                           storeTransaction
+                         }: { customerInfo: CustomerInfo, storeTransaction: PurchasesStoreTransaction }) => void;
+  onPurchaseError?: ({ error }: { error: PurchasesError }) => void;
+  onPurchaseCancelled?: () => void;
+  onRestoreStarted?: () => void;
+  onRestoreCompleted?: ({ customerInfo }: { customerInfo: CustomerInfo }) => void;
+  onRestoreError?: ({ error }: { error: PurchasesError }) => void;
+  onDismiss?: () => void;
+};
+
+export type FooterPaywallViewProps = {
+  style?: StyleProp<ViewStyle>;
+  children?: ReactNode;
+  options?: FooterPaywallViewOptions;
+  onPurchaseStarted?: ({packageBeingPurchased}: { packageBeingPurchased: PurchasesPackage }) => void;
+  onPurchaseCompleted?: ({
+                           customerInfo,
+                           storeTransaction
+                         }: { customerInfo: CustomerInfo, storeTransaction: PurchasesStoreTransaction }) => void;
+  onPurchaseError?: ({error}: { error: PurchasesError }) => void;
+  onPurchaseCancelled?: () => void;
+  onRestoreStarted?: () => void;
+  onRestoreCompleted?: ({customerInfo}: { customerInfo: CustomerInfo }) => void;
+  onRestoreError?: ({error}: { error: PurchasesError }) => void;
+  onDismiss?: () => void;
+};
+
+export type CustomerCenterManagementOption =
+  | 'cancel'
+  | 'custom_url'
+  | 'missing_purchase'
+  | 'refund_request'
+  | 'change_plans'
+  | 'unknown'
+  | string;
+
+export type CustomerCenterManagementOptionEvent =
+  | { option: 'custom_url'; url: string }
+  | { option: Exclude<CustomerCenterManagementOption, 'custom_url'>; url: null };
+
+export interface CustomerCenterCallbacks {
+  onFeedbackSurveyCompleted?: ({feedbackSurveyOptionId}: { feedbackSurveyOptionId: string }) => void;
+  onShowingManageSubscriptions?: () => void;
+  onRestoreCompleted?: ({customerInfo}: { customerInfo: CustomerInfo }) => void;
+  onRestoreFailed?: ({error}: { error: PurchasesError }) => void;
+  onRestoreStarted?: () => void;
+  onRefundRequestStarted?: ({productIdentifier}: { productIdentifier: string }) => void;
+  onRefundRequestCompleted?: ({productIdentifier, refundRequestStatus}: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => void;
+  onManagementOptionSelected?: (event: CustomerCenterManagementOptionEvent) => void;
+}
+
+export interface PresentCustomerCenterParams {
+  callbacks?: CustomerCenterCallbacks;
+}
+
+// Internal PlaceholderPaywall component
+interface PlaceholderPaywallProps {
+  onPurchaseCompleted: () => void;
+  onPurchaseError: (error: PurchasesError) => void;
+  onRestoreCompleted?: () => void;
+  onRestoreError?: (error: PurchasesError) => void;
+  onDismiss: () => void;
+  displayCloseButton?: boolean;
+  offering?: PurchasesOffering | null;
+  fontFamily?: string | null; // Added fontFamily to props
+}
+
+const mockCustomerInfoPlaceholder: CustomerInfo = {
+  entitlements: { all: {}, active: {} },
+  activeSubscriptions: [],
+  allPurchasedProductIdentifiers: [],
+  latestExpirationDate: null,
+  firstSeen: "2023-01-01T00:00:00Z",
+  originalAppUserId: "mock_user_id_placeholder",
+  requestDate: "2023-01-01T00:00:00Z",
+  originalApplicationVersion: "1.0",
+  originalPurchaseDate: null,
+  managementURL: null,
+  nonSubscriptionTransactions: [],
+  verificationResult: VERIFICATION_RESULT.NOT_REQUESTED,
+};
+
+const mockStoreTransactionPlaceholder: PurchasesStoreTransaction = {
+  transactionIdentifier: "mock_transaction_id_placeholder",
+  productIdentifier: "mock_product_id_placeholder",
+  purchaseDate: new Date().toISOString(),
+};
+
+const mockProduct: PurchasesStoreProduct = { // Needed for mockPackage
+    identifier: "mock_product",
+    description: "Mock Product",
+    title: "Mock Product",
+    price: 1.99,
+    priceString: "$1.99",
+    currencyCode: "USD",
+    introPrice: null,
+    discounts: [],
+    productCategory: PRODUCT_CATEGORY.SUBSCRIPTION,
+    subscriptionPeriod: "P1M",
+    defaultOption: null,
+    subscriptionOptions: [],
+    presentedOfferingIdentifier: "mock_offering",
+    presentedOfferingContext: {
+      offeringIdentifier: "mock_offering",
+      placementIdentifier: null,
+      targetingContext: null,
+    },
+};
+
+const mockPackage: PurchasesPackage = { // Needed for onPurchaseStarted
+    identifier: "mock_package",
+    packageType: PACKAGE_TYPE.MONTHLY,
+    product: mockProduct,
+    offeringIdentifier: "mock_offering",
+    presentedOfferingContext: {
+      offeringIdentifier: "mock_offering",
+      placementIdentifier: null,
+      targetingContext: null,
+    },
+};
+
+const mockPurchasesErrorPlaceholder: PurchasesError = {
+  code: PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR,
+  message: "User cancelled the purchase in mock.",
+  userInfo: {
+    readableErrorCode: "USER_CANCELLED",
+    underlyingErrorMessage: "Mock underlying error message for cancellation.",
+  },
+  userCancelled: true,
+};
+
+
+const PlaceholderPaywall: React.FC<PlaceholderPaywallProps> = ({
+  onPurchaseCompleted,
+  onPurchaseError,
+  onDismiss,
+  displayCloseButton,
+  offering,
+  fontFamily, // Added fontFamily
+  onRestoreCompleted,
+  onRestoreError,
+}) => {
+  const handlePurchase = () => {
+    onPurchaseCompleted();
+  };
+
+  const handleCancelOrError = () => { // Renamed for clarity
+    onPurchaseError(mockPurchasesErrorPlaceholder);
+  };
+
+  const handleClose = () => {
+    // For this mock, closing is treated like a cancellation/error for simplicity.
+    onPurchaseError(mockPurchasesErrorPlaceholder);
+  };
+
+  const handleRestore = () => {
+    if (onRestoreCompleted) {
+      onRestoreCompleted();
+    } else if (onRestoreError) { // Call restore error if restore completed is not defined
+      onRestoreError(mockPurchasesErrorPlaceholder); // Or a specific restore error
+    }
+  };
+
+  return (
+    <View style={styles.placeholderContainer}>
+      <Text style={styles.placeholderTitle}>Expo Go - RevenueCat Paywall Placeholder</Text>
+      <Text style={styles.placeholderMessage}>
+        This is a mock view. Use the buttons to simulate outcomes.
+      </Text>
+      {offering && <Text style={styles.placeholderMessage}>Offering: {offering.identifier}</Text>}
+      {fontFamily && <Text style={styles.placeholderMessage}>Font Family: {fontFamily}</Text>}
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.button} onPress={handlePurchase}>
+          <Text style={styles.buttonText}>Simulate Successful Purchase</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.button} onPress={handleCancelOrError}>
+          <Text style={styles.buttonText}>Simulate Cancel / Error</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.buttonRow}>
+        <TouchableOpacity style={styles.button} onPress={handleRestore}>
+            <Text style={styles.buttonText}>Simulate Restore</Text>
+        </TouchableOpacity>
+      </View>
+      {displayCloseButton && (
+        <View style={styles.buttonRow}>
+          <TouchableOpacity style={[styles.button, styles.closeButton]} onPress={handleClose}>
+            <Text style={styles.buttonText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+};
+
+
+export default class RevenueCatUI {
+  public static PAYWALL_RESULT = PAYWALL_RESULT;
+  private static Defaults = { // Added from original index.tsx for presentPaywall methods
+    PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON: true
+  }
+
+  public static async presentPaywall(
+    { offering, displayCloseButton = RevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON, fontFamily }: PresentPaywallParams = {}
+  ): Promise<PAYWALL_RESULT> {
+    console.log(
+        `Mock RevenueCatUI.presentPaywall called with:
+        Offering: ${offering?.identifier},
+        DisplayCloseButton: ${displayCloseButton},
+        FontFamily: ${fontFamily}`
+      );
+    return Promise.resolve(PAYWALL_RESULT.NOT_PRESENTED);
+  }
+
+  public static async presentPaywallIfNeeded(
+    { requiredEntitlementIdentifier, offering, displayCloseButton = RevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON, fontFamily }: PresentPaywallIfNeededParams
+  ): Promise<PAYWALL_RESULT> {
+    console.log(
+        `Mock RevenueCatUI.presentPaywallIfNeeded called with:
+        RequiredEntitlement: ${requiredEntitlementIdentifier},
+        Offering: ${offering?.identifier},
+        DisplayCloseButton: ${displayCloseButton},
+        FontFamily: ${fontFamily}`
+      );
+    try {
+      const customerInfo = await Purchases.getCustomerInfo();
+      if (customerInfo.entitlements.all[requiredEntitlementIdentifier]?.isActive) {
+        console.log(`Mock presentPaywallIfNeeded: Entitlement ${requiredEntitlementIdentifier} is active. Paywall not shown.`);
+        return PAYWALL_RESULT.ALREADY_ENTITLED;
+      } else {
+        console.log(`Mock presentPaywallIfNeeded: Entitlement ${requiredEntitlementIdentifier} is not active. Paywall would be shown (but this is a mock).`);
+        return PAYWALL_RESULT.NOT_PRESENTED;
+      }
+    } catch (error) {
+      console.error("Error in mock presentPaywallIfNeeded:", error);
+      const purchasesError = error as PurchasesError;
+      if (purchasesError.code === PURCHASES_ERROR_CODE.OPERATION_TIMED_OUT_ERROR) {
+        // Specific handling for timeout, though mock might not produce this.
+      }
+      return PAYWALL_RESULT.ERROR;
+    }
+  }
+
+  public static async presentCustomerCenter(params?: PresentCustomerCenterParams): Promise<void> {
+    console.log("Mock RevenueCatUI.presentCustomerCenter called with params:", params);
+    return Promise.resolve();
+  }
+
+  public static Paywall: React.FC<FullScreenPaywallViewProps> = ({
+    style,
+    // children, // children are not typically rendered by the main Paywall component itself when it shows a full screen view
+    options,
+    onPurchaseStarted,
+    onPurchaseCompleted,
+    onPurchaseError,
+    onPurchaseCancelled, // This is for the 'X' button if different from general error
+    onRestoreStarted,
+    onRestoreCompleted,
+    onRestoreError,
+    onDismiss,
+  }) => {
+
+    const handlePurchaseWrapper = () => {
+      onPurchaseStarted?.({ packageBeingPurchased: mockPackage });
+      onPurchaseCompleted?.({ customerInfo: mockCustomerInfoPlaceholder, storeTransaction: mockStoreTransactionPlaceholder });
+      onDismiss?.();
+    };
+
+    const handleErrorWrapper = (error: PurchasesError) => { // PlaceholderPaywall now passes the error
+      onPurchaseStarted?.({ packageBeingPurchased: mockPackage }); // Assume purchase was attempted
+      onPurchaseError?.({ error }); // Use the error from PlaceholderPaywall
+      onDismiss?.();
+    };
+    
+    const handleRestoreWrapper = () => {
+      onRestoreStarted?.();
+      onRestoreCompleted?.({ customerInfo: mockCustomerInfoPlaceholder });
+      onDismiss?.();
+    };
+
+    const handleRestoreErrorWrapper = (error: PurchasesError) => { // PlaceholderPaywall could pass an error
+        onRestoreStarted?.();
+        onRestoreError?.({ error }); // Use the error from PlaceholderPaywall
+        onDismiss?.();
+    };
+
+    // This is specifically for the 'X' button in PlaceholderPaywall
+    // PlaceholderPaywall's "Close" button calls its onPurchaseError prop.
+    // So, it will flow through handleErrorWrapper. If a distinct onPurchaseCancelled is needed for 'X',
+    // PlaceholderPaywall would need a new prop. For this mock, it's fine.
+    // If onPurchaseCancelled is provided, we assume it's for explicit user action like pressing 'X'.
+    // The current PlaceholderPaywall's "Close" button calls its internal `handleClose` which calls `onPurchaseError`.
+    // This means `onPurchaseCancelled` from `Paywall` props might not be directly called by `PlaceholderPaywall`'s "Close" button as intended.
+    // For simplicity, we'll let PlaceholderPaywall's "Close" button trigger `handleErrorWrapper`.
+    // If `onPurchaseCancelled` needs to be distinct, `PlaceholderPaywall` would need an `onCancel` prop for its close button.
+
+    const handleDismissWrapper = () => {
+        // If onPurchaseCancelled is provided and is different from onDismiss,
+        // we might call it here if the dismiss originated from a user explicit cancel action.
+        // However, PlaceholderPaywall's buttons already call onDismiss via the wrappers.
+        // This direct onDismiss is for the PlaceholderPaywall's own onDismiss calls.
+        if (onDismiss) {
+            onDismiss();
+        }
+    };
+
+
+    return (
+      <View style={[{ flex: 1 }, style]}>
+        <PlaceholderPaywall
+          offering={options?.offering}
+          fontFamily={options?.fontFamily}
+          displayCloseButton={options?.displayCloseButton}
+          onPurchaseCompleted={handlePurchaseWrapper}
+          onPurchaseError={handleErrorWrapper}
+          onRestoreCompleted={handleRestoreWrapper}
+          onRestoreError={handleRestoreErrorWrapper} // Pass this down
+          onDismiss={handleDismissWrapper}
+        />
+        {/* Children are not rendered here as PlaceholderPaywall is full screen */}
+      </View>
+    );
+  };
+
+  public static OriginalTemplatePaywallFooterContainerView: React.FC<FooterPaywallViewProps> = ({
+    style,
+    children,
+    options,
+  }) => {
+    return (
+      <View style={[{ flex: 1, justifyContent: 'space-between' }, style]}>
+        {children}
+        <View style={styles.mockFooterBar}>
+          <Text style={styles.mockFooterText}>
+            Mock Paywall Footer Area (Offering: {options?.offering?.identifier || 'Default'})
+          </Text>
+        </View>
+      </View>
+    );
+  };
+
+  public static PaywallFooterContainerView: React.FC<FooterPaywallViewProps> = RevenueCatUI.OriginalTemplatePaywallFooterContainerView;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f0f0f0',
+    padding: 10,
+    borderWidth: 1,
+    borderColor: 'red',
+  },
+  text: {
+    color: 'black',
+  },
+  placeholderContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(250, 250, 250, 1)',
+    padding: 20,
+  },
+  placeholderTitle: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 15,
+    color: '#333',
+  },
+  placeholderMessage: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 10,
+    color: '#555',
+  },
+  buttonRow: {
+    marginTop: 12,
+    width: '90%',
+  },
+  button: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 12,
+    paddingHorizontal: 25,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  closeButton: {
+    backgroundColor: '#FF3B30',
+  },
+  // Styles for mockFooterBar
+  mockFooterBar: {
+    padding: 15, // Increased padding
+    backgroundColor: '#E0E0E0', // Lighter gray
+    borderTopWidth: 1,
+    borderColor: '#BDBDBD', // Slightly darker border
+    alignItems: 'center', // Center text
+    justifyContent: 'center', // Center text
+  },
+  mockFooterText: {
+    textAlign: 'center',
+    color: '#424242', // Darker text for better contrast
+    fontSize: 14, // Slightly larger font
+  }
+});
+
+export { PAYWALL_RESULT };

--- a/react-native-purchases-ui/src/__tests__/PaywallComponent.test.tsx
+++ b/react-native-purchases-ui/src/__tests__/PaywallComponent.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import RevenueCatUIMock from '../../src/RevenueCatUIMock'; // Import the mock directly
+import {
+  PAYWALL_RESULT,
+  PURCHASES_ERROR_CODE,
+  // The following are not strictly needed for these tests as we're checking if callbacks are called,
+  // not necessarily the exact shape of internal mock data passed to them,
+  // as that's an internal detail of RevenueCatUIMock's Paywall->PlaceholderPaywall interaction.
+  // CustomerInfo,
+  // PurchasesStoreTransaction,
+  // PurchasesPackage,
+  // PurchasesError,
+} from '@revenuecat/purchases-typescript-internal';
+
+const { Paywall } = RevenueCatUIMock;
+
+describe('Mock Paywall Component from RevenueCatUIMock', () => {
+  it('calls onPurchaseStarted, onPurchaseCompleted, and onDismiss when "Simulate Successful Purchase" is pressed', () => {
+    const mockOnPurchaseStarted = jest.fn();
+    const mockOnPurchaseCompleted = jest.fn();
+    const mockOnDismiss = jest.fn();
+
+    const { getByText } = render(
+      <Paywall
+        onPurchaseStarted={mockOnPurchaseStarted}
+        onPurchaseCompleted={mockOnPurchaseCompleted}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    fireEvent.press(getByText('Simulate Successful Purchase'));
+
+    expect(mockOnPurchaseStarted).toHaveBeenCalledTimes(1);
+    expect(mockOnPurchaseCompleted).toHaveBeenCalledTimes(1);
+    // Further assertions could check the payload of mockOnPurchaseCompleted if needed
+    // e.g., expect(mockOnPurchaseCompleted).toHaveBeenCalledWith(expect.objectContaining({ customerInfo: expect.any(Object) }));
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPurchaseStarted, onPurchaseError, and onDismiss when "Simulate Cancel / Error" is pressed', () => {
+    const mockOnPurchaseStarted = jest.fn();
+    const mockOnPurchaseError = jest.fn();
+    const mockOnDismiss = jest.fn();
+
+    const { getByText } = render(
+      <Paywall
+        onPurchaseStarted={mockOnPurchaseStarted}
+        onPurchaseError={mockOnPurchaseError}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    fireEvent.press(getByText('Simulate Cancel / Error'));
+    expect(mockOnPurchaseStarted).toHaveBeenCalledTimes(1);
+    expect(mockOnPurchaseError).toHaveBeenCalledTimes(1);
+    expect(mockOnPurchaseError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR, // Or PAYWALL_RESULT.CANCELLED depending on mock
+          userCancelled: true,
+        }),
+      })
+    );
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onRestoreStarted, onRestoreCompleted, and onDismiss when "Simulate Restore" is pressed', () => {
+    const mockOnRestoreStarted = jest.fn();
+    const mockOnRestoreCompleted = jest.fn();
+    const mockOnDismiss = jest.fn();
+
+    const { getByText } = render(
+      <Paywall
+        onRestoreStarted={mockOnRestoreStarted}
+        onRestoreCompleted={mockOnRestoreCompleted}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    fireEvent.press(getByText('Simulate Restore'));
+    expect(mockOnRestoreStarted).toHaveBeenCalledTimes(1);
+    expect(mockOnRestoreCompleted).toHaveBeenCalledTimes(1);
+    // e.g., expect(mockOnRestoreCompleted).toHaveBeenCalledWith(expect.objectContaining({ customerInfo: expect.any(Object) }));
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onPurchaseError and onDismiss when "Close" button is pressed (if displayCloseButton is true)', () => {
+    const mockOnPurchaseError = jest.fn();
+    const mockOnDismiss = jest.fn();
+    // onPurchaseCancelled is not explicitly used by PlaceholderPaywall's close button, it calls onPurchaseError.
+    const mockOnPurchaseCancelled = jest.fn(); 
+
+    const { getByText } = render(
+      <Paywall
+        options={{ displayCloseButton: true }}
+        onPurchaseError={mockOnPurchaseError}
+        onPurchaseCancelled={mockOnPurchaseCancelled} // To see if it's inadvertently called
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    fireEvent.press(getByText('Close'));
+    
+    // Based on current RevenueCatUIMock.tsx, the "Close" button in PlaceholderPaywall calls its onPurchaseError prop.
+    expect(mockOnPurchaseError).toHaveBeenCalledTimes(1);
+    expect(mockOnPurchaseError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            code: PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR, // Or PAYWALL_RESULT.CANCELLED
+            userCancelled: true,
+          }),
+        })
+      );
+    expect(mockOnPurchaseCancelled).not.toHaveBeenCalled(); // Ensure the specific onPurchaseCancelled isn't called by this path
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('"Close" button should not be visible if displayCloseButton is false or undefined', () => {
+    const { queryByText } = render(<Paywall options={{ displayCloseButton: false }} />);
+    expect(queryByText('Close')).toBeNull();
+
+    const { queryByText: queryByTextUndefined } = render(<Paywall />);
+    expect(queryByTextUndefined('Close')).toBeNull();
+  });
+
+  it('displays offering identifier if provided in options', () => {
+    const offeringIdentifier = "test_offering";
+    const { getByText } = render(<Paywall options={{ offering: { identifier: offeringIdentifier } as any }} />);
+    expect(getByText(`Offering: ${offeringIdentifier}`)).toBeTruthy();
+  });
+
+  it('displays font family if provided in options', () => {
+    const fontFamily = "Arial";
+    const { getByText } = render(<Paywall options={{ fontFamily: fontFamily }} />);
+    expect(getByText(`Font Family: ${fontFamily}`)).toBeTruthy();
+  });
+
+});

--- a/react-native-purchases-ui/src/__tests__/index.test.tsx
+++ b/react-native-purchases-ui/src/__tests__/index.test.tsx
@@ -1,1 +1,61 @@
-it.todo('write a test');
+import { NativeModules } from 'react-native';
+import { PAYWALL_RESULT } from '@revenuecat/purchases-typescript-internal';
+
+// It's assumed that Jest is auto-mocking 'react-native' and thus NativeModules.RNPaywalls
+// If not, explicit mocks like jest.mock('react-native', () => ({...})) would be needed.
+
+describe('RevenueCatUI SDK Mocking', () => {
+  let originalExpoGoMockFlag: boolean | undefined;
+  let MockRevenueCatUI: any;
+  // We cannot easily import OriginalRevenueCatUI directly as it's defined conditionally.
+
+  beforeAll(() => {
+    originalExpoGoMockFlag = (global as any).__EXPO_GO_MOCK_REVENUECAT__;
+    // Load MockRevenueCatUI once for comparison
+    MockRevenueCatUI = require('../../src/RevenueCatUIMock').default;
+  });
+
+  afterEach(() => {
+    (global as any).__EXPO_GO_MOCK_REVENUECAT__ = originalExpoGoMockFlag;
+    jest.resetModules(); // This is crucial to re-evaluate the import of ../../src/index
+    jest.clearAllMocks(); // Clear mock calls between tests
+  });
+
+  it('should use MockRevenueCatUI when global.__EXPO_GO_MOCK_REVENUECAT__ is true', async () => {
+    (global as any).__EXPO_GO_MOCK_REVENUECAT__ = true;
+    const RevenueCatUIToTest = require('../../src/index').default;
+
+    expect(RevenueCatUIToTest).toBe(MockRevenueCatUI);
+
+    const result = await RevenueCatUIToTest.presentPaywall();
+    expect(result).toBe(PAYWALL_RESULT.NOT_PRESENTED);
+
+    // Check that the native module method was NOT called by the mock
+    expect(NativeModules.RNPaywalls.presentPaywall).not.toHaveBeenCalled();
+  });
+
+  it('should use OriginalRevenueCatUI when global.__EXPO_GO_MOCK_REVENUECAT__ is false', async () => {
+    (global as any).__EXPO_GO_MOCK_REVENUECAT__ = false;
+    const RevenueCatUIToTest = require('../../src/index').default;
+    
+    expect(RevenueCatUIToTest).not.toBe(MockRevenueCatUI);
+
+    // Mock the native method for this specific call to avoid errors if it's not fully defined by default Jest mock
+    NativeModules.RNPaywalls.presentPaywall = jest.fn().mockResolvedValue(PAYWALL_RESULT.ERROR); // Or some other result
+
+    await RevenueCatUIToTest.presentPaywall();
+    expect(NativeModules.RNPaywalls.presentPaywall).toHaveBeenCalled();
+  });
+
+  it('should use OriginalRevenueCatUI when global.__EXPO_GO_MOCK_REVENUECAT__ is undefined', async () => {
+    (global as any).__EXPO_GO_MOCK_REVENUECAT__ = undefined;
+    const RevenueCatUIToTest = require('../../src/index').default;
+
+    expect(RevenueCatUIToTest).not.toBe(MockRevenueCatUI);
+
+    NativeModules.RNPaywalls.presentPaywall = jest.fn().mockResolvedValue(PAYWALL_RESULT.ERROR);
+
+    await RevenueCatUIToTest.presentPaywall();
+    expect(NativeModules.RNPaywalls.presentPaywall).toHaveBeenCalled();
+  });
+});

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -1,14 +1,4 @@
-import {
-  NativeEventEmitter,
-  NativeModules,
-  Platform,
-  requireNativeComponent,
-  ScrollView,
-  type StyleProp,
-  UIManager,
-  View,
-  type ViewStyle,
-} from "react-native";
+import React, { type ReactNode, useEffect, useState } from "react";
 import {
   type CustomerInfo,
   PAYWALL_RESULT, type PurchasesError,
@@ -16,107 +6,34 @@ import {
   type PurchasesStoreTransaction,
   REFUND_REQUEST_STATUS
 } from "@revenuecat/purchases-typescript-internal";
-import React, { type ReactNode, useEffect, useState } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
+
+import MockRevenueCatUI from './RevenueCatUIMock';
 
 export { PAYWALL_RESULT } from "@revenuecat/purchases-typescript-internal";
 
-const LINKING_ERROR =
-  `The package 'react-native-purchases-ui' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ios: "- You have run 'pod install'\n", default: ''}) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo Go\n';
-
-const RNPaywalls = NativeModules.RNPaywalls;
-const RNCustomerCenter = NativeModules.RNCustomerCenter;
-
-if (!RNPaywalls) {
-  throw new Error(LINKING_ERROR);
-}
-
-if (!RNCustomerCenter) {
-  throw new Error(LINKING_ERROR);
-}
-
-const eventEmitter = new NativeEventEmitter(RNPaywalls);
-const customerCenterEventEmitter = new NativeEventEmitter(RNCustomerCenter);
-
-const InternalPaywall =
-  UIManager.getViewManagerConfig('Paywall') != null
-    ? requireNativeComponent<FullScreenPaywallViewProps>('Paywall')
-    : () => {
-      throw new Error(LINKING_ERROR);
-    };
-
-const InternalPaywallFooterView = UIManager.getViewManagerConfig('Paywall') != null
-  ? requireNativeComponent<InternalFooterPaywallViewProps>('RCPaywallFooterView')
-  : () => {
-    throw new Error(LINKING_ERROR);
-  };
-
+// All exportable type/interface definitions from the original file remain here at the top level
 export interface PresentPaywallParams {
-  /**
-   * Whether to display the close button or not.
-   * Only available for original template paywalls. Ignored for V2 Paywalls.
-   */
   displayCloseButton?: boolean;
-
-  /**
-   * The offering to load the paywall with. This will be the "current" offering by default.
-   */
   offering?: PurchasesOffering;
-
-  /**
-   * The fontFamily name to use in the Paywall. In order to add a font family, add it in the react native app and make
-   * sure to run `npx react-native-asset` so it's added to the native components.
-   * Supported font types are `.ttf` and `.otf`.
-   * Make sure the file names follow the convention:
-   * - Regular: MyFont.ttf/MyFont.otf
-   * - Bold: MyFont_bold.ttf/MyFont_bold.otf
-   * - Italic: MyFont_italic.ttf/MyFont_italic.otf
-   * - Bold and Italic: MyFont_bold_italic.ttf/MyFont_bold_italic.otf
-   * Only available for original template paywalls. Ignored for V2 Paywalls.
-   */
   fontFamily?: string | null;
 }
 
 export type PresentPaywallIfNeededParams = PresentPaywallParams & {
-  /**
-   * The paywall will only be presented if this entitlement is not active.
-   */
   requiredEntitlementIdentifier: string;
-}
+};
 
 export interface PaywallViewOptions {
-  /**
-   * The offering to load the paywall with. This will be the "current" offering by default.
-   */
   offering?: PurchasesOffering | null;
-
-  /**
-   * The fontFamily name to use in the Paywall. In order to add a font family, add it in the react native app and make
-   * sure to run `npx react-native-asset` so it's added to the native components.
-   * Supported font types are `.ttf` and `.otf`.
-   * Make sure the file names follow the convention:
-   * - Regular: MyFont.ttf/MyFont.otf
-   * - Bold: MyFont_bold.ttf/MyFont_bold.otf
-   * - Italic: MyFont_italic.ttf/MyFont_italic.otf
-   * - Bold and Italic: MyFont_bold_italic.ttf/MyFont_bold_italic.otf
-   * Only available for original template paywalls. Ignored for V2 Paywalls.
-   */
   fontFamily?: string | null;
 }
 
 export interface FullScreenPaywallViewOptions extends PaywallViewOptions {
-  /**
-   * Whether to display the close button or not.
-   * Only available for original template paywalls. Ignored for V2 Paywalls.
-   */
   displayCloseButton?: boolean | false;
 }
 
-// Currently the same as the base type, but can be extended later if needed
 export interface FooterPaywallViewOptions extends PaywallViewOptions {
-  // Additional properties for FooterPaywallViewOptions can be added here if needed in the future
+  // Additional properties can be added here if needed
 }
 
 type FullScreenPaywallViewProps = {
@@ -157,317 +74,313 @@ type InternalFooterPaywallViewProps = FooterPaywallViewProps & {
   onMeasure?: ({height}: { height: number }) => void;
 };
 
-export type CustomerCenterManagementOption = 
+
+export type CustomerCenterManagementOption =
   | 'cancel'
   | 'custom_url'
   | 'missing_purchase'
   | 'refund_request'
   | 'change_plans'
   | 'unknown'
-  | string; // This is to prevent breaking changes when the native SDK adds new options
+  | string;
 
-export type CustomerCenterManagementOptionEvent = 
+export type CustomerCenterManagementOptionEvent =
   | { option: 'custom_url'; url: string }
   | { option: Exclude<CustomerCenterManagementOption, 'custom_url'>; url: null };
 
 export interface CustomerCenterCallbacks {
-  /**
-   * Called when a feedback survey is completed with the selected option ID.
-   */
   onFeedbackSurveyCompleted?: ({feedbackSurveyOptionId}: { feedbackSurveyOptionId: string }) => void;
-  
-  /**
-   * Called when the manage subscriptions section is being shown.
-   */
   onShowingManageSubscriptions?: () => void;
-  
-  /**
-   * Called when a restore operation is completed successfully.
-   */
   onRestoreCompleted?: ({customerInfo}: { customerInfo: CustomerInfo }) => void;
-  
-  /**
-   * Called when a restore operation fails.
-   */
   onRestoreFailed?: ({error}: { error: PurchasesError }) => void;
-  
-  /**
-   * Called when a restore operation starts.
-   */
   onRestoreStarted?: () => void;
-
-  /**
-   * Called when a refund request starts with the product identifier. iOS-only callback.
-   */
   onRefundRequestStarted?: ({productIdentifier}: { productIdentifier: string }) => void;
-  
-  /**
-   * Called when a refund request completes with status information. iOS-only callback.
-   */
   onRefundRequestCompleted?: ({productIdentifier, refundRequestStatus}: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => void;
-
-  /**
-   * Called when a customer center management option is selected.
-   * For 'custom_url' options, the url parameter will contain the URL.
-   * For all other options, the url parameter will be null.
-   */
   onManagementOptionSelected?: (event: CustomerCenterManagementOptionEvent) => void;
 }
 
 export interface PresentCustomerCenterParams {
-  /**
-   * Optional callbacks for customer center events.
-   */
   callbacks?: CustomerCenterCallbacks;
 }
 
-export default class RevenueCatUI {
+let RevenueCatUIToExport: any;
+let isExpoGoForUI = false;
 
-  private static Defaults = {
-    PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON: true
+try {
+  const Constants = require('expo-constants').default;
+  if (Constants && Constants.executionEnvironment === "storeClient") {
+    isExpoGoForUI = true;
+  }
+} catch (e: any) {
+  // expo-constants not available. Assume not in Expo Go.
+  // console.log("RevenueCat SDK (UI): Could not determine Expo Go environment. Mock mode will rely on global flag only. Error: " + e.message);
+}
+
+// Variable name `isMockMode` is kept as it was previously used in this file.
+const isMockMode = isExpoGoForUI || (global as any).__EXPO_GO_MOCK_REVENUECAT__ === true;
+
+if (isMockMode) {
+  RevenueCatUIToExport = MockRevenueCatUI;
+  if (isExpoGoForUI && (global as any).__EXPO_GO_MOCK_REVENUECAT__ !== false) { // Check if explicitly disabled
+     console.log("RevenueCat SDK (UI): Expo Go environment detected. Mock mode automatically enabled. To disable, set global.__EXPO_GO_MOCK_REVENUECAT__ = false;");
+  } else if ((global as any).__EXPO_GO_MOCK_REVENUECAT__ === true) {
+    console.log("RevenueCat SDK (UI): Global flag __EXPO_GO_MOCK_REVENUECAT__ is true. Mock mode enabled.");
+  }
+} else {
+  // All original React Native specific imports, native module usages, and the original class definition go here.
+  const ReactNative = require("react-native"); 
+  const {
+    NativeEventEmitter,
+    NativeModules,
+    Platform,
+    requireNativeComponent,
+    ScrollView,
+    UIManager,
+    View,
+  } = ReactNative;
+
+  const LINKING_ERROR =
+    `The package 'react-native-purchases-ui' doesn't seem to be linked. Make sure: \n\n` +
+    Platform.select({ios: "- You have run 'pod install'\n", default: ''}) +
+    '- You rebuilt the app after installing the package\n' +
+    '- You are not using Expo Go\n';
+
+  const RNPaywalls = NativeModules.RNPaywalls;
+  const RNCustomerCenter = NativeModules.RNCustomerCenter;
+
+  if (!RNPaywalls) {
+    throw new Error(LINKING_ERROR);
   }
 
-  /**
-   * The result of presenting a paywall. This will be the last situation the user experienced before the paywall closed.
-   * @readonly
-   * @enum {string}
-   */
-  public static PAYWALL_RESULT = PAYWALL_RESULT;
-
-  /**
-   * Presents a paywall to the user with optional customization.
-   *
-   * This method allows for presenting a specific offering's paywall to the user. The caller
-   * can decide whether to display a close button on the paywall through the `displayCloseButton`
-   * parameter. By default, the close button is displayed.
-   *
-   * @param {PresentPaywallParams} params - The options for presenting the paywall.
-   * @returns {Promise<PAYWALL_RESULT>} A promise that resolves with the result of the paywall presentation.
-   */
-  public static presentPaywall({
-                                 offering,
-                                 displayCloseButton = RevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON,
-                                 fontFamily,
-                               }: PresentPaywallParams = {}): Promise<PAYWALL_RESULT> {
-    return RNPaywalls.presentPaywall(
-      offering?.identifier ?? null,
-      displayCloseButton,
-      fontFamily,
-    )
+  if (!RNCustomerCenter) {
+    throw new Error(LINKING_ERROR);
   }
 
-  /**
-   * Presents a paywall to the user if a specific entitlement is not already owned.
-   *
-   * This method evaluates whether the user already owns the specified entitlement.
-   * If the entitlement is not owned, it presents a paywall for the specified offering (if provided), or the
-   * default offering (if no offering is provided), to the user. The paywall will be presented
-   * allowing the user the opportunity to purchase the offering. The caller
-   * can decide whether to display a close button on the paywall through the `displayCloseButton`
-   * parameter. By default, the close button is displayed.
-   *
-   * @param {PresentPaywallIfNeededParams} params - The parameters for presenting the paywall.
-   * @returns {Promise<PAYWALL_RESULT>} A promise that resolves with the result of the paywall presentation.
-   */
-  public static presentPaywallIfNeeded({
-                                         requiredEntitlementIdentifier,
-                                         offering,
-                                         displayCloseButton = RevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON,
-                                         fontFamily,
-                                       }: PresentPaywallIfNeededParams): Promise<PAYWALL_RESULT> {
-    return RNPaywalls.presentPaywallIfNeeded(
-      requiredEntitlementIdentifier,
-      offering?.identifier ?? null,
-      displayCloseButton,
-      fontFamily,
-    )
-  }
+  const eventEmitter = new NativeEventEmitter(RNPaywalls);
+  const customerCenterEventEmitter = new NativeEventEmitter(RNCustomerCenter);
 
-  public static Paywall: React.FC<FullScreenPaywallViewProps> = ({
-                                                                   style,
-                                                                   children,
-                                                                   options,
-                                                                   onPurchaseStarted,
-                                                                   onPurchaseCompleted,
-                                                                   onPurchaseError,
-                                                                   onPurchaseCancelled,
-                                                                   onRestoreStarted,
-                                                                   onRestoreCompleted,
-                                                                   onRestoreError,
-                                                                   onDismiss,
-                                                                 }) => (
-    <InternalPaywall options={options}
-                     children={children}
-                     onPurchaseStarted={(event: any) => onPurchaseStarted && onPurchaseStarted(event.nativeEvent)}
-                     onPurchaseCompleted={(event: any) => onPurchaseCompleted && onPurchaseCompleted(event.nativeEvent)}
-                     onPurchaseError={(event: any) => onPurchaseError && onPurchaseError(event.nativeEvent)}
-                     onPurchaseCancelled={() => onPurchaseCancelled && onPurchaseCancelled()}
-                     onRestoreStarted={() => onRestoreStarted && onRestoreStarted()}
-                     onRestoreCompleted={(event: any) => onRestoreCompleted && onRestoreCompleted(event.nativeEvent)}
-                     onRestoreError={(event: any) => onRestoreError && onRestoreError(event.nativeEvent)}
-                     onDismiss={() => onDismiss && onDismiss()}
-                     style={[{flex: 1}, style]}/>
-  );
-
-  public static OriginalTemplatePaywallFooterContainerView: React.FC<FooterPaywallViewProps> = ({
-                                                                                                  style,
-                                                                                                  children,
-                                                                                                  options,
-                                                                                                  onPurchaseStarted,
-                                                                                                  onPurchaseCompleted,
-                                                                                                  onPurchaseError,
-                                                                                                  onPurchaseCancelled,
-                                                                                                  onRestoreStarted,
-                                                                                                  onRestoreCompleted,
-                                                                                                  onRestoreError,
-                                                                                                  onDismiss,
-                                                                                                }) => {
-    // We use 20 as the default paddingBottom because that's the corner radius in the Android native SDK.
-    // We also listen to safeAreaInsetsDidChange which is only sent from iOS and which is triggered when the
-    // safe area insets change. Not adding this extra padding on iOS will cause the content of the scrollview
-    // to be hidden behind the rounded corners of the paywall.
-    const [paddingBottom, setPaddingBottom] = useState(20);
-    const [height, setHeight] = useState(0);
-
-    useEffect(() => {
-      interface HandleSafeAreaInsetsChangeParams {
-        bottom: number;
-      }
-
-      const handleSafeAreaInsetsChange = ({bottom}: HandleSafeAreaInsetsChangeParams) => {
-        setPaddingBottom(20 + bottom);
+  const InternalPaywall =
+    UIManager.getViewManagerConfig('Paywall') != null
+      ? requireNativeComponent<FullScreenPaywallViewProps>('Paywall')
+      : () => {
+        throw new Error(LINKING_ERROR);
       };
 
-      const subscription = eventEmitter.addListener(
-        'safeAreaInsetsDidChange',
-        handleSafeAreaInsetsChange
-      );
+  const InternalPaywallFooterView = UIManager.getViewManagerConfig('Paywall') != null
+    ? requireNativeComponent<InternalFooterPaywallViewProps>('RCPaywallFooterView')
+    : () => {
+      throw new Error(LINKING_ERROR);
+    };
 
-      return () => {
-        subscription.remove();
-      };
-    }, []);
+  class OriginalRevenueCatUI {
 
-    return (
-      <View style={[{flex: 1}, style]}>
-        <ScrollView contentContainerStyle={{flexGrow: 1, paddingBottom}}>
-          {children}
-        </ScrollView>
-        {/*Adding negative margin to the footer view to make it overlap with the extra padding of the scroll*/}
-        <InternalPaywallFooterView
-          style={Platform.select({
-            ios: {marginTop: -20},
-            android: {marginTop: -20, height}
-          })}
-          options={options}
-          onPurchaseStarted={(event: any) => onPurchaseStarted && onPurchaseStarted(event.nativeEvent)}
-          onPurchaseCompleted={(event: any) => onPurchaseCompleted && onPurchaseCompleted(event.nativeEvent)}
-          onPurchaseError={(event: any) => onPurchaseError && onPurchaseError(event.nativeEvent)}
-          onPurchaseCancelled={() => onPurchaseCancelled && onPurchaseCancelled()}
-          onRestoreStarted={() => onRestoreStarted && onRestoreStarted()}
-          onRestoreCompleted={(event: any) => onRestoreCompleted && onRestoreCompleted(event.nativeEvent)}
-          onRestoreError={(event: any) => onRestoreError && onRestoreError(event.nativeEvent)}
-          onDismiss={() => onDismiss && onDismiss()}
-          onMeasure={(event: any) => setHeight(event.nativeEvent.measurements.height)}
-        />
-      </View>
-    );
-  };
-
-  /**
-   * Presents the customer center to the user.
-   * 
-   * @param {PresentCustomerCenterParams} params - Optional parameters for presenting the customer center.
-   * @returns {Promise<void>} A promise that resolves when the customer center is presented.
-   */
-  public static presentCustomerCenter(params?: PresentCustomerCenterParams): Promise<void> {
-    if (params?.callbacks) {
-      const subscriptions: { remove: () => void }[] = [];
-      const callbacks = params.callbacks as CustomerCenterCallbacks;
-
-      if (callbacks.onFeedbackSurveyCompleted) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onFeedbackSurveyCompleted',
-          (event: { feedbackSurveyOptionId: string }) => callbacks.onFeedbackSurveyCompleted && 
-            callbacks.onFeedbackSurveyCompleted(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onShowingManageSubscriptions) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onShowingManageSubscriptions',
-          () => callbacks.onShowingManageSubscriptions && callbacks.onShowingManageSubscriptions()
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onRestoreCompleted) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onRestoreCompleted',
-          (event: { customerInfo: CustomerInfo }) => callbacks.onRestoreCompleted && 
-            callbacks.onRestoreCompleted(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onRestoreFailed) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onRestoreFailed',
-          (event: { error: PurchasesError }) => callbacks.onRestoreFailed && 
-            callbacks.onRestoreFailed(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onRestoreStarted) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onRestoreStarted',
-          () => callbacks.onRestoreStarted && callbacks.onRestoreStarted()
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onRefundRequestStarted) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onRefundRequestStarted',
-          (event: { productIdentifier: string }) => callbacks.onRefundRequestStarted && 
-            callbacks.onRefundRequestStarted(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onRefundRequestCompleted) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onRefundRequestCompleted',
-          (event: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => callbacks.onRefundRequestCompleted && 
-            callbacks.onRefundRequestCompleted(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      if (callbacks.onManagementOptionSelected) {
-        const subscription = customerCenterEventEmitter.addListener(
-          'onManagementOptionSelected',
-          (event: CustomerCenterManagementOptionEvent) => callbacks.onManagementOptionSelected && 
-            callbacks.onManagementOptionSelected(event)
-        );
-        subscriptions.push(subscription);
-      }
-
-      // Return a promise that resolves when the customer center is dismissed
-      return RNCustomerCenter.presentCustomerCenter().finally(() => {
-        // Clean up all event listeners when the customer center is dismissed
-        subscriptions.forEach(subscription => subscription.remove());
-      });
+    private static Defaults = {
+      PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON: true
     }
 
-    return RNCustomerCenter.presentCustomerCenter();
-  }
+    public static PAYWALL_RESULT = PAYWALL_RESULT;
 
-  /**
-   * @deprecated, Use {@link OriginalTemplatePaywallFooterContainerView} instead
-   */
-  public static PaywallFooterContainerView: React.FC<FooterPaywallViewProps> =
-    RevenueCatUI.OriginalTemplatePaywallFooterContainerView;
+    public static presentPaywall({
+                                   offering,
+                                   displayCloseButton = OriginalRevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON,
+                                   fontFamily,
+                                 }: PresentPaywallParams = {}): Promise<PAYWALL_RESULT> {
+      return RNPaywalls.presentPaywall(
+        offering?.identifier ?? null,
+        displayCloseButton,
+        fontFamily,
+      )
+    }
+
+    public static presentPaywallIfNeeded({
+                                           requiredEntitlementIdentifier,
+                                           offering,
+                                           displayCloseButton = OriginalRevenueCatUI.Defaults.PRESENT_PAYWALL_DISPLAY_CLOSE_BUTTON,
+                                           fontFamily,
+                                         }: PresentPaywallIfNeededParams): Promise<PAYWALL_RESULT> {
+      return RNPaywalls.presentPaywallIfNeeded(
+        requiredEntitlementIdentifier,
+        offering?.identifier ?? null,
+        displayCloseButton,
+        fontFamily,
+      )
+    }
+
+    public static Paywall: React.FC<FullScreenPaywallViewProps> = ({
+                                                                     style,
+                                                                     children,
+                                                                     options,
+                                                                     onPurchaseStarted,
+                                                                     onPurchaseCompleted,
+                                                                     onPurchaseError,
+                                                                     onPurchaseCancelled,
+                                                                     onRestoreStarted,
+                                                                     onRestoreCompleted,
+                                                                     onRestoreError,
+                                                                     onDismiss,
+                                                                   }) => (
+      <InternalPaywall options={options}
+                       children={children}
+                       onPurchaseStarted={(event: any) => onPurchaseStarted && onPurchaseStarted(event.nativeEvent)}
+                       onPurchaseCompleted={(event: any) => onPurchaseCompleted && onPurchaseCompleted(event.nativeEvent)}
+                       onPurchaseError={(event: any) => onPurchaseError && onPurchaseError(event.nativeEvent)}
+                       onPurchaseCancelled={() => onPurchaseCancelled && onPurchaseCancelled()}
+                       onRestoreStarted={() => onRestoreStarted && onRestoreStarted()}
+                       onRestoreCompleted={(event: any) => onRestoreCompleted && onRestoreCompleted(event.nativeEvent)}
+                       onRestoreError={(event: any) => onRestoreError && onRestoreError(event.nativeEvent)}
+                       onDismiss={() => onDismiss && onDismiss()}
+                       style={[{flex: 1}, style]}/>
+    );
+
+    public static OriginalTemplatePaywallFooterContainerView: React.FC<FooterPaywallViewProps> = ({
+                                                                                                    style,
+                                                                                                    children,
+                                                                                                    options,
+                                                                                                    onPurchaseStarted,
+                                                                                                    onPurchaseCompleted,
+                                                                                                    onPurchaseError,
+                                                                                                    onPurchaseCancelled,
+                                                                                                    onRestoreStarted,
+                                                                                                    onRestoreCompleted,
+                                                                                                    onRestoreError,
+                                                                                                    onDismiss,
+                                                                                                  }) => {
+      const [paddingBottom, setPaddingBottom] = useState(20);
+      const [height, setHeight] = useState(0);
+
+      useEffect(() => {
+        interface HandleSafeAreaInsetsChangeParams {
+          bottom: number;
+        }
+
+        const handleSafeAreaInsetsChange = ({bottom}: HandleSafeAreaInsetsChangeParams) => {
+          setPaddingBottom(20 + bottom);
+        };
+
+        const subscription = eventEmitter.addListener(
+          'safeAreaInsetsDidChange',
+          handleSafeAreaInsetsChange
+        );
+
+        return () => {
+          subscription.remove();
+        };
+      }, []);
+
+      return (
+        <View style={[{flex: 1}, style]}>
+          <ScrollView contentContainerStyle={{flexGrow: 1, paddingBottom}}>
+            {children}
+          </ScrollView>
+          <InternalPaywallFooterView
+            style={Platform.select({
+              ios: {marginTop: -20},
+              android: {marginTop: -20, height}
+            })}
+            options={options}
+            onPurchaseStarted={(event: any) => onPurchaseStarted && onPurchaseStarted(event.nativeEvent)}
+            onPurchaseCompleted={(event: any) => onPurchaseCompleted && onPurchaseCompleted(event.nativeEvent)}
+            onPurchaseError={(event: any) => onPurchaseError && onPurchaseError(event.nativeEvent)}
+            onPurchaseCancelled={() => onPurchaseCancelled && onPurchaseCancelled()}
+            onRestoreStarted={() => onRestoreStarted && onRestoreStarted()}
+            onRestoreCompleted={(event: any) => onRestoreCompleted && onRestoreCompleted(event.nativeEvent)}
+            onRestoreError={(event: any) => onRestoreError && onRestoreError(event.nativeEvent)}
+            onDismiss={() => onDismiss && onDismiss()}
+            onMeasure={(event: any) => setHeight(event.nativeEvent.measurements.height)}
+          />
+        </View>
+      );
+    };
+
+    public static presentCustomerCenter(params?: PresentCustomerCenterParams): Promise<void> {
+      if (params?.callbacks) {
+        const subscriptions: { remove: () => void }[] = [];
+        const callbacks = params.callbacks as CustomerCenterCallbacks;
+
+        if (callbacks.onFeedbackSurveyCompleted) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onFeedbackSurveyCompleted',
+            (event: { feedbackSurveyOptionId: string }) => callbacks.onFeedbackSurveyCompleted &&
+              callbacks.onFeedbackSurveyCompleted(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onShowingManageSubscriptions) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onShowingManageSubscriptions',
+            () => callbacks.onShowingManageSubscriptions && callbacks.onShowingManageSubscriptions()
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onRestoreCompleted) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onRestoreCompleted',
+            (event: { customerInfo: CustomerInfo }) => callbacks.onRestoreCompleted &&
+              callbacks.onRestoreCompleted(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onRestoreFailed) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onRestoreFailed',
+            (event: { error: PurchasesError }) => callbacks.onRestoreFailed &&
+              callbacks.onRestoreFailed(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onRestoreStarted) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onRestoreStarted',
+            () => callbacks.onRestoreStarted && callbacks.onRestoreStarted()
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onRefundRequestStarted) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onRefundRequestStarted',
+            (event: { productIdentifier: string }) => callbacks.onRefundRequestStarted &&
+              callbacks.onRefundRequestStarted(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onRefundRequestCompleted) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onRefundRequestCompleted',
+            (event: { productIdentifier: string; refundRequestStatus: REFUND_REQUEST_STATUS }) => callbacks.onRefundRequestCompleted &&
+              callbacks.onRefundRequestCompleted(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        if (callbacks.onManagementOptionSelected) {
+          const subscription = customerCenterEventEmitter.addListener(
+            'onManagementOptionSelected',
+            (event: CustomerCenterManagementOptionEvent) => callbacks.onManagementOptionSelected &&
+              callbacks.onManagementOptionSelected(event)
+          );
+          subscriptions.push(subscription);
+        }
+
+        return RNCustomerCenter.presentCustomerCenter().finally(() => {
+          subscriptions.forEach(subscription => subscription.remove());
+        });
+      }
+      return RNCustomerCenter.presentCustomerCenter();
+    }
+
+    /**
+     * @deprecated, Use {@link OriginalTemplatePaywallFooterContainerView} instead
+     */
+    public static PaywallFooterContainerView: React.FC<FooterPaywallViewProps> =
+      OriginalRevenueCatUI.OriginalTemplatePaywallFooterContainerView;
+  }
+  RevenueCatUIToExport = OriginalRevenueCatUI;
 }
+
+export default RevenueCatUIToExport;

--- a/src/PurchasesMock.ts
+++ b/src/PurchasesMock.ts
@@ -1,0 +1,602 @@
+import {
+  PurchasesError,
+  PURCHASES_ERROR_CODE,
+  UninitializedPurchasesError,
+  UnsupportedPlatformError,
+  CustomerInfo,
+  PurchasesEntitlementInfo,
+  PRORATION_MODE,
+  PACKAGE_TYPE,
+  INTRO_ELIGIBILITY_STATUS,
+  PurchasesOfferings,
+  PurchasesStoreProduct,
+  UpgradeInfo,
+  PurchasesPromotionalOffer,
+  PurchasesPackage,
+  IntroEligibility,
+  PurchasesStoreProductDiscount,
+  SubscriptionOption,
+  PRODUCT_CATEGORY,
+  GoogleProductChangeInfo,
+  PURCHASE_TYPE,
+  BILLING_FEATURE,
+  REFUND_REQUEST_STATUS,
+  LOG_LEVEL,
+  PurchasesConfiguration,
+  CustomerInfoUpdateListener,
+  ShouldPurchasePromoProductListener,
+  MakePurchaseResult,
+  LogHandler,
+  LogInResult,
+  IN_APP_MESSAGE_TYPE,
+  ENTITLEMENT_VERIFICATION_MODE,
+  VERIFICATION_RESULT,
+  STOREKIT_VERSION,
+  PurchasesStoreTransaction,
+  PurchasesOffering,
+  PURCHASES_ARE_COMPLETED_BY_TYPE,
+  PurchasesAreCompletedBy,
+  PurchasesAreCompletedByMyApp, // Ensure this is imported if used, or define a mock
+  PurchasesWinBackOffer,
+  WebPurchaseRedemption,
+  WebPurchaseRedemptionResult,
+  Storefront,
+} from "@revenuecat/purchases-typescript-internal";
+
+const mockCustomerInfo: CustomerInfo = {
+  entitlements: { all: {}, active: {} },
+  activeSubscriptions: [],
+  allPurchasedProductIdentifiers: [],
+  latestExpirationDate: null,
+  firstSeen: "2023-01-01T00:00:00Z",
+  originalAppUserId: "mock_user_id",
+  requestDate: "2023-01-01T00:00:00Z",
+  originalApplicationVersion: "1.0",
+  originalPurchaseDate: null,
+  managementURL: null,
+  nonSubscriptionTransactions: [],
+  verificationResult: VERIFICATION_RESULT.NOT_REQUESTED,
+};
+
+const mockMakePurchaseResult: MakePurchaseResult = {
+  customerInfo: mockCustomerInfo,
+  productIdentifier: "mock_product_id",
+};
+
+const mockLogInResult: LogInResult = {
+  customerInfo: mockCustomerInfo,
+  created: false,
+};
+
+export default class Purchases {
+  public static PURCHASE_TYPE = PURCHASE_TYPE;
+  public static PRODUCT_CATEGORY = PRODUCT_CATEGORY;
+  public static BILLING_FEATURE = BILLING_FEATURE;
+  public static REFUND_REQUEST_STATUS = REFUND_REQUEST_STATUS;
+  public static PRORATION_MODE = PRORATION_MODE;
+  public static PACKAGE_TYPE = PACKAGE_TYPE;
+  public static INTRO_ELIGIBILITY_STATUS = INTRO_ELIGIBILITY_STATUS;
+  public static PURCHASES_ERROR_CODE = PURCHASES_ERROR_CODE;
+  public static LOG_LEVEL = LOG_LEVEL;
+  public static IN_APP_MESSAGE_TYPE = IN_APP_MESSAGE_TYPE;
+  public static ENTITLEMENT_VERIFICATION_MODE = ENTITLEMENT_VERIFICATION_MODE;
+  public static VERIFICATION_RESULT = VERIFICATION_RESULT;
+  public static STOREKIT_VERSION = STOREKIT_VERSION;
+  public static PURCHASES_ARE_COMPLETED_BY_TYPE =
+    PURCHASES_ARE_COMPLETED_BY_TYPE;
+
+  public static UninitializedPurchasesError = UninitializedPurchasesError;
+  public static UnsupportedPlatformError = UnsupportedPlatformError;
+
+  private static customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
+  private static shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
+    [];
+  // @ts-ignore
+  private static customLogHandler: LogHandler;
+
+  public static configure({
+    apiKey,
+    appUserID = null,
+    purchasesAreCompletedBy = PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT,
+    userDefaultsSuiteName,
+    storeKitVersion = STOREKIT_VERSION.DEFAULT,
+    useAmazon = false,
+    shouldShowInAppMessagesAutomatically = true,
+    entitlementVerificationMode = ENTITLEMENT_VERIFICATION_MODE.DISABLED,
+  }: PurchasesConfiguration): void {
+    // Mock: Does nothing, configuration is assumed to be successful
+    if (apiKey === undefined || typeof apiKey !== "string") {
+      console.error(
+        'Invalid API key. It must be called with an Object: configure({apiKey: "key"})'
+      );
+      return;
+    }
+  }
+
+  public static async setAllowSharingStoreAccount(
+    allowSharing: boolean
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setSimulatesAskToBuyInSandbox(
+    simulatesAskToBuyInSandbox: boolean
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static addCustomerInfoUpdateListener(
+    customerInfoUpdateListener: CustomerInfoUpdateListener
+  ): void {
+    if (typeof customerInfoUpdateListener !== "function") {
+      throw new Error("addCustomerInfoUpdateListener needs a function");
+    }
+    if (
+      !Purchases.customerInfoUpdateListeners.includes(
+        customerInfoUpdateListener
+      )
+    ) {
+      Purchases.customerInfoUpdateListeners.push(customerInfoUpdateListener);
+    }
+  }
+
+  public static removeCustomerInfoUpdateListener(
+    listenerToRemove: CustomerInfoUpdateListener
+  ): boolean {
+    if (Purchases.customerInfoUpdateListeners.includes(listenerToRemove)) {
+      Purchases.customerInfoUpdateListeners =
+        Purchases.customerInfoUpdateListeners.filter(
+          (listener) => listenerToRemove !== listener
+        );
+      return true;
+    }
+    return false;
+  }
+
+  public static addShouldPurchasePromoProductListener(
+    shouldPurchasePromoProductListener: ShouldPurchasePromoProductListener
+  ): void {
+    if (typeof shouldPurchasePromoProductListener !== "function") {
+      throw new Error("addShouldPurchasePromoProductListener needs a function");
+    }
+    if (
+      !Purchases.shouldPurchasePromoProductListeners.includes(
+        shouldPurchasePromoProductListener
+      )
+    ) {
+      Purchases.shouldPurchasePromoProductListeners.push(
+        shouldPurchasePromoProductListener
+      );
+    }
+  }
+
+  public static removeShouldPurchasePromoProductListener(
+    listenerToRemove: ShouldPurchasePromoProductListener
+  ): boolean {
+    if (
+      Purchases.shouldPurchasePromoProductListeners.includes(listenerToRemove)
+    ) {
+      Purchases.shouldPurchasePromoProductListeners =
+        Purchases.shouldPurchasePromoProductListeners.filter(
+          (listener) => listenerToRemove !== listener
+        );
+      return true;
+    }
+    return false;
+  }
+
+  public static async getOfferings(): Promise<PurchasesOfferings> {
+    const mockOfferings: PurchasesOfferings = {
+      current: null,
+      all: {},
+      // @ts-ignore
+      offerings: {}, // offerings is deprecated but still part of the type
+    };
+    return Promise.resolve(mockOfferings);
+  }
+
+  public static async getCurrentOfferingForPlacement(
+    placementIdentifier: string
+  ): Promise<PurchasesOffering | null> {
+    return Promise.resolve(null);
+  }
+
+  public static async syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings> {
+    const mockOfferings: PurchasesOfferings = {
+      current: null,
+      all: {},
+      // @ts-ignore
+      offerings: {},
+    };
+    return Promise.resolve(mockOfferings);
+  }
+
+  public static async getProducts(
+    productIdentifiers: string[],
+    type: PURCHASE_TYPE | PRODUCT_CATEGORY = PRODUCT_CATEGORY.SUBSCRIPTION
+  ): Promise<PurchasesStoreProduct[]> {
+    return Promise.resolve([]);
+  }
+
+  public static async purchaseProduct(
+    productIdentifier: string,
+    upgradeInfo?: UpgradeInfo | null,
+    type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
+  ): Promise<MakePurchaseResult> {
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchaseStoreProduct(
+    product: PurchasesStoreProduct,
+    googleProductChangeInfo?: GoogleProductChangeInfo | null,
+    googleIsPersonalizedPrice?: boolean | null
+  ): Promise<MakePurchaseResult> {
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchaseDiscountedProduct(
+    product: PurchasesStoreProduct,
+    discount: PurchasesPromotionalOffer
+  ): Promise<MakePurchaseResult> {
+    if (typeof discount === "undefined" || discount == null) {
+      return Promise.reject(new Error("A discount is required"));
+    }
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchasePackage(
+    aPackage: PurchasesPackage,
+    upgradeInfo?: UpgradeInfo | null,
+    googleProductChangeInfo?: GoogleProductChangeInfo | null,
+    googleIsPersonalizedPrice?: boolean | null
+  ): Promise<MakePurchaseResult> {
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchaseSubscriptionOption(
+    subscriptionOption: SubscriptionOption,
+    googleProductChangeInfo?: GoogleProductChangeInfo,
+    googleIsPersonalizedPrice?: boolean
+  ): Promise<MakePurchaseResult> {
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchaseDiscountedPackage(
+    aPackage: PurchasesPackage,
+    discount: PurchasesPromotionalOffer
+  ): Promise<MakePurchaseResult> {
+    if (typeof discount === "undefined" || discount == null) {
+      return Promise.reject(new Error("A discount is required"));
+    }
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async restorePurchases(): Promise<CustomerInfo> {
+    return Promise.resolve(mockCustomerInfo);
+  }
+
+  public static async getAppUserID(): Promise<string> {
+    return Promise.resolve("mock_user_id");
+  }
+
+  public static async getStorefront(): Promise<Storefront | null> {
+    const mockStorefront: Storefront = {
+        identifier: "USA",
+        countryCode: "US",
+    }
+    return Promise.resolve(mockStorefront);
+  }
+
+  public static async logIn(appUserID: string): Promise<LogInResult> {
+    if (typeof appUserID !== "string") {
+      return Promise.reject(new Error("appUserID needs to be a string"));
+    }
+    return Promise.resolve(mockLogInResult);
+  }
+
+  public static async logOut(): Promise<CustomerInfo> {
+    return Promise.resolve(mockCustomerInfo);
+  }
+
+  public static async setDebugLogsEnabled(enabled: boolean): Promise<void> {
+    // Mock: Does nothing
+  }
+
+  public static async setLogLevel(level: LOG_LEVEL): Promise<void> {
+    // Mock: Does nothing
+  }
+
+  public static setLogHandler(logHandler: LogHandler): void {
+    Purchases.customLogHandler = logHandler;
+  }
+
+  public static async getCustomerInfo(): Promise<CustomerInfo> {
+    return Promise.resolve(mockCustomerInfo);
+  }
+
+  public static async syncPurchases(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async syncAmazonPurchase(
+    productID: string,
+    receiptID: string,
+    amazonUserID: string,
+    isoCurrencyCode?: string | null,
+    price?: number | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async syncObserverModeAmazonPurchase(
+    productID: string,
+    receiptID: string,
+    amazonUserID: string,
+    isoCurrencyCode?: string | null,
+    price?: number | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async recordPurchase(
+    productID: string
+  ): Promise<PurchasesStoreTransaction> {
+    const mockTransaction: PurchasesStoreTransaction = {
+        transactionIdentifier: "mock_transaction_id_" + productID,
+        productIdentifier: productID,
+        purchaseDate: new Date().toISOString(),
+    }
+    return Promise.resolve(mockTransaction);
+  }
+
+  public static async enableAdServicesAttributionTokenCollection(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async isAnonymous(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  public static async checkTrialOrIntroductoryPriceEligibility(
+    productIdentifiers: string[]
+  ): Promise<{ [productId: string]: IntroEligibility }> {
+    const mockEligibility: { [productId: string]: IntroEligibility } = {};
+    productIdentifiers.forEach((id) => {
+      mockEligibility[id] = {
+        status: INTRO_ELIGIBILITY_STATUS.ELIGIBLE,
+        description: "Mock eligibility",
+      };
+    });
+    return Promise.resolve(mockEligibility);
+  }
+
+  public static async getPromotionalOffer(
+    product: PurchasesStoreProduct,
+    discount: PurchasesStoreProductDiscount
+  ): Promise<PurchasesPromotionalOffer | undefined> {
+    if (typeof discount === "undefined" || discount == null) {
+        return Promise.reject(new Error("A discount is required"));
+    }
+    // Return undefined as per original behavior for Android or if no offer found
+    return Promise.resolve(undefined);
+  }
+
+  public static async getEligibleWinBackOffersForProduct(
+    product: PurchasesStoreProduct
+  ): Promise<[PurchasesWinBackOffer] | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public static async getEligibleWinBackOffersForPackage(
+    aPackage: PurchasesPackage
+  ): Promise<[PurchasesWinBackOffer] | undefined> {
+    return Promise.resolve(undefined);
+  }
+
+  public static async purchaseProductWithWinBackOffer(
+    product: PurchasesStoreProduct,
+    winBackOffer: PurchasesWinBackOffer
+  ): Promise<MakePurchaseResult> {
+    if (typeof winBackOffer === "undefined" || winBackOffer == null) {
+      return Promise.reject(new Error("A win-back offer is required"));
+    }
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async purchasePackageWithWinBackOffer(
+    aPackage: PurchasesPackage,
+    winBackOffer: PurchasesWinBackOffer
+  ): Promise<MakePurchaseResult> {
+    if (typeof winBackOffer === "undefined" || winBackOffer == null) {
+      return Promise.reject(new Error("A win-back offer is required"));
+    }
+    return Promise.resolve(mockMakePurchaseResult);
+  }
+
+  public static async invalidateCustomerInfoCache(): Promise<void> {
+    // Mock: Does nothing
+  }
+
+  public static async presentCodeRedemptionSheet(): Promise<void> {
+    // Mock: Does nothing
+  }
+
+  public static async setAttributes(attributes: {
+    [key: string]: string | null;
+  }): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setEmail(email: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setPhoneNumber(
+    phoneNumber: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setDisplayName(
+    displayName: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setPushToken(pushToken: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setProxyURL(url: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async collectDeviceIdentifiers(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setAdjustID(adjustID: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setAppsflyerID(
+    appsflyerID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setFBAnonymousID(
+    fbAnonymousID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setMparticleID(
+    mparticleID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setCleverTapID(
+    cleverTapID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setMixpanelDistinctID(
+    mixpanelDistinctID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setFirebaseAppInstanceID(
+    firebaseAppInstanceID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+ public static async setTenjinAnalyticsInstallationID(
+    tenjinAnalyticsInstallationID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setKochavaDeviceID(
+    kochavaDeviceID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setOnesignalID(
+    onesignalID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setAirshipChannelID(
+    airshipChannelID: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setMediaSource(
+    mediaSource: string | null
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setCampaign(campaign: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setAdGroup(adGroup: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setAd(ad: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setKeyword(keyword: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async setCreative(creative: string | null): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async canMakePayments(
+    features: BILLING_FEATURE[] = []
+  ): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  public static async beginRefundRequestForActiveEntitlement(): Promise<REFUND_REQUEST_STATUS> {
+    return Promise.resolve(REFUND_REQUEST_STATUS.SUCCESS);
+  }
+
+  public static async beginRefundRequestForEntitlement(
+    entitlementInfo: PurchasesEntitlementInfo
+  ): Promise<REFUND_REQUEST_STATUS> {
+    return Promise.resolve(REFUND_REQUEST_STATUS.SUCCESS);
+  }
+
+  public static async beginRefundRequestForProduct(
+    storeProduct: PurchasesStoreProduct
+  ): Promise<REFUND_REQUEST_STATUS> {
+    return Promise.resolve(REFUND_REQUEST_STATUS.SUCCESS);
+  }
+
+  public static async showManageSubscriptions(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async showInAppMessages(
+    messageTypes?: IN_APP_MESSAGE_TYPE[]
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public static async parseAsWebPurchaseRedemption(
+    urlString: string
+  ): Promise<WebPurchaseRedemption | null> {
+    // Basic mock: assume any string containing "redeem" is a valid link
+    if (urlString.includes("redeem")) {
+        return Promise.resolve({ redemptionLink: urlString });
+    }
+    return Promise.resolve(null);
+  }
+
+  public static async redeemWebPurchase(
+    webPurchaseRedemption: WebPurchaseRedemption
+  ): Promise<WebPurchaseRedemptionResult> {
+    return Promise.resolve({
+        customerInfo: mockCustomerInfo,
+        created: false, // Or true, depending on what you want to mock
+    });
+  }
+
+  public static isConfigured(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,40 @@
-import Purchases from './purchases';
-export default Purchases;
+// src/index.ts
+import OriginalPurchasesModule from './purchases';
+import MockPurchasesModule from './PurchasesMock';
 
+let PurchasesToExport: any;
+let isExpoGo = false;
+
+try {
+  // Dynamically require expo-constants to avoid issues in non-Expo environments
+  // where the module might not be present.
+  const Constants = require('expo-constants').default; // .default is often needed for CJS modules when using require
+  if (Constants && Constants.executionEnvironment === "storeClient") {
+    isExpoGo = true;
+  }
+} catch (e: any) {
+  // expo-constants not available, or other error. Assume not in Expo Go.
+  // console.log("RevenueCat SDK (core): Could not determine Expo Go environment. Mock mode will rely on global flag only. Error: " + e.message);
+}
+
+const useMock = isExpoGo || (global as any).__EXPO_GO_MOCK_REVENUECAT__ === true;
+
+if (useMock) {
+  PurchasesToExport = MockPurchasesModule;
+  if (isExpoGo && (global as any).__EXPO_GO_MOCK_REVENUECAT__ !== false) { // Check if explicitly disabled
+    console.log("RevenueCat SDK (core): Expo Go environment detected. Mock mode automatically enabled. To disable, set global.__EXPO_GO_MOCK_REVENUECAT__ = false;");
+  } else if ((global as any).__EXPO_GO_MOCK_REVENUECAT__ === true) {
+    console.log("RevenueCat SDK (core): Global flag __EXPO_GO_MOCK_REVENUECAT__ is true. Mock mode enabled.");
+  }
+} else {
+  PurchasesToExport = OriginalPurchasesModule;
+}
+
+export default PurchasesToExport;
+
+// Re-export all named exports from the *original* ./purchases module.
+// This ensures that enums, types, etc., are still available.
 export * from './errors';
 export * from './customerInfo';
-export * from './purchases';
+export * from './purchases'; // This will re-export named items from the original purchases.ts
 export * from './offerings';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,6 +2738,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react-native@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "@testing-library/react-native@npm:13.2.0"
+  dependencies:
+    chalk: ^4.1.2
+    jest-matcher-utils: ^29.7.0
+    pretty-format: ^29.7.0
+    redent: ^3.0.0
+  peerDependencies:
+    jest: ">=29.0.0"
+    react: ">=18.2.0"
+    react-native: ">=0.71"
+    react-test-renderer: ">=18.2.0"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: fa2f59353b27a5afea72c04296e94e597b7e20f09f7e69d5dd1693da15bdeabfdd1ba655b1e194dbf5727b9dfa92de5af06ec77484b3392aab96dab4f7c05e44
+  languageName: node
+  linkType: hard
+
 "@types/babel__core@npm:^7.1.14":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -6649,6 +6669,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: bfc6dd03c5eaf623a4963ebd94d087f6f4bbbfd8c41329a7f09706b0cb66969c4ddd336abeb587bc44bc6f08e13bf90f0b374f9d71f9f01e04adc2cd6f083ef1
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -7563,6 +7590,7 @@ __metadata:
   resolution: "react-native-purchases-ui@workspace:react-native-purchases-ui"
   dependencies:
     "@revenuecat/purchases-typescript-internal": 13.32.0
+    "@testing-library/react-native": ^13.2.0
     "@types/jest": ^29.5.12
     "@types/react": ^18.2.44
     "@types/react-dom": ~18.2.0
@@ -7825,6 +7853,16 @@ __metadata:
     tiny-invariant: ^1.3.3
     tslib: ^2.0.1
   checksum: be8e896a46b24e30fbeafcd111ff3beaf2b5532d241c199f833fe1c18e89f695b2704cf83f3006fa96a785851019031de0de50bd3e0fd7bb114be18bf2cad900
+  languageName: node
+  linkType: hard
+
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: ^4.0.0
+    strip-indent: ^3.0.0
+  checksum: fa1ef20404a2d399235e83cc80bd55a956642e37dd197b4b612ba7327bf87fa32745aeb4a1634b2bab25467164ab4ed9c15be2c307923dd08b0fe7c52431ae6b
   languageName: node
   linkType: hard
 
@@ -8502,6 +8540,15 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: ^1.0.0
+  checksum: 18f045d57d9d0d90cd16f72b2313d6364fd2cb4bf85b9f593523ad431c8720011a4d5f08b6591c9d580f446e78855c5334a30fb91aa1560f5d9f95ed1b4a0530
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I've introduced a JavaScript-only mock mode for `react-native-purchases` and `react-native-purchases-ui` to improve your developer experience in environments like Expo Go where native modules are not readily available.

Key changes:

1.  **Automatic Expo Go Detection:**
    *   Mock mode is now enabled automatically when I detect I'm running within the Expo Go client. This is achieved using `expo-constants` to check `Constants.executionEnvironment`.
    *   `expo-constants` has been added as a dependency to both SDK packages.

2.  **Global Override Flag:**
    *   The global flag `global.__EXPO_GO_MOCK_REVENUECAT__ = true` can still be used to manually enable mock mode in other JS-only environments or for your specific testing needs.
    *   If Expo Go is detected, mock mode will be active regardless of this flag.

3.  **Mock Implementations:**
    *   `react-native-purchases`: A `PurchasesMock.ts` provides a JS-only version of the `Purchases` class, returning mock data for all API calls without native interaction.
    *   `react-native-purchases-ui`: A `RevenueCatUIMock.tsx` provides a JS-only version of `RevenueCatUI`.
        *   Includes a `PlaceholderPaywall` component that renders in place of the native paywall.
        *   This placeholder displays informative messages and provides buttons to simulate successful purchases, cancellations/errors, and restores.

4.  **Conditional Loading:**
    *   The entry points for both SDKs (`src/index.ts` and `react-native-purchases-ui/src/index.tsx`) now conditionally load either the mock or the original native implementation based on the detection logic.
    *   Console logs have been added to indicate when mock mode is active.

5.  **Testing:**
    *   I've added comprehensive Jest tests to verify:
        *   The correct SDK (mock or original) is loaded under various conditions (Expo Go detected, global flag set, neither).
        *   The behavior of mock API methods.
        *   The functionality of the `PlaceholderPaywall` component and its interaction with callbacks.

6.  **Documentation:**
    *   `DEVELOPMENT.md` has been updated with a detailed section on "Expo Go Mock Mode," explaining the automatic activation, manual flag usage, and SDK behavior in this mode.

This feature allows you to test your RevenueCat integration logic, API calls, and basic purchase flows directly within Expo Go without needing immediate custom development builds, significantly streamlining the initial setup and iteration process.

Thank you for contributing to react-native-purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.
