### PR TITLE
Posts request layout in `ComposeViewWrapper`

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/ComposeViewWrapper.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/ComposeViewWrapper.kt
@@ -37,7 +37,9 @@ abstract class ComposeViewWrapper<T : View> : FrameLayout {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         isAttached = true
-        requestLayout()
+        post {
+            requestLayout()
+        }
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
After the fix from #1274 , some folks are reporting their Paywall shows blank an they have to force a recomposition.

I can't reproduce, but hoping that posting the `requestLayout` call would help