### PR TITLE
Preview API Mode for Expo Go

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1104,6 +1104,7 @@ describe("Purchases", () => {
       "setProxyURL",
       "isPurchasesAreCompletedByMyApp",
       "parseAsWebPurchaseRedemption",
+      "logWarningIfPreviewAPIMode",
     ];
     const functionsThatRequireAndroidAndInstance = [
       "syncAmazonPurchase",

--- a/src/mocks/nativeModule.ts
+++ b/src/mocks/nativeModule.ts
@@ -1,4 +1,4 @@
-import { CustomerInfo, VERIFICATION_RESULT } from '@revenuecat/purchases-typescript-internal';
+import { CustomerInfo, MakePurchaseResult, PurchasesStoreTransaction, VERIFICATION_RESULT, WebPurchaseRedemptionResultType } from '@revenuecat/purchases-typescript-internal';
 
 const mockCustomerInfo: CustomerInfo = {
   activeSubscriptions: [],
@@ -21,6 +21,18 @@ const mockCustomerInfo: CustomerInfo = {
   subscriptionsByProductIdentifier: {}
 };
 
+const mockPurchaseStoreTransaction: PurchasesStoreTransaction = {
+  transactionIdentifier: 'mock-transaction-id',
+  productIdentifier: 'mock-product-id',
+  purchaseDate: new Date().toISOString()
+};
+
+const mockMakePurchaseResult: MakePurchaseResult = {
+  productIdentifier: 'mock-product-id',
+  customerInfo: mockCustomerInfo,
+  transaction: mockPurchaseStoreTransaction
+};
+
 /**
  * Mock implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
  * (like Expo Go).
@@ -31,7 +43,7 @@ export const mockNativeModuleRNPurchases = {
     return null;
   },
   setAllowSharingStoreAccount: async () => null,
-  addAttributionData: async () => null,
+  setSimulatesAskToBuyInSandbox: async () => null,
   getOfferings: async () => ({
     all: {},
     current: null
@@ -39,13 +51,9 @@ export const mockNativeModuleRNPurchases = {
   getCurrentOfferingForPlacement: async () => null,
   syncAttributesAndOfferingsIfNeeded: async () => null,
   getProductInfo: async () => [],
-  makePurchase: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-  },
-  restorePurchases: async () => {
-    console.warn('RevenueCat: Restore purchases is not available in mock mode');
-  },
+  restorePurchases: async () => mockCustomerInfo,
   getAppUserID: async () => 'mock-user-id',
+  getStorefront: async () => 'mock-storefront',
   setDebugLogsEnabled: async () => null,
   setLogLevel: async () => null,
   setLogHandler: async () => null,
@@ -58,6 +66,8 @@ export const mockNativeModuleRNPurchases = {
   syncPurchases: async () => null,
   syncAmazonPurchase: async () => null,
   syncObserverModeAmazonPurchase: async () => null,
+  recordPurchaseForProductID: async () => null,
+  enableAdServicesAttributionTokenCollection: async () => null,
   purchaseProduct: async () => {
     console.warn('RevenueCat: Purchases are not available in mock mode');
   },
@@ -68,40 +78,47 @@ export const mockNativeModuleRNPurchases = {
     console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   isAnonymous: async () => true,
-  makeDeferredPurchase: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-  },
+  makeDeferredPurchase: async () => null,
   checkTrialOrIntroductoryPriceEligibility: async () => ({}),
-  purchaseDiscountedPackage: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-  },
-  purchaseDiscountedProduct: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-  },
   getPromotionalOffer: async () => null,
+  eligibleWinBackOffersForProductIdentifier: async () => [],
+  purchaseProductWithWinBackOffer: async () => mockMakePurchaseResult,
+  purchasePackageWithWinBackOffer: async () => mockMakePurchaseResult,
   invalidateCustomerInfoCache: async () => null,
-  setAttributes: async () => null,
+  presentCodeRedemptionSheet: async () => null,
+  setAttributes: async () => null, 
   setEmail: async () => null,
   setPhoneNumber: async () => null,
   setDisplayName: async () => null,
   setPushToken: async () => null,
+  setProxyURLString: async () => null,
+  collectDeviceIdentifiers: async () => null,
+  setAdjustID: async () => null,
+  setAppsflyerID: async () => null,
+  setFBAnonymousID: async () => null,
+  setMparticleID: async () => null,
   setCleverTapID: async () => null,
   setMixpanelDistinctID: async () => null,
   setFirebaseAppInstanceID: async () => null,
   setTenjinAnalyticsInstallationID: async () => null,
   setKochavaDeviceID: async () => null,
+  setOnesignalID: async () => null,
+  setAirshipChannelID: async () => null,
+  setMediaSource: async () => null,
+  setMediaCampaign: async () => null,
+  setAd: async () => null,
+  setKeyword: async () => null,
+  setCreative: async () => null,
   canMakePayments: async () => false,
-  beginRefundRequestForActiveEntitlement: async () => {
-    console.warn('RevenueCat: Refunds are not available in mock mode'); 
-  },
-  beginRefundRequestForEntitlementId: async () => {
-    console.warn('RevenueCat: Refunds are not available in mock mode');
-  },
-  beginRefundRequestForProductId: async () => {
-    console.warn('RevenueCat: Refunds are not available in mock mode');
-  },
+  beginRefundRequestForActiveEntitlement: async () => 0,
+  beginRefundRequestForEntitlementId: async () => 0,
+  beginRefundRequestForProductId: async () => 0,
+  showManageSubscriptions: async () => null,
   showInAppMessages: async () => null,
+  isWebPurchaseRedemptionURL: async () => null,
   isConfigured: async () => true,
-  parseAsWebPurchaseRedemption: async () => null,
-  redeemWebPurchase: async () => null
+  redeemWebPurchase: async () => ({
+    result: WebPurchaseRedemptionResultType.SUCCESS,
+    customerInfo: mockCustomerInfo
+  }),
 }; 

--- a/src/mocks/nativeModule.ts
+++ b/src/mocks/nativeModule.ts
@@ -177,6 +177,7 @@ export const mockNativeModuleRNPurchases = {
   },
   recordPurchaseForProductID: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockPurchaseStoreTransaction
   },
   enableAdServicesAttributionTokenCollection: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
@@ -286,6 +287,12 @@ export const mockNativeModuleRNPurchases = {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setMediaCampaign: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setCampaign: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAdGroup: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAd: async () => {

--- a/src/mocks/nativeModule.ts
+++ b/src/mocks/nativeModule.ts
@@ -1,0 +1,107 @@
+import { CustomerInfo, VERIFICATION_RESULT } from '@revenuecat/purchases-typescript-internal';
+
+const mockCustomerInfo: CustomerInfo = {
+  activeSubscriptions: [],
+  allExpirationDates: {},
+  allPurchaseDates: {},
+  allPurchasedProductIdentifiers: [],
+  entitlements: {
+    active: {},
+    all: {},
+    verification: VERIFICATION_RESULT.NOT_REQUESTED
+  },
+  firstSeen: new Date().toISOString(),
+  latestExpirationDate: null,
+  originalAppUserId: 'mock-user-id',
+  originalApplicationVersion: null,
+  requestDate: new Date().toISOString(),
+  managementURL: null,
+  originalPurchaseDate: new Date().toISOString(),
+  nonSubscriptionTransactions: [],
+  subscriptionsByProductIdentifier: {}
+};
+
+/**
+ * Mock implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
+ * (like Expo Go).
+ */
+export const mockNativeModuleRNPurchases = {
+  setupPurchases: async () => {
+    console.warn('RevenueCat: Running in mock mode - native module not available');
+    return null;
+  },
+  setAllowSharingStoreAccount: async () => null,
+  addAttributionData: async () => null,
+  getOfferings: async () => ({
+    all: {},
+    current: null
+  }),
+  getCurrentOfferingForPlacement: async () => null,
+  syncAttributesAndOfferingsIfNeeded: async () => null,
+  getProductInfo: async () => [],
+  makePurchase: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  restorePurchases: async () => {
+    throw new Error('Restore purchases is not available in mock mode');
+  },
+  getAppUserID: async () => 'mock-user-id',
+  setDebugLogsEnabled: async () => null,
+  setLogLevel: async () => null,
+  setLogHandler: async () => null,
+  getCustomerInfo: async () => mockCustomerInfo,
+  logIn: async () => ({
+    customerInfo: mockCustomerInfo,
+    created: false
+  }),
+  logOut: async () => mockCustomerInfo,
+  syncPurchases: async () => null,
+  syncAmazonPurchase: async () => null,
+  syncObserverModeAmazonPurchase: async () => null,
+  purchaseProduct: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  purchasePackage: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  purchaseSubscriptionOption: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  isAnonymous: async () => true,
+  makeDeferredPurchase: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  checkTrialOrIntroductoryPriceEligibility: async () => ({}),
+  purchaseDiscountedPackage: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  purchaseDiscountedProduct: async () => {
+    throw new Error('Purchases are not available in mock mode');
+  },
+  getPromotionalOffer: async () => null,
+  invalidateCustomerInfoCache: async () => null,
+  setAttributes: async () => null,
+  setEmail: async () => null,
+  setPhoneNumber: async () => null,
+  setDisplayName: async () => null,
+  setPushToken: async () => null,
+  setCleverTapID: async () => null,
+  setMixpanelDistinctID: async () => null,
+  setFirebaseAppInstanceID: async () => null,
+  setTenjinAnalyticsInstallationID: async () => null,
+  setKochavaDeviceID: async () => null,
+  canMakePayments: async () => false,
+  beginRefundRequestForActiveEntitlement: async () => {
+    throw new Error('Refunds are not available in mock mode');
+  },
+  beginRefundRequestForEntitlementId: async () => {
+    throw new Error('Refunds are not available in mock mode');
+  },
+  beginRefundRequestForProductId: async () => {
+    throw new Error('Refunds are not available in mock mode');
+  },
+  showInAppMessages: async () => null,
+  isConfigured: async () => true,
+  parseAsWebPurchaseRedemption: async () => null,
+  redeemWebPurchase: async () => null
+}; 

--- a/src/mocks/nativeModule.ts
+++ b/src/mocks/nativeModule.ts
@@ -27,7 +27,7 @@ const mockCustomerInfo: CustomerInfo = {
  */
 export const mockNativeModuleRNPurchases = {
   setupPurchases: async () => {
-    console.warn('RevenueCat: Running in mock mode - native module not available');
+    console.warn('RevenueCat: Running in mock mode');
     return null;
   },
   setAllowSharingStoreAccount: async () => null,
@@ -40,10 +40,10 @@ export const mockNativeModuleRNPurchases = {
   syncAttributesAndOfferingsIfNeeded: async () => null,
   getProductInfo: async () => [],
   makePurchase: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   restorePurchases: async () => {
-    throw new Error('Restore purchases is not available in mock mode');
+    console.warn('RevenueCat: Restore purchases is not available in mock mode');
   },
   getAppUserID: async () => 'mock-user-id',
   setDebugLogsEnabled: async () => null,
@@ -59,24 +59,24 @@ export const mockNativeModuleRNPurchases = {
   syncAmazonPurchase: async () => null,
   syncObserverModeAmazonPurchase: async () => null,
   purchaseProduct: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   purchasePackage: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   purchaseSubscriptionOption: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   isAnonymous: async () => true,
   makeDeferredPurchase: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   checkTrialOrIntroductoryPriceEligibility: async () => ({}),
   purchaseDiscountedPackage: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   purchaseDiscountedProduct: async () => {
-    throw new Error('Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in mock mode');
   },
   getPromotionalOffer: async () => null,
   invalidateCustomerInfoCache: async () => null,
@@ -92,13 +92,13 @@ export const mockNativeModuleRNPurchases = {
   setKochavaDeviceID: async () => null,
   canMakePayments: async () => false,
   beginRefundRequestForActiveEntitlement: async () => {
-    throw new Error('Refunds are not available in mock mode');
+    console.warn('RevenueCat: Refunds are not available in mock mode'); 
   },
   beginRefundRequestForEntitlementId: async () => {
-    throw new Error('Refunds are not available in mock mode');
+    console.warn('RevenueCat: Refunds are not available in mock mode');
   },
   beginRefundRequestForProductId: async () => {
-    throw new Error('Refunds are not available in mock mode');
+    console.warn('RevenueCat: Refunds are not available in mock mode');
   },
   showInAppMessages: async () => null,
   isConfigured: async () => true,

--- a/src/mocks/nativeModule.ts
+++ b/src/mocks/nativeModule.ts
@@ -1,4 +1,4 @@
-import { CustomerInfo, MakePurchaseResult, PurchasesStoreTransaction, VERIFICATION_RESULT, WebPurchaseRedemptionResultType } from '@revenuecat/purchases-typescript-internal';
+import { CustomerInfo, INTRO_ELIGIBILITY_STATUS, MakePurchaseResult, PurchasesStoreTransaction, VERIFICATION_RESULT, WebPurchaseRedemptionResultType, PurchasesPackage, PurchasesStoreProduct, PACKAGE_TYPE, PRODUCT_CATEGORY, PRODUCT_TYPE, PurchasesOffering, PurchasesOfferings } from '@revenuecat/purchases-typescript-internal';
 
 const mockCustomerInfo: CustomerInfo = {
   activeSubscriptions: [],
@@ -33,6 +33,67 @@ const mockMakePurchaseResult: MakePurchaseResult = {
   transaction: mockPurchaseStoreTransaction
 };
 
+const mockStoreProduct: PurchasesStoreProduct = {
+  identifier: 'mock-product-id',
+  description: 'Mock product description',
+  title: 'Mock Product',
+  price: 9.99,
+  priceString: '$9.99',
+  pricePerWeek: 2.50,
+  pricePerMonth: 9.99,
+  pricePerYear: 99.99,
+  pricePerWeekString: '$2.50',
+  pricePerMonthString: '$9.99',
+  pricePerYearString: '$99.99',
+  currencyCode: 'USD',
+  introPrice: null,
+  discounts: null,
+  subscriptionPeriod: 'P1M',
+  productCategory: PRODUCT_CATEGORY.SUBSCRIPTION,
+  productType: PRODUCT_TYPE.AUTO_RENEWABLE_SUBSCRIPTION,
+  defaultOption: null,
+  subscriptionOptions: null,
+  presentedOfferingIdentifier: 'mock-offering',
+  presentedOfferingContext: {
+    offeringIdentifier: 'mock-offering',
+    placementIdentifier: 'mock-placement',
+    targetingContext: null
+  }
+};
+
+const mockPackage: PurchasesPackage = {
+  identifier: 'mock-package-id',
+  packageType: PACKAGE_TYPE.MONTHLY,
+  product: mockStoreProduct,
+  offeringIdentifier: 'mock-offering',
+  presentedOfferingContext: {
+    offeringIdentifier: 'mock-offering',
+    placementIdentifier: 'mock-placement',
+    targetingContext: null
+  }
+};
+
+const mockOffering: PurchasesOffering = {
+  identifier: 'mock-offering',
+  serverDescription: 'Mock offering for testing',
+  metadata: {},
+  availablePackages: [mockPackage],
+  lifetime: null,
+  annual: null,
+  sixMonth: null,
+  threeMonth: null,
+  twoMonth: null,
+  monthly: mockPackage,
+  weekly: null
+};
+
+const mockOfferings: PurchasesOfferings = {
+  all: {
+    'mock-offering': mockOffering
+  },
+  current: mockOffering
+};
+
 /**
  * Mock implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
  * (like Expo Go).
@@ -42,83 +103,235 @@ export const mockNativeModuleRNPurchases = {
     console.warn('RevenueCat: Running in mock mode');
     return null;
   },
-  setAllowSharingStoreAccount: async () => null,
-  setSimulatesAskToBuyInSandbox: async () => null,
-  getOfferings: async () => ({
-    all: {},
-    current: null
-  }),
-  getCurrentOfferingForPlacement: async () => null,
-  syncAttributesAndOfferingsIfNeeded: async () => null,
-  getProductInfo: async () => [],
-  restorePurchases: async () => mockCustomerInfo,
-  getAppUserID: async () => 'mock-user-id',
-  getStorefront: async () => 'mock-storefront',
-  setDebugLogsEnabled: async () => null,
-  setLogLevel: async () => null,
-  setLogHandler: async () => null,
-  getCustomerInfo: async () => mockCustomerInfo,
-  logIn: async () => ({
-    customerInfo: mockCustomerInfo,
-    created: false
-  }),
-  logOut: async () => mockCustomerInfo,
-  syncPurchases: async () => null,
-  syncAmazonPurchase: async () => null,
-  syncObserverModeAmazonPurchase: async () => null,
-  recordPurchaseForProductID: async () => null,
-  enableAdServicesAttributionTokenCollection: async () => null,
+  setAllowSharingStoreAccount: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  setSimulatesAskToBuyInSandbox: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  getOfferings: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockOfferings;
+  },
+  getCurrentOfferingForPlacement: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockOffering;
+  },
+  syncAttributesAndOfferingsIfNeeded: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockOfferings;
+  },
+  getProductInfo: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return [mockStoreProduct];
+  },
+  restorePurchases: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockCustomerInfo;
+  },
+  getAppUserID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return 'mock-user-id';
+  },
+  getStorefront: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return 'mock-storefront';
+  },
+  setDebugLogsEnabled: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  setLogLevel: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  setLogHandler: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  getCustomerInfo: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockCustomerInfo;
+  },
+  logIn: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return {
+      customerInfo: mockCustomerInfo,
+      created: false
+    };
+  },
+  logOut: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockCustomerInfo;
+  },
+  syncPurchases: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  syncAmazonPurchase: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  syncObserverModeAmazonPurchase: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  recordPurchaseForProductID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  enableAdServicesAttributionTokenCollection: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
   purchaseProduct: async () => {
     console.warn('RevenueCat: Purchases are not available in mock mode');
+    return mockMakePurchaseResult;
   },
   purchasePackage: async () => {
     console.warn('RevenueCat: Purchases are not available in mock mode');
+    return mockMakePurchaseResult;
   },
   purchaseSubscriptionOption: async () => {
     console.warn('RevenueCat: Purchases are not available in mock mode');
   },
-  isAnonymous: async () => true,
-  makeDeferredPurchase: async () => null,
-  checkTrialOrIntroductoryPriceEligibility: async () => ({}),
-  getPromotionalOffer: async () => null,
-  eligibleWinBackOffersForProductIdentifier: async () => [],
-  purchaseProductWithWinBackOffer: async () => mockMakePurchaseResult,
-  purchasePackageWithWinBackOffer: async () => mockMakePurchaseResult,
-  invalidateCustomerInfoCache: async () => null,
-  presentCodeRedemptionSheet: async () => null,
-  setAttributes: async () => null, 
-  setEmail: async () => null,
-  setPhoneNumber: async () => null,
-  setDisplayName: async () => null,
-  setPushToken: async () => null,
-  setProxyURLString: async () => null,
-  collectDeviceIdentifiers: async () => null,
-  setAdjustID: async () => null,
-  setAppsflyerID: async () => null,
-  setFBAnonymousID: async () => null,
-  setMparticleID: async () => null,
-  setCleverTapID: async () => null,
-  setMixpanelDistinctID: async () => null,
-  setFirebaseAppInstanceID: async () => null,
-  setTenjinAnalyticsInstallationID: async () => null,
-  setKochavaDeviceID: async () => null,
-  setOnesignalID: async () => null,
-  setAirshipChannelID: async () => null,
-  setMediaSource: async () => null,
-  setMediaCampaign: async () => null,
-  setAd: async () => null,
-  setKeyword: async () => null,
-  setCreative: async () => null,
-  canMakePayments: async () => false,
-  beginRefundRequestForActiveEntitlement: async () => 0,
-  beginRefundRequestForEntitlementId: async () => 0,
-  beginRefundRequestForProductId: async () => 0,
-  showManageSubscriptions: async () => null,
-  showInAppMessages: async () => null,
-  isWebPurchaseRedemptionURL: async () => null,
-  isConfigured: async () => true,
-  redeemWebPurchase: async () => ({
-    result: WebPurchaseRedemptionResultType.SUCCESS,
-    customerInfo: mockCustomerInfo
-  }),
+  isAnonymous: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return true;
+  },
+  makeDeferredPurchase: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  checkTrialOrIntroductoryPriceEligibility: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return ({
+      'mock-product-id': INTRO_ELIGIBILITY_STATUS.INTRO_ELIGIBILITY_STATUS_ELIGIBLE
+    });
+  },
+  getPromotionalOffer: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return undefined;
+  },
+  eligibleWinBackOffersForProductIdentifier: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return [];
+  },
+  purchaseProductWithWinBackOffer: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockMakePurchaseResult;
+  },
+  purchasePackageWithWinBackOffer: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return mockMakePurchaseResult;
+  },
+  invalidateCustomerInfoCache: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  presentCodeRedemptionSheet: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAttributes: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setEmail: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setPhoneNumber: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setDisplayName: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setPushToken: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setProxyURLString: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  collectDeviceIdentifiers: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAdjustID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAppsflyerID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setFBAnonymousID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setMparticleID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setCleverTapID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setMixpanelDistinctID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setFirebaseAppInstanceID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setTenjinAnalyticsInstallationID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setKochavaDeviceID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setOnesignalID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAirshipChannelID: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setMediaSource: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setMediaCampaign: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setAd: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setKeyword: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  setCreative: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  canMakePayments: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return false;
+  },
+  beginRefundRequestForActiveEntitlement: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return 0;
+  },
+  beginRefundRequestForEntitlementId: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return 0;
+  },
+  beginRefundRequestForProductId: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return 0;
+  },
+  showManageSubscriptions: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  showInAppMessages: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+  },
+  isWebPurchaseRedemptionURL: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return null;
+  },
+  isConfigured: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return true;
+  },
+  redeemWebPurchase: async () => {
+    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
+    return {
+      result: WebPurchaseRedemptionResultType.SUCCESS,
+      customerInfo: mockCustomerInfo
+    };
+  },
 }; 

--- a/src/preview/nativeModule.ts
+++ b/src/preview/nativeModule.ts
@@ -1,6 +1,6 @@
 import { CustomerInfo, INTRO_ELIGIBILITY_STATUS, MakePurchaseResult, PurchasesStoreTransaction, VERIFICATION_RESULT, WebPurchaseRedemptionResultType, PurchasesPackage, PurchasesStoreProduct, PACKAGE_TYPE, PRODUCT_CATEGORY, PRODUCT_TYPE, PurchasesOffering, PurchasesOfferings } from '@revenuecat/purchases-typescript-internal';
 
-const mockCustomerInfo: CustomerInfo = {
+const previewCustomerInfo: CustomerInfo = {
   activeSubscriptions: [],
   allExpirationDates: {},
   allPurchaseDates: {},
@@ -12,7 +12,7 @@ const mockCustomerInfo: CustomerInfo = {
   },
   firstSeen: new Date().toISOString(),
   latestExpirationDate: null,
-  originalAppUserId: 'mock-user-id',
+  originalAppUserId: 'preview-user-id',
   originalApplicationVersion: null,
   requestDate: new Date().toISOString(),
   managementURL: null,
@@ -21,22 +21,22 @@ const mockCustomerInfo: CustomerInfo = {
   subscriptionsByProductIdentifier: {}
 };
 
-const mockPurchaseStoreTransaction: PurchasesStoreTransaction = {
-  transactionIdentifier: 'mock-transaction-id',
-  productIdentifier: 'mock-product-id',
+const previewPurchaseStoreTransaction: PurchasesStoreTransaction = {
+  transactionIdentifier: 'preview-transaction-id',
+  productIdentifier: 'preview-product-id',
   purchaseDate: new Date().toISOString()
 };
 
-const mockMakePurchaseResult: MakePurchaseResult = {
-  productIdentifier: 'mock-product-id',
-  customerInfo: mockCustomerInfo,
-  transaction: mockPurchaseStoreTransaction
+const previewMakePurchaseResult: MakePurchaseResult = {
+  productIdentifier: 'preview-product-id',
+  customerInfo: previewCustomerInfo,
+  transaction: previewPurchaseStoreTransaction
 };
 
-const mockStoreProduct: PurchasesStoreProduct = {
-  identifier: 'mock-product-id',
-  description: 'Mock product description',
-  title: 'Mock Product',
+const previewStoreProduct: PurchasesStoreProduct = {
+  identifier: 'preview-product-id',
+  description: 'Preview product description',
+  title: 'Preview Product',
   price: 9.99,
   priceString: '$9.99',
   pricePerWeek: 2.50,
@@ -53,54 +53,54 @@ const mockStoreProduct: PurchasesStoreProduct = {
   productType: PRODUCT_TYPE.AUTO_RENEWABLE_SUBSCRIPTION,
   defaultOption: null,
   subscriptionOptions: null,
-  presentedOfferingIdentifier: 'mock-offering',
+  presentedOfferingIdentifier: 'preview-offering',
   presentedOfferingContext: {
-    offeringIdentifier: 'mock-offering',
-    placementIdentifier: 'mock-placement',
+    offeringIdentifier: 'preview-offering',
+    placementIdentifier: 'preview-placement',
     targetingContext: null
   }
 };
 
-const mockPackage: PurchasesPackage = {
-  identifier: 'mock-package-id',
+const previewPackage: PurchasesPackage = {
+  identifier: 'preview-package-id',
   packageType: PACKAGE_TYPE.MONTHLY,
-  product: mockStoreProduct,
-  offeringIdentifier: 'mock-offering',
+  product: previewStoreProduct,
+  offeringIdentifier: 'preview-offering',
   presentedOfferingContext: {
-    offeringIdentifier: 'mock-offering',
-    placementIdentifier: 'mock-placement',
+    offeringIdentifier: 'preview-offering',
+    placementIdentifier: 'preview-placement',
     targetingContext: null
   }
 };
 
-const mockOffering: PurchasesOffering = {
-  identifier: 'mock-offering',
-  serverDescription: 'Mock offering for testing',
+const previewOffering: PurchasesOffering = {
+  identifier: 'preview-offering',
+  serverDescription: 'Preview offering for testing',
   metadata: {},
-  availablePackages: [mockPackage],
+  availablePackages: [previewPackage],
   lifetime: null,
   annual: null,
   sixMonth: null,
   threeMonth: null,
   twoMonth: null,
-  monthly: mockPackage,
+  monthly: previewPackage,
   weekly: null
 };
 
-const mockOfferings: PurchasesOfferings = {
+const previewOfferings: PurchasesOfferings = {
   all: {
-    'mock-offering': mockOffering
+    'preview-offering': previewOffering
   },
-  current: mockOffering
+  current: previewOffering
 };
 
 /**
- * Mock implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
+ * Preview implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
  * (like Expo Go).
  */
-export const mockNativeModuleRNPurchases = {
+export const previewNativeModuleRNPurchases = {
   setupPurchases: async () => {
-    console.warn('RevenueCat: Running in mock mode');
+    console.warn('RevenueCat: Running in preview mode');
     return null;
   },
   setAllowSharingStoreAccount: async () => {
@@ -113,31 +113,31 @@ export const mockNativeModuleRNPurchases = {
   },
   getOfferings: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockOfferings;
+    return previewOfferings;
   },
   getCurrentOfferingForPlacement: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockOffering;
+    return previewOffering;
   },
   syncAttributesAndOfferingsIfNeeded: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockOfferings;
+    return previewOfferings;
   },
   getProductInfo: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return [mockStoreProduct];
+    return [previewStoreProduct];
   },
   restorePurchases: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockCustomerInfo;
+    return previewCustomerInfo;
   },
   getAppUserID: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return 'mock-user-id';
+    return 'preview-user-id';
   },
   getStorefront: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return 'mock-storefront';
+    return 'preview-storefront';
   },
   setDebugLogsEnabled: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
@@ -153,18 +153,18 @@ export const mockNativeModuleRNPurchases = {
   },
   getCustomerInfo: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockCustomerInfo;
+    return previewCustomerInfo;
   },
   logIn: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return {
-      customerInfo: mockCustomerInfo,
+      customerInfo: previewCustomerInfo,
       created: false
     };
   },
   logOut: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockCustomerInfo;
+    return previewCustomerInfo;
   },
   syncPurchases: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
@@ -177,21 +177,21 @@ export const mockNativeModuleRNPurchases = {
   },
   recordPurchaseForProductID: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockPurchaseStoreTransaction
+    return previewPurchaseStoreTransaction
   },
   enableAdServicesAttributionTokenCollection: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   purchaseProduct: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-    return mockMakePurchaseResult;
+    console.warn('RevenueCat: Purchases are not available in preview mode');
+    return previewMakePurchaseResult;
   },
   purchasePackage: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
-    return mockMakePurchaseResult;
+    console.warn('RevenueCat: Purchases are not available in preview mode');
+    return previewMakePurchaseResult;
   },
   purchaseSubscriptionOption: async () => {
-    console.warn('RevenueCat: Purchases are not available in mock mode');
+    console.warn('RevenueCat: Purchases are not available in preview mode');
   },
   isAnonymous: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
@@ -204,7 +204,7 @@ export const mockNativeModuleRNPurchases = {
   checkTrialOrIntroductoryPriceEligibility: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return ({
-      'mock-product-id': INTRO_ELIGIBILITY_STATUS.INTRO_ELIGIBILITY_STATUS_ELIGIBLE
+      'preview-product-id': INTRO_ELIGIBILITY_STATUS.INTRO_ELIGIBILITY_STATUS_ELIGIBLE
     });
   },
   getPromotionalOffer: async () => {
@@ -217,11 +217,11 @@ export const mockNativeModuleRNPurchases = {
   },
   purchaseProductWithWinBackOffer: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockMakePurchaseResult;
+    return previewMakePurchaseResult;
   },
   purchasePackageWithWinBackOffer: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
-    return mockMakePurchaseResult;
+    return previewMakePurchaseResult;
   },
   invalidateCustomerInfoCache: async () => {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
@@ -338,7 +338,7 @@ export const mockNativeModuleRNPurchases = {
     console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return {
       result: WebPurchaseRedemptionResultType.SUCCESS,
-      customerInfo: mockCustomerInfo
+      customerInfo: previewCustomerInfo
     };
   },
 }; 

--- a/src/preview/nativeModule.ts
+++ b/src/preview/nativeModule.ts
@@ -95,247 +95,180 @@ const previewOfferings: PurchasesOfferings = {
 };
 
 /**
- * Preview implementation of the native module for Compatibility API mode, i.e. for environments where native modules are not available
+ * Preview implementation of the native module for Preview API mode, i.e. for environments where native modules are not available
  * (like Expo Go).
  */
 export const previewNativeModuleRNPurchases = {
   setupPurchases: async () => {
-    console.warn('RevenueCat: Running in preview mode');
     return null;
   },
   setAllowSharingStoreAccount: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   setSimulatesAskToBuyInSandbox: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   getOfferings: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewOfferings;
   },
   getCurrentOfferingForPlacement: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewOffering;
   },
   syncAttributesAndOfferingsIfNeeded: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewOfferings;
   },
   getProductInfo: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return [previewStoreProduct];
   },
   restorePurchases: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewCustomerInfo;
   },
   getAppUserID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return 'preview-user-id';
   },
   getStorefront: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return 'preview-storefront';
   },
   setDebugLogsEnabled: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   setLogLevel: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   setLogHandler: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   getCustomerInfo: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewCustomerInfo;
   },
   logIn: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return {
       customerInfo: previewCustomerInfo,
       created: false
     };
   },
   logOut: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewCustomerInfo;
   },
   syncPurchases: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   syncAmazonPurchase: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   syncObserverModeAmazonPurchase: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   recordPurchaseForProductID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewPurchaseStoreTransaction
   },
   enableAdServicesAttributionTokenCollection: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   purchaseProduct: async () => {
-    console.warn('RevenueCat: Purchases are not available in preview mode');
     return previewMakePurchaseResult;
   },
   purchasePackage: async () => {
-    console.warn('RevenueCat: Purchases are not available in preview mode');
     return previewMakePurchaseResult;
   },
   purchaseSubscriptionOption: async () => {
-    console.warn('RevenueCat: Purchases are not available in preview mode');
   },
   isAnonymous: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return true;
   },
   makeDeferredPurchase: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   checkTrialOrIntroductoryPriceEligibility: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return ({
       'preview-product-id': INTRO_ELIGIBILITY_STATUS.INTRO_ELIGIBILITY_STATUS_ELIGIBLE
     });
   },
   getPromotionalOffer: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return undefined;
   },
   eligibleWinBackOffersForProductIdentifier: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return [];
   },
   purchaseProductWithWinBackOffer: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewMakePurchaseResult;
   },
   purchasePackageWithWinBackOffer: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return previewMakePurchaseResult;
   },
   invalidateCustomerInfoCache: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   presentCodeRedemptionSheet: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAttributes: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setEmail: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setPhoneNumber: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setDisplayName: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setPushToken: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setProxyURLString: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   collectDeviceIdentifiers: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAdjustID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAppsflyerID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setFBAnonymousID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setMparticleID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setCleverTapID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setMixpanelDistinctID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setFirebaseAppInstanceID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setTenjinAnalyticsInstallationID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setKochavaDeviceID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setOnesignalID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAirshipChannelID: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setMediaSource: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setMediaCampaign: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setCampaign: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAdGroup: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setAd: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setKeyword: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   setCreative: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   canMakePayments: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return false;
   },
   beginRefundRequestForActiveEntitlement: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return 0;
   },
   beginRefundRequestForEntitlementId: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return 0;
   },
   beginRefundRequestForProductId: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return 0;
   },
   showManageSubscriptions: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   showInAppMessages: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
   },
   isWebPurchaseRedemptionURL: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return null;
   },
   isConfigured: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return true;
   },
   redeemWebPurchase: async () => {
-    console.warn('RevenueCat: In Compatibility API Mode, this method is available but has no effect');
     return {
       result: WebPurchaseRedemptionResultType.SUCCESS,
       customerInfo: previewCustomerInfo

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -285,6 +285,7 @@ export default class Purchases {
     }
 
     if (usingPreviewAPIMode) {
+      // tslint:disable-next-line:no-console
       console.warn("[RevenueCat] [configure], You successfully installed the RevenueCat SDK. However, it's currently running in Preview API mode because it requires some native modules that are not available in Expo Go. All the APIs are available but have no effect. Please, use a development build to test the real behavior of the RevenueCat SDK.");
     }
 
@@ -1623,6 +1624,7 @@ export default class Purchases {
 
   private static logWarningIfPreviewAPIMode(methodName: string) {
     if (usingPreviewAPIMode) {
+      // tslint:disable-next-line:no-console
       console.warn(`[RevenueCat] [${methodName}] This method is available but has no effect in Preview API mode.`);
     }
   }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -44,7 +44,7 @@ import {
   Storefront,
 } from "@revenuecat/purchases-typescript-internal";
 import { shouldUseCompatibilityAPIMode } from "./utils/environment";
-import { mockNativeModuleRNPurchases } from "./mocks/nativeModule";
+import { previewNativeModuleRNPurchases } from "./preview/nativeModule";
 
 // This export is kept to keep backwards compatibility to any possible users using this file directly
 export {
@@ -66,9 +66,9 @@ export {
 
 import { Platform } from "react-native";
 
-// Get the native module or use the mock implementation
+// Get the native module or use the preview implementation
 const usingCompatibilityAPIMode = shouldUseCompatibilityAPIMode();
-const RNPurchases = usingCompatibilityAPIMode ? mockNativeModuleRNPurchases : NativeModules.RNPurchases;
+const RNPurchases = usingCompatibilityAPIMode ? previewNativeModuleRNPurchases : NativeModules.RNPurchases;
 const eventEmitter = usingCompatibilityAPIMode ? null : new NativeEventEmitter(RNPurchases);
 
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -43,6 +43,8 @@ import {
   WebPurchaseRedemptionResult,
   Storefront,
 } from "@revenuecat/purchases-typescript-internal";
+import { shouldUseCompatibilityAPIMode } from "./utils/environment";
+import { mockNativeModuleRNPurchases } from "./mocks/nativeModule";
 
 // This export is kept to keep backwards compatibility to any possible users using this file directly
 export {
@@ -64,7 +66,9 @@ export {
 
 import { Platform } from "react-native";
 
-const { RNPurchases } = NativeModules;
+// Get the native module or use the mock implementation
+const RNPurchases = shouldUseCompatibilityAPIMode() ? mockNativeModuleRNPurchases : NativeModules.RNPurchases;
+
 const eventEmitter = new NativeEventEmitter(RNPurchases);
 
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -43,7 +43,7 @@ import {
   WebPurchaseRedemptionResult,
   Storefront,
 } from "@revenuecat/purchases-typescript-internal";
-import { shouldUseCompatibilityAPIMode } from "./utils/environment";
+import { shouldUsePreviewAPIMode } from "./utils/environment";
 import { previewNativeModuleRNPurchases } from "./preview/nativeModule";
 
 // This export is kept to keep backwards compatibility to any possible users using this file directly
@@ -67,9 +67,9 @@ export {
 import { Platform } from "react-native";
 
 // Get the native module or use the preview implementation
-const usingCompatibilityAPIMode = shouldUseCompatibilityAPIMode();
-const RNPurchases = usingCompatibilityAPIMode ? previewNativeModuleRNPurchases : NativeModules.RNPurchases;
-const eventEmitter = usingCompatibilityAPIMode ? null : new NativeEventEmitter(RNPurchases);
+const usingPreviewAPIMode = shouldUsePreviewAPIMode();
+const RNPurchases = usingPreviewAPIMode ? previewNativeModuleRNPurchases : NativeModules.RNPurchases;
+const eventEmitter = usingPreviewAPIMode ? null : new NativeEventEmitter(RNPurchases);
 
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
@@ -284,6 +284,10 @@ export default class Purchases {
       }
     }
 
+    if (usingPreviewAPIMode) {
+      console.warn("[RevenueCat] [configure], You successfully installed the RevenueCat SDK. However, it's currently running in Preview API mode because it requires some native modules that are not available in Expo Go. All the APIs are available but have no effect. Please, use a development build to test the real behavior of the RevenueCat SDK.");
+    }
+
     RNPurchases.setupPurchases(
       apiKey,
       appUserID,
@@ -312,6 +316,7 @@ export default class Purchases {
     allowSharing: boolean
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAllowSharingStoreAccount');
     RNPurchases.setAllowSharingStoreAccount(allowSharing);
   }
 
@@ -405,6 +410,7 @@ export default class Purchases {
    */
   public static async getOfferings(): Promise<PurchasesOfferings> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getOfferings');
     return RNPurchases.getOfferings();
   }
 
@@ -419,6 +425,7 @@ export default class Purchases {
     placementIdentifier: string
   ): Promise<PurchasesOffering | null> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getCurrentOfferingForPlacement');
     return RNPurchases.getCurrentOfferingForPlacement(placementIdentifier);
   }
 
@@ -431,6 +438,7 @@ export default class Purchases {
    */
   public static async syncAttributesAndOfferingsIfNeeded(): Promise<PurchasesOfferings> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('syncAttributesAndOfferingsIfNeeded');
     return RNPurchases.syncAttributesAndOfferingsIfNeeded();
   }
 
@@ -448,6 +456,7 @@ export default class Purchases {
     type: PURCHASE_TYPE | PRODUCT_CATEGORY = PRODUCT_CATEGORY.SUBSCRIPTION
   ): Promise<PurchasesStoreProduct[]> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getProducts');
     return RNPurchases.getProductInfo(productIdentifiers, type);
   }
 
@@ -466,6 +475,7 @@ export default class Purchases {
     type: PURCHASE_TYPE = PURCHASE_TYPE.SUBS
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseProduct');
     return RNPurchases.purchaseProduct(
       productIdentifier,
       upgradeInfo,
@@ -500,6 +510,7 @@ export default class Purchases {
     googleIsPersonalizedPrice?: boolean | null
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseStoreProduct');
     return RNPurchases.purchaseProduct(
       product.identifier,
       googleProductChangeInfo,
@@ -534,6 +545,7 @@ export default class Purchases {
     discount: PurchasesPromotionalOffer
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseDiscountedProduct');
     if (typeof discount === "undefined" || discount == null) {
       throw new Error("A discount is required");
     }
@@ -573,6 +585,7 @@ export default class Purchases {
     googleIsPersonalizedPrice?: boolean | null
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchasePackage');
     return RNPurchases.purchasePackage(
       aPackage.identifier,
       aPackage.presentedOfferingContext,
@@ -608,6 +621,7 @@ export default class Purchases {
     googleIsPersonalizedPrice?: boolean
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseSubscriptionOption');
     await Purchases.throwIfIOSPlatform();
     return RNPurchases.purchaseSubscriptionOption(
       subscriptionOption.productId,
@@ -640,6 +654,7 @@ export default class Purchases {
     discount: PurchasesPromotionalOffer
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseDiscountedPackage');
     if (typeof discount === "undefined" || discount == null) {
       throw new Error("A discount is required");
     }
@@ -663,6 +678,7 @@ export default class Purchases {
    */
   public static async restorePurchases(): Promise<CustomerInfo> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('restorePurchases');
     return RNPurchases.restorePurchases();
   }
 
@@ -672,6 +688,7 @@ export default class Purchases {
    */
   public static async getAppUserID(): Promise<string> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getAppUserID');
     return RNPurchases.getAppUserID();
   }
 
@@ -681,6 +698,7 @@ export default class Purchases {
    */
     public static async getStorefront(): Promise<Storefront | null> {
       await Purchases.throwIfNotConfigured();
+      Purchases.logWarningIfPreviewAPIMode('getStorefront');
       return RNPurchases.getStorefront();
     }
 
@@ -694,6 +712,7 @@ export default class Purchases {
    */
   public static async logIn(appUserID: string): Promise<LogInResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('logIn');
     // noinspection SuspiciousTypeOfGuard
     if (typeof appUserID !== "string") {
       throw new Error("appUserID needs to be a string");
@@ -709,6 +728,7 @@ export default class Purchases {
    */
   public static async logOut(): Promise<CustomerInfo> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('logOut');
     return RNPurchases.logOut();
   }
 
@@ -750,6 +770,7 @@ export default class Purchases {
    */
   public static async getCustomerInfo(): Promise<CustomerInfo> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getCustomerInfo');
     return RNPurchases.getCustomerInfo();
   }
 
@@ -763,6 +784,7 @@ export default class Purchases {
    */
   public static async syncPurchases(): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('syncPurchases');
     RNPurchases.syncPurchases();
   }
 
@@ -789,6 +811,7 @@ export default class Purchases {
   ): Promise<void> {
     await Purchases.throwIfIOSPlatform();
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('syncAmazonPurchase');
     RNPurchases.syncAmazonPurchase(
       productID,
       receiptID,
@@ -823,6 +846,7 @@ export default class Purchases {
   ): Promise<void> {
     await Purchases.throwIfIOSPlatform();
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('syncObserverModeAmazonPurchase');
     RNPurchases.syncObserverModeAmazonPurchase(
       productID,
       receiptID,
@@ -852,6 +876,7 @@ export default class Purchases {
   ): Promise<PurchasesStoreTransaction> {
     await Purchases.throwIfAndroidPlatform();
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('recordPurchase');
     return RNPurchases.recordPurchaseForProductID(productID);
   }
 
@@ -862,6 +887,7 @@ export default class Purchases {
   public static async enableAdServicesAttributionTokenCollection(): Promise<void> {
     if (Platform.OS === "ios") {
       await Purchases.throwIfNotConfigured();
+      Purchases.logWarningIfPreviewAPIMode('enableAdServicesAttributionTokenCollection');
       RNPurchases.enableAdServicesAttributionTokenCollection();
     }
   }
@@ -872,6 +898,7 @@ export default class Purchases {
    */
   public static async isAnonymous(): Promise<boolean> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('isAnonymous');
     return RNPurchases.isAnonymous();
   }
 
@@ -894,6 +921,7 @@ export default class Purchases {
     productIdentifiers: string[]
   ): Promise<{ [productId: string]: IntroEligibility }> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('checkTrialOrIntroductoryPriceEligibility');
     return RNPurchases.checkTrialOrIntroductoryPriceEligibility(
       productIdentifiers
     );
@@ -913,6 +941,7 @@ export default class Purchases {
     discount: PurchasesStoreProductDiscount
   ): Promise<PurchasesPromotionalOffer | undefined> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getPromotionalOffer');
     if (Platform.OS === "android") {
       return Promise.resolve(undefined);
     }
@@ -938,6 +967,7 @@ export default class Purchases {
     product: PurchasesStoreProduct
   ): Promise<[PurchasesWinBackOffer] | undefined> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getEligibleWinBackOffersForProduct');
     if (Platform.OS === "android") {
       return Promise.resolve(undefined);
     }
@@ -960,6 +990,7 @@ export default class Purchases {
     aPackage: PurchasesPackage
   ): Promise<[PurchasesWinBackOffer] | undefined> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('getEligibleWinBackOffersForPackage');
     if (Platform.OS === "android") {
       return Promise.resolve(undefined);
     }
@@ -986,6 +1017,7 @@ export default class Purchases {
     winBackOffer: PurchasesWinBackOffer
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchaseProductWithWinBackOffer');
     if (typeof winBackOffer === "undefined" || winBackOffer == null) {
       throw new Error("A win-back offer is required");
     }
@@ -1019,6 +1051,7 @@ export default class Purchases {
     winBackOffer: PurchasesWinBackOffer
   ): Promise<MakePurchaseResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('purchasePackageWithWinBackOffer');
     if (typeof winBackOffer === "undefined" || winBackOffer == null) {
       throw new Error("A win-back offer is required");
     }
@@ -1050,6 +1083,7 @@ export default class Purchases {
    */
   public static async invalidateCustomerInfoCache(): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('invalidateCustomerInfoCache');
     RNPurchases.invalidateCustomerInfoCache();
   }
 
@@ -1062,6 +1096,7 @@ export default class Purchases {
   public static async presentCodeRedemptionSheet(): Promise<void> {
     if (Platform.OS === "ios") {
       await Purchases.throwIfNotConfigured();
+      Purchases.logWarningIfPreviewAPIMode('presentCodeRedemptionSheet');
       RNPurchases.presentCodeRedemptionSheet();
     }
   }
@@ -1082,6 +1117,7 @@ export default class Purchases {
     [key: string]: string | null;
   }): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAttributes');
     RNPurchases.setAttributes(attributes);
   }
 
@@ -1094,6 +1130,7 @@ export default class Purchases {
    */
   public static async setEmail(email: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setEmail');
     RNPurchases.setEmail(email);
   }
 
@@ -1108,6 +1145,7 @@ export default class Purchases {
     phoneNumber: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setPhoneNumber');
     RNPurchases.setPhoneNumber(phoneNumber);
   }
 
@@ -1122,6 +1160,7 @@ export default class Purchases {
     displayName: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setDisplayName');
     RNPurchases.setDisplayName(displayName);
   }
 
@@ -1134,6 +1173,7 @@ export default class Purchases {
    */
   public static async setPushToken(pushToken: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setPushToken');
     RNPurchases.setPushToken(pushToken);
   }
 
@@ -1155,6 +1195,7 @@ export default class Purchases {
    */
   public static async collectDeviceIdentifiers(): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('collectDeviceIdentifiers');
     RNPurchases.collectDeviceIdentifiers();
   }
 
@@ -1168,6 +1209,7 @@ export default class Purchases {
    */
   public static async setAdjustID(adjustID: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAdjustID');
     RNPurchases.setAdjustID(adjustID);
   }
 
@@ -1182,6 +1224,7 @@ export default class Purchases {
     appsflyerID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAppsflyerID');
     RNPurchases.setAppsflyerID(appsflyerID);
   }
 
@@ -1197,6 +1240,7 @@ export default class Purchases {
     fbAnonymousID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setFBAnonymousID');
     RNPurchases.setFBAnonymousID(fbAnonymousID);
   }
 
@@ -1212,6 +1256,7 @@ export default class Purchases {
     mparticleID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setMparticleID');
     RNPurchases.setMparticleID(mparticleID);
   }
 
@@ -1227,6 +1272,7 @@ export default class Purchases {
     cleverTapID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setCleverTapID');
     RNPurchases.setCleverTapID(cleverTapID);
   }
 
@@ -1242,6 +1288,7 @@ export default class Purchases {
     mixpanelDistinctID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setMixpanelDistinctID');
     RNPurchases.setMixpanelDistinctID(mixpanelDistinctID);
   }
 
@@ -1257,6 +1304,7 @@ export default class Purchases {
     firebaseAppInstanceID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setFirebaseAppInstanceID');
     RNPurchases.setFirebaseAppInstanceID(firebaseAppInstanceID);
   }
 
@@ -1272,6 +1320,7 @@ export default class Purchases {
     tenjinAnalyticsInstallationID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setTenjinAnalyticsInstallationID');
     RNPurchases.setTenjinAnalyticsInstallationID(tenjinAnalyticsInstallationID);
   }
 
@@ -1287,6 +1336,7 @@ export default class Purchases {
     kochavaDeviceID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setKochavaDeviceID');
     RNPurchases.setKochavaDeviceID(kochavaDeviceID);
   }
 
@@ -1302,6 +1352,7 @@ export default class Purchases {
     onesignalID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setOnesignalID');
     RNPurchases.setOnesignalID(onesignalID);
   }
 
@@ -1317,6 +1368,7 @@ export default class Purchases {
     airshipChannelID: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAirshipChannelID');
     RNPurchases.setAirshipChannelID(airshipChannelID);
   }
 
@@ -1331,6 +1383,7 @@ export default class Purchases {
     mediaSource: string | null
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setMediaSource');
     RNPurchases.setMediaSource(mediaSource);
   }
 
@@ -1343,6 +1396,7 @@ export default class Purchases {
    */
   public static async setCampaign(campaign: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setCampaign');
     RNPurchases.setCampaign(campaign);
   }
 
@@ -1355,6 +1409,7 @@ export default class Purchases {
    */
   public static async setAdGroup(adGroup: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAdGroup');
     RNPurchases.setAdGroup(adGroup);
   }
 
@@ -1367,6 +1422,7 @@ export default class Purchases {
    */
   public static async setAd(ad: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setAd');
     RNPurchases.setAd(ad);
   }
 
@@ -1379,6 +1435,7 @@ export default class Purchases {
    */
   public static async setKeyword(keyword: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setKeyword');
     RNPurchases.setKeyword(keyword);
   }
 
@@ -1391,6 +1448,7 @@ export default class Purchases {
    */
   public static async setCreative(creative: string | null): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('setCreative');
     RNPurchases.setCreative(creative);
   }
 
@@ -1428,6 +1486,7 @@ export default class Purchases {
    */
   public static async beginRefundRequestForActiveEntitlement(): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('beginRefundRequestForActiveEntitlement');
     await Purchases.throwIfAndroidPlatform();
     const refundRequestStatusInt =
       await RNPurchases.beginRefundRequestForActiveEntitlement();
@@ -1452,6 +1511,7 @@ export default class Purchases {
     entitlementInfo: PurchasesEntitlementInfo
   ): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('beginRefundRequestForEntitlement');
     await Purchases.throwIfAndroidPlatform();
     const refundRequestStatusInt =
       await RNPurchases.beginRefundRequestForEntitlementId(
@@ -1478,6 +1538,7 @@ export default class Purchases {
     storeProduct: PurchasesStoreProduct
   ): Promise<REFUND_REQUEST_STATUS> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('beginRefundRequestForProduct');
     await Purchases.throwIfAndroidPlatform();
     const refundRequestStatusInt =
       await RNPurchases.beginRefundRequestForProductId(storeProduct.identifier);
@@ -1492,6 +1553,7 @@ export default class Purchases {
    */
   public static async showManageSubscriptions(): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('showManageSubscriptions');
     await Purchases.throwIfAndroidPlatform();
     return RNPurchases.showManageSubscriptions();
   }
@@ -1511,6 +1573,7 @@ export default class Purchases {
     messageTypes?: IN_APP_MESSAGE_TYPE[]
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('showInAppMessages');
     return RNPurchases.showInAppMessages(messageTypes);
   }
 
@@ -1538,6 +1601,7 @@ export default class Purchases {
     webPurchaseRedemption: WebPurchaseRedemption
   ): Promise<WebPurchaseRedemptionResult> {
     await Purchases.throwIfNotConfigured();
+    Purchases.logWarningIfPreviewAPIMode('redeemWebPurchase');
     return RNPurchases.redeemWebPurchase(webPurchaseRedemption.redemptionLink);
   }
 
@@ -1554,6 +1618,12 @@ export default class Purchases {
     const isConfigured = await Purchases.isConfigured();
     if (!isConfigured) {
       throw new UninitializedPurchasesError();
+    }
+  }
+
+  private static logWarningIfPreviewAPIMode(methodName: string) {
+    if (usingPreviewAPIMode) {
+      console.warn(`[RevenueCat] [${methodName}] This method is available but has no effect in Preview API mode.`);
     }
   }
 
@@ -1592,4 +1662,5 @@ export default class Purchases {
         return REFUND_REQUEST_STATUS.ERROR;
     }
   }
+
 }

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -67,23 +67,23 @@ export {
 import { Platform } from "react-native";
 
 // Get the native module or use the mock implementation
-const RNPurchases = shouldUseCompatibilityAPIMode() ? mockNativeModuleRNPurchases : NativeModules.RNPurchases;
-
-const eventEmitter = new NativeEventEmitter(RNPurchases);
+const usingCompatibilityAPIMode = shouldUseCompatibilityAPIMode();
+const RNPurchases = usingCompatibilityAPIMode ? mockNativeModuleRNPurchases : NativeModules.RNPurchases;
+const eventEmitter = usingCompatibilityAPIMode ? null : new NativeEventEmitter(RNPurchases);
 
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
   [];
 let customLogHandler: LogHandler;
 
-eventEmitter.addListener(
+eventEmitter?.addListener(
   "Purchases-CustomerInfoUpdated",
   (customerInfo: CustomerInfo) => {
     customerInfoUpdateListeners.forEach((listener) => listener(customerInfo));
   }
 );
 
-eventEmitter.addListener(
+eventEmitter?.addListener(
   "Purchases-ShouldPurchasePromoProduct",
   ({ callbackID }: { callbackID: number }) => {
     shouldPurchasePromoProductListeners.forEach((listener) =>
@@ -92,7 +92,7 @@ eventEmitter.addListener(
   }
 );
 
-eventEmitter.addListener(
+eventEmitter?.addListener(
   "Purchases-LogHandlerEvent",
   ({ logLevel, message }: { logLevel: LOG_LEVEL; message: string }) => {
     const logLevelEnum = LOG_LEVEL[logLevel];

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,4 +1,5 @@
-import { NativeModules } from 'react-native';
+// import { NativeModules, Platform } from 'react-native';
+// import DeviceInfo from 'react-native-device-info';
 
 /**
  * Detects if the app is running in an environment where native modules are not available
@@ -11,10 +12,17 @@ export function shouldUseCompatibilityAPIMode(): boolean {
   return isExpoGo();
 }
 
+// const EXPO_GO_BUNDLE_ID_IOS = 'host.exp.Exponent';
+// const EXPO_GO_PACKAGE_ID_ANDROID = 'host.exp.Exponent';
+
 /**
  * Detects if the app is running in Expo Go
  */
 function isExpoGo(): boolean {
-  // Taken from https://docs.expo.dev/versions/latest/sdk/constants/#executionenvironment
-  return NativeModules.ExpoConstants?.executionEnvironment === 'storeClient';
+  // if (Platform.OS === 'ios') {
+  //   return DeviceInfo.getBundleId() === EXPO_GO_BUNDLE_ID_IOS;
+  // } else if (Platform.OS === 'android') {
+  //   return DeviceInfo.getPackageName() === EXPO_GO_PACKAGE_ID_ANDROID;
+  // }
+  return true; // TODO: Remove this once we have a way to detect Expo Go
 }

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -7,12 +7,12 @@ import { NativeModules } from "react-native";
  * @returns {boolean} True if the app is running in an environment where native modules are not available
  * (like Expo Go) or if the required native modules are missing.
  */
-export function shouldUseCompatibilityAPIMode(): boolean {
-  let useCompatibilityMode = isExpoGo();
-  if (useCompatibilityMode) {
-    console.log('Expo Go app detected. Using RevenueCat in Compatibility API Mode.');
+export function shouldUsePreviewAPIMode(): boolean {
+  let usePreviewAPIMode = isExpoGo();
+  if (usePreviewAPIMode) {
+    console.log('Expo Go app detected. Using RevenueCat in Preview API Mode.');
   }
-  return useCompatibilityMode;
+  return usePreviewAPIMode;
 }
 
 declare global {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -8,11 +8,6 @@ import { NativeModules } from 'react-native';
  * (like Expo Go) or if the required native modules are missing.
  */
 export function shouldUseCompatibilityAPIMode(): boolean {
-  // Check if RNPurchases native module exists
-  if (!NativeModules.RNPurchases) {
-    return false;
-  }
-
   return isExpoGo();
 }
 
@@ -20,5 +15,6 @@ export function shouldUseCompatibilityAPIMode(): boolean {
  * Detects if the app is running in Expo Go
  */
 function isExpoGo(): boolean {
+  // Taken from https://docs.expo.dev/versions/latest/sdk/constants/#executionenvironment
   return NativeModules.ExpoConstants?.executionEnvironment === 'storeClient';
 }

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,5 +1,4 @@
-// import { NativeModules, Platform } from 'react-native';
-// import DeviceInfo from 'react-native-device-info';
+import { NativeModules } from "react-native";
 
 /**
  * Detects if the app is running in an environment where native modules are not available
@@ -9,20 +8,26 @@
  * (like Expo Go) or if the required native modules are missing.
  */
 export function shouldUseCompatibilityAPIMode(): boolean {
-  return isExpoGo();
+  let useCompatibilityMode = isExpoGo();
+  if (useCompatibilityMode) {
+    console.log('Expo Go app detected. Using RevenueCat in Compatibility API Mode.');
+  }
+  return useCompatibilityMode;
 }
-
-// const EXPO_GO_BUNDLE_ID_IOS = 'host.exp.Exponent';
-// const EXPO_GO_PACKAGE_ID_ANDROID = 'host.exp.Exponent';
 
 /**
  * Detects if the app is running in Expo Go
  */
 function isExpoGo(): boolean {
-  // if (Platform.OS === 'ios') {
-  //   return DeviceInfo.getBundleId() === EXPO_GO_BUNDLE_ID_IOS;
-  // } else if (Platform.OS === 'android') {
-  //   return DeviceInfo.getPackageName() === EXPO_GO_PACKAGE_ID_ANDROID;
-  // }
-  return true; // TODO: Remove this once we have a way to detect Expo Go
+  if (!!NativeModules.RNPurchases) {
+    return false;
+  }
+
+  try {
+    const Constants = require('expo-constants').default;
+    return Constants.executionEnvironment === 'storeClient';
+  } catch (error) {
+    // No expo-constants module found, so we're not running in Expo Go
+    return false;
+  }
 }

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,0 +1,24 @@
+import { NativeModules } from 'react-native';
+
+/**
+ * Detects if the app is running in an environment where native modules are not available
+ * (like Expo Go) or if the required native modules are missing.
+ * 
+ * @returns {boolean} True if the app is running in an environment where native modules are not available
+ * (like Expo Go) or if the required native modules are missing.
+ */
+export function shouldUseCompatibilityAPIMode(): boolean {
+  // Check if RNPurchases native module exists
+  if (!NativeModules.RNPurchases) {
+    return false;
+  }
+
+  return isExpoGo();
+}
+
+/**
+ * Detects if the app is running in Expo Go
+ */
+function isExpoGo(): boolean {
+  return NativeModules.ExpoConstants?.executionEnvironment === 'storeClient';
+}

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -15,6 +15,14 @@ export function shouldUseCompatibilityAPIMode(): boolean {
   return useCompatibilityMode;
 }
 
+declare global {
+  var expo: {
+    modules?: {
+      ExpoGo?: boolean;
+    };
+  };
+}
+
 /**
  * Detects if the app is running in Expo Go
  */
@@ -23,11 +31,5 @@ function isExpoGo(): boolean {
     return false;
   }
 
-  try {
-    const Constants = require('expo-constants').default;
-    return Constants.executionEnvironment === 'storeClient';
-  } catch (error) {
-    // No expo-constants module found, so we're not running in Expo Go
-    return false;
-  }
+  return !!globalThis.expo?.modules?.ExpoGo;
 }


### PR DESCRIPTION
Testing a RevenueCat integration in Expo Go was broken: calling any RC API raised an error prompting the Expo Go user to use a development build. This happens because you can’t add custom native code to Expo Go — it's a purely JS app that only works with a fixed set of native modules (like Camera, Notifications, etc. that are precompiled and bundled into the app).

This PR solves that integration:
* react-native-purchases automatically detects whether it's being run in Expo Go.
* When Expo Go is detected, a Preview API Mode is enabled in react-native-purchases.
* In Preview API Mode, all native calls are replaced by Javascript-Level mock APIs.

This way, although the RevenueCat has no real functionality in Expo Go, it allows testing the integration without breaking the development flow of the Expo Go user.

### To do in a future PR
Do something similar for `react-native-purchases-ui`