### PR TITLE
Remove `react-native-get-random-values` dependency temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
   },
   "dependencies": {
     "@revenuecat/purchases-js-hybrid-mappings": "16.2.1",
-    "@revenuecat/purchases-typescript-internal": "16.2.1",
-    "react-native-get-random-values": "^1.11.0"
+    "@revenuecat/purchases-typescript-internal": "16.2.1"
   }
 }

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -1,4 +1,3 @@
-import 'react-native-get-random-values'; // needed to generate random Ids in purchases-js in RN apps.
 import {
   INTRO_ELIGIBILITY_STATUS,
   MakePurchaseResult,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5139,13 +5139,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 4c59eb1775a7f132333f296c5082476fdcc8f58d023c42ed6d378d2e2da4c328c7a71562f271181a725dd17cdaa8f2805346cc330cdbad3b8e4b9751508bd0a3
-  languageName: node
-  linkType: hard
-
 "fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
@@ -8411,17 +8404,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "react-native-get-random-values@npm:1.11.0"
-  dependencies:
-    fast-base64-decode: ^1.0.0
-  peerDependencies:
-    react-native: ">=0.56"
-  checksum: 07729f70a007f7a3b8f98ebf687c1298ba288b87dd71d8ba385be6b5a377718b27b97547bbe1db6b225b83ee109dfce0b01721e6ed535d53892f3ac81e6bf975
-  languageName: node
-  linkType: hard
-
 "react-native-is-edge-to-edge@npm:^1.1.7":
   version: 1.1.7
   resolution: "react-native-is-edge-to-edge@npm:1.1.7"
@@ -8480,7 +8462,6 @@ __metadata:
     prettier: ^2.0.5
     react: 18.2.0
     react-native: 0.73.5
-    react-native-get-random-values: ^1.11.0
     ts-jest: ^29.1.2
     tslint: ^5.20.0
     tslint-config-prettier: ^1.18.0


### PR DESCRIPTION
This dependency was added to add minimal support for Expo Go. When creating anonymous user ids, it's not able to find the `crypto` library in Expo Go, which is used by `purchases-js`. `react-native-get-random-values` adds that dependency so it works on Expo Go, however, some devs have reported issues in #1356. While we haven't been able to repro as of now, there are alternatives we can follow once we add more functional support to Expo Go. 

This PR reverts adding that library for now until we work on those. React native web support should still work fine on a browser but running on Expo Go will crash with a `[ReferenceError: Property 'crypto' doesn't exist]` error. For users trying to make it work, they can potentially add `react-native-get-random-values` to their dependencies and import the library somewhere in their app, like: `import 'react-native-get-random-values';`.