### PR TITLE
Add default log handler

### DIFF
--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -75,28 +75,7 @@ let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
   [];
 
-console.log("Purchases -> Will set LogHandler to default one");
-let customLogHandler: LogHandler = (logLevel: LOG_LEVEL, message: string) => {
-  switch (logLevel) {
-    case LOG_LEVEL.DEBUG:
-      console.debug(`[RevenueCat] ${message}`);
-      break;
-    case LOG_LEVEL.INFO:
-      console.info(`[RevenueCat] ${message}`);
-      break;
-    case LOG_LEVEL.WARN:
-      console.warn(`[RevenueCat] ${message}`);
-      break;
-    case LOG_LEVEL.ERROR:
-      console.error(`[RevenueCat] ${message}`);
-      break;
-    default:
-      console.log(`[RevenueCat] ${message}`);
-  }
-};
-
-RNPurchases.setLogHandler(customLogHandler);
-console.log("Purchases -> did set LogHandler  to default one");
+let customLogHandler: LogHandler;
 
 eventEmitter?.addListener(
   "Purchases-CustomerInfoUpdated",
@@ -118,7 +97,6 @@ eventEmitter?.addListener(
   "Purchases-LogHandlerEvent",
   ({ logLevel, message }: { logLevel: LOG_LEVEL; message: string }) => {
     const logLevelEnum = LOG_LEVEL[logLevel];
-    console.log(`Purchases-LogHandlerEvent received: ${message}`);
     customLogHandler(logLevelEnum, message);
   }
 );
@@ -264,6 +242,28 @@ export default class Purchases {
     pendingTransactionsForPrepaidPlansEnabled = false,
     diagnosticsEnabled = false,
   }: PurchasesConfiguration): void {
+
+    if (!customLogHandler) {
+      this.setLogHandler((logLevel: LOG_LEVEL, message: string) => {
+        switch (logLevel) {
+          case LOG_LEVEL.DEBUG:
+            console.debug(`[RevenueCat] ${message}`);
+            break;
+          case LOG_LEVEL.INFO:
+            console.info(`[RevenueCat] ${message}`);
+            break;
+          case LOG_LEVEL.WARN:
+            console.warn(`[RevenueCat] ${message}`);
+            break;
+          case LOG_LEVEL.ERROR:
+            console.error(`[RevenueCat] ${message}`);
+            break;
+          default:
+            console.log(`[RevenueCat] ${message}`);
+        }
+      });
+    }
+
     if (apiKey === undefined || typeof apiKey !== "string") {
       throw new Error(
         'Invalid API key. It must be called with an Object: configure({apiKey: "key"})'

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -247,18 +247,23 @@ export default class Purchases {
       this.setLogHandler((logLevel: LOG_LEVEL, message: string) => {
         switch (logLevel) {
           case LOG_LEVEL.DEBUG:
+            // tslint:disable-next-line:no-console
             console.debug(`[RevenueCat] ${message}`);
             break;
           case LOG_LEVEL.INFO:
+            // tslint:disable-next-line:no-console
             console.info(`[RevenueCat] ${message}`);
             break;
           case LOG_LEVEL.WARN:
+            // tslint:disable-next-line:no-console
             console.warn(`[RevenueCat] ${message}`);
             break;
           case LOG_LEVEL.ERROR:
+            // tslint:disable-next-line:no-console
             console.error(`[RevenueCat] ${message}`);
             break;
           default:
+            // tslint:disable-next-line:no-console
             console.log(`[RevenueCat] ${message}`);
         }
       });

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -70,7 +70,26 @@ const eventEmitter = new NativeEventEmitter(RNPurchases);
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
   [];
-let customLogHandler: LogHandler;
+let customLogHandler: LogHandler = (logLevel: LOG_LEVEL, message: string) => {
+  switch (logLevel) {
+    case LOG_LEVEL.DEBUG:
+      console.debug(`[RevenueCat] ${message}`);
+      break;
+    case LOG_LEVEL.INFO:
+      console.info(`[RevenueCat] ${message}`);
+      break;
+    case LOG_LEVEL.WARN:
+      console.warn(`[RevenueCat] ${message}`);
+      break;
+    case LOG_LEVEL.ERROR:
+      console.error(`[RevenueCat] ${message}`);
+      break;
+    default:
+      console.log(`[RevenueCat] ${message}`);
+  }
+};
+
+RNPurchases.setLogHandler(customLogHandler);
 
 eventEmitter.addListener(
   "Purchases-CustomerInfoUpdated",

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -70,6 +70,8 @@ const eventEmitter = new NativeEventEmitter(RNPurchases);
 let customerInfoUpdateListeners: CustomerInfoUpdateListener[] = [];
 let shouldPurchasePromoProductListeners: ShouldPurchasePromoProductListener[] =
   [];
+
+console.log("Purchases -> Will set LogHandler to default one");
 let customLogHandler: LogHandler = (logLevel: LOG_LEVEL, message: string) => {
   switch (logLevel) {
     case LOG_LEVEL.DEBUG:
@@ -90,6 +92,7 @@ let customLogHandler: LogHandler = (logLevel: LOG_LEVEL, message: string) => {
 };
 
 RNPurchases.setLogHandler(customLogHandler);
+console.log("Purchases -> did set LogHandler  to default one");
 
 eventEmitter.addListener(
   "Purchases-CustomerInfoUpdated",
@@ -111,6 +114,7 @@ eventEmitter.addListener(
   "Purchases-LogHandlerEvent",
   ({ logLevel, message }: { logLevel: LOG_LEVEL; message: string }) => {
     const logLevelEnum = LOG_LEVEL[logLevel];
+    console.log(`Purchases-LogHandlerEvent received: ${message}`);
     customLogHandler(logLevelEnum, message);
   }
 );


### PR DESCRIPTION
iOS and Android logs are not logged into the JS console. 

This PR sets the native SDK's `logHandler` to a default one that logs every message coming from the native SDKs to the JS console. This way, by default, all logs generated in the native SDKs are now visible in the JS console.

Note that developers can still override the log handler by calling the existing public API `setLogHandler`.