### PR TITLE
Fix error when using `RevenueCatUI.Paywall`

### DIFF
--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -47,7 +47,7 @@ const NativePaywall = !usingPreviewAPIMode && UIManager.getViewManagerConfig('Pa
   ? requireNativeComponent<FullScreenPaywallViewProps>('Paywall')
   : null;
 
-const NativePaywallFooter = !usingPreviewAPIMode && UIManager.getViewManagerConfig('RCPaywallFooterView') != null 
+const NativePaywallFooter = !usingPreviewAPIMode && UIManager.getViewManagerConfig('Paywall') != null 
   ? requireNativeComponent<InternalFooterPaywallViewProps>('RCPaywallFooterView')
   : null;
 


### PR DESCRIPTION
The existing implementation of `RevenueCatUI.Paywall` was causing an error in native mode

> Tried to register two views with the same name 'Paywall'

This PR fixes the error