### PR TITLE
Better native modules check for Preview API mode in react-native-purchases-ui

### DIFF
--- a/react-native-purchases-ui/src/utils/environment.ts
+++ b/react-native-purchases-ui/src/utils/environment.ts
@@ -27,7 +27,7 @@ declare global {
  * Detects if the app is running in Expo Go
  */
 function isExpoGo(): boolean {
-  if (!!NativeModules.RNPurchases) {
+  if (!!NativeModules.RNPaywalls && !!NativeModules.RNCustomerCenter) {
     return false;
   }
 


### PR DESCRIPTION
A small correction on #1272. The presence of native modules in `react-native-purchases-ui` was being checked with 
```ts
if (!!NativeModules.RNPurchases) {
```

This PR changes it to
```ts
if (!!NativeModules.RNPaywalls && !!NativeModules.RNCustomerCenter) {
```