### PR TITLE
Change `react-native-purchases-ui` dependency of `react-native-purchases` to peerDependency

### DIFF
--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -75,7 +75,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-purchases": "8.11.8"
   },
   "packageManager": "yarn@3.6.1",
   "jest": {
@@ -114,7 +115,6 @@
     ]
   },
   "dependencies": {
-    "@revenuecat/purchases-typescript-internal": "14.1.0",
-    "react-native-purchases": "8.11.8"
+    "@revenuecat/purchases-typescript-internal": "14.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,7 +7573,6 @@ __metadata:
     react: 18.2.0
     react-native: 0.73.5
     react-native-builder-bob: ^0.20.0
-    react-native-purchases: 8.11.8
     ts-jest: ^29.1.2
     tslint: ^5.20.0
     tslint-config-prettier: ^1.18.0
@@ -7582,10 +7581,11 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-purchases: 8.11.8
   languageName: unknown
   linkType: soft
 
-"react-native-purchases@8.11.8, react-native-purchases@workspace:.":
+"react-native-purchases@workspace:.":
   version: 0.0.0-use.local
   resolution: "react-native-purchases@workspace:."
   dependencies:


### PR DESCRIPTION
We don't want to always include the version of `react-native-purchases` referenced by `react-native-purchases-ui`. This may cause us to have multiple version of `react-native-purchases`, which can cause problems, specially when pointing to specific versions of the libraries.

This is a breaking change however, since we won't include the base SDK automatically anymore if someone only tries to use the UI dependency.
