### PR TITLE
Wrap PaywallView in a FrameLayout and wait for it to render to fix WindowRecomposer issue

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/FrameLayoutPaywallView.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/FrameLayoutPaywallView.kt
@@ -1,0 +1,100 @@
+package com.revenuecat.purchases.ui.revenuecatui.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
+import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
+
+class FrameLayoutPaywallView : FrameLayout {
+    private var paywallView: PaywallView? = null
+    private var isAttached = false
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        init(context, attrs)
+    }
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+        init(context, attrs)
+    }
+
+    @JvmOverloads
+    constructor(
+        context: Context,
+        offering: Offering? = null,
+        listener: PaywallListener? = null,
+        fontProvider: FontProvider? = null,
+        shouldDisplayDismissButton: Boolean? = null,
+        dismissHandler: (() -> Unit)? = null,
+    ) : super(context) {
+        init(context, null)
+        paywallView?.let { view ->
+            listener?.let { view.setPaywallListener(it) }
+            dismissHandler?.let { view.setDismissHandler(it) }
+            offering?.let { view.setOfferingId(it.identifier) }
+            fontProvider?.let { view.setFontProvider(it) }
+            shouldDisplayDismissButton?.let { view.setDisplayDismissButton(it) }
+        }
+    }
+
+    private fun init(context: Context, attrs: AttributeSet?) {
+        paywallView = PaywallView(context, attrs).apply {
+            layoutParams = LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+        }
+        addView(paywallView)
+    }
+
+    fun setPaywallListener(listener: PaywallListener?) {
+        paywallView?.setPaywallListener(listener)
+    }
+
+    fun setDismissHandler(dismissHandler: (() -> Unit)?) {
+        paywallView?.setDismissHandler(dismissHandler)
+    }
+
+    fun setOfferingId(offeringId: String?) {
+        paywallView?.setOfferingId(offeringId)
+    }
+
+    fun setFontProvider(fontProvider: FontProvider?) {
+        paywallView?.setFontProvider(fontProvider)
+    }
+
+    fun setDisplayDismissButton(shouldDisplayDismissButton: Boolean) {
+        paywallView?.setDisplayDismissButton(shouldDisplayDismissButton)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        isAttached = true
+        requestLayout()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        isAttached = false
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        if (isAttached) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        } else {
+            setMeasuredDimension(
+                MeasureSpec.getSize(widthMeasureSpec),
+                MeasureSpec.getSize(heightMeasureSpec)
+            )
+        }
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        super.onLayout(changed, left, top, right, bottom)
+        if (isAttached) {
+            paywallView?.requestLayout()
+        }
+    }
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -2,10 +2,11 @@ package com.revenuecat.purchases.react.ui
 
 import com.facebook.react.uimanager.ThemedReactContext
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
+import com.revenuecat.purchases.ui.revenuecatui.views.FrameLayoutPaywallView
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
 
 
-internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
+internal class PaywallViewManager : BasePaywallViewManager<FrameLayoutPaywallView>() {
 
     companion object {
         const val REACT_CLASS = "Paywall"
@@ -15,8 +16,8 @@ internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
         return REACT_CLASS
     }
 
-    override fun createViewInstance(themedReactContext: ThemedReactContext): PaywallView {
-        return PaywallView(themedReactContext).also { view ->
+    override fun createViewInstance(themedReactContext: ThemedReactContext): FrameLayoutPaywallView {
+        return FrameLayoutPaywallView(themedReactContext).also { view ->
             view.setPaywallListener(createPaywallListenerWrapper(themedReactContext, view))
             view.setDismissHandler(getDismissHandler(themedReactContext, view))
         }
@@ -26,15 +27,15 @@ internal class PaywallViewManager : BasePaywallViewManager<PaywallView>() {
         return PaywallViewShadowNode()
     }
 
-    override fun setOfferingId(view: PaywallView, identifier: String) {
+    override fun setOfferingId(view: FrameLayoutPaywallView, identifier: String) {
         view.setOfferingId(identifier)
     }
 
-    override fun setFontFamily(view: PaywallView, customFontProvider: CustomFontProvider) {
+    override fun setFontFamily(view: FrameLayoutPaywallView, customFontProvider: CustomFontProvider) {
         view.setFontProvider(customFontProvider)
     }
 
-    override fun setDisplayDismissButton(view: PaywallView, display: Boolean) {
+    override fun setDisplayDismissButton(view: FrameLayoutPaywallView, display: Boolean) {
         view.setDisplayDismissButton(display)
     }
 


### PR DESCRIPTION
Inspired by https://github.com/vegaro/react-navigation-compose-issue/compare/main...fix-exception I wrapped the PaywallView in a FrameLayout and waited for it to render and it looks like it has fixed the WindowRecomposer issue reported in https://github.com/RevenueCat/react-native-purchases/issues/1162

I also see it's been sized correctly.

I still need to do more tests, but this is promissing