### PR TITLE
Fix crash on refresh app on the iOS simulator

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -42,6 +42,14 @@ NSString *RNPurchasesLogHandlerEvent = @"Purchases-LogHandlerEvent";
              RNPurchasesLogHandlerEvent];
 }
 
+- (void)sendEventWithName:(NSString *)name body:(id)body {
+    /// This prevents a potential crash that can occur when the JS modules are not set up yet.
+    /// See https://github.com/RevenueCat/react-native-purchases/issues/1305
+    if (self.callableJSModules != nil) {
+        [super sendEventWithName:name body:body];
+    }
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey


### PR DESCRIPTION
This PR should fix #1305, which is a crash that happens when refreshing the app in the simulator.

## Description

I wasn't able to reproduce the crash of the issue, but seeing the issue description, it's obvious that the exception comes from [this assert in React Native's RCTEventEmitter](https://github.com/facebook/react-native/blob/7725a0aee35ca3f4ac1932fae970d1f13f70c881/packages/react-native/React/Modules/RCTEventEmitter.m#L41-L54) 
```objc
- (void)sendEventWithName:(NSString *)eventName body:(id)body
{
  // Assert that subclasses of RCTEventEmitter does not have `@synthesize _callableJSModules`
  // which would cause _callableJSModules in the parent RCTEventEmitter to be nil.
  RCTAssert(
      _callableJSModules != nil,
      @"Error when sending event: %@ with body: %@. "
       "RCTCallableJSModules is not set. This is probably because you've "
       "explicitly synthesized the RCTCallableJSModules in %@, even though it's inherited "
       "from RCTEventEmitter.",
      eventName,
      body,
      [self class]);
```

The fix in this PR just makes sure that `self.callableJSModules != nil` in `RNPurchases` before calling `super`'s (i.e. `RCTEventEmitter`) implementation of `-sendEventWithName:body:`.

## Other notes

* The reason this problem has probably appeared recently is due to #1271, where the native SDK's `logHandler` is automatically set to a default one at `configure` time, which causes logs to be propagated sooner.
* With this fix, we prevent the crash, but it also means that some early logs could be missed. Since this depends on React Native's implementation, I don't think there's much we can do about it, other than perhaps implementing a queueing mechanism for pending logs to be sent.