### PR TITLE
Force `presentPaywall` to run on main thread

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
@@ -89,21 +89,25 @@ internal class RNPaywallsModule(
         val fontFamily = fontFamilyName?.let {
             FontAssetManager.getPaywallFontFamily(fontFamilyName = it, activity.resources.assets)
         }
-        presentPaywallFromFragment(
-            activity = activity,
-            PresentPaywallOptions(
-                requiredEntitlementIdentifier = requiredEntitlementIdentifier,
-                shouldDisplayDismissButton = displayCloseButton,
-                paywallSource = offeringIdentifier?.let {
-                    PaywallSource.OfferingIdentifier(it)
-                } ?: PaywallSource.DefaultOffering,
-                paywallResultListener = object : PaywallResultListener {
-                    override fun onPaywallResult(paywallResult: String) {
-                        promise.resolve(paywallResult)
-                    }
-                },
-                fontFamily = fontFamily
+
+        // @ReactMethod is not guaranteed to run on the main thread
+        activity.runOnUiThread {
+            presentPaywallFromFragment(
+                activity = activity,
+                PresentPaywallOptions(
+                    requiredEntitlementIdentifier = requiredEntitlementIdentifier,
+                    shouldDisplayDismissButton = displayCloseButton,
+                    paywallSource = offeringIdentifier?.let {
+                        PaywallSource.OfferingIdentifier(it)
+                    } ?: PaywallSource.DefaultOffering,
+                    paywallResultListener = object : PaywallResultListener {
+                        override fun onPaywallResult(paywallResult: String) {
+                            promise.resolve(paywallResult)
+                        }
+                    },
+                    fontFamily = fontFamily
+                )
             )
-        )
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/react-native-purchases/issues/1296

Enforce `presentPaywall` to run on main thread which is needed for https://github.com/RevenueCat/purchases-hybrid-common/pull/1165/files#diff-30371bed0b3177e346fba85b6e89d14baddd42ac5883b2b997840d83790948f1R40
