### PR TITLE
Make hold job wait for tests to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,22 +199,23 @@ jobs:
             open_pr:true \
             automatic_release:<< pipeline.parameters.automatic >>
 workflows:
-  test:
+  build-test-hold-deploy:
     when:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
+      # Testing phase - runs on all branches
       - analyse_js
       - android
       - ios
 
-  deploy:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
+      # Hold and deploy phase - only on release branches
       - hold:
           type: approval
+          requires:
+            - analyse_js
+            - android
+            - ios
           <<: *release-branches
       - revenuecat/tag-current-branch:
           requires:


### PR DESCRIPTION
In release branches, it was possible to approve the hold job without waiting for tests to pass, since the tests weren't a requiremnt of the `hold` job.

I decided to create a `build-test-hold-deploy` to avoid duplication (similar to https://github.com/RevenueCat/purchases-capacitor/pull/492)

An alternative is to have two separate workflows with duplicated test jobs, but filter the non-release branches in the `test` workflow.