### PR TITLE
Passing the PresentedOfferingContext from the Offering to the PHC APIs when navigating to a paywall

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -84,16 +84,17 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
             return
         }
 
-        val availablePackages = offeringMap.getArray(OPTION_OFFERING_AVAILABLE_PACKAGES)?.toArrayList() //as? Array<Map<*, *>>
-        val firstAvailablePackage = availablePackages?.firstOrNull() as? Map<*, *>;
-
-        val presentedOfferingContext = firstAvailablePackage?.let {
-            (it.get(OPTION_OFFERING_AVAILABLE_PACKAGES_PRESENTED_OFFERING_CONTEXT) as? Map<*,*>)?.let {
-                RNPurchasesConverters.presentedOfferingContext(offeringIdentifier, it)
-            }
-        } ?: PresentedOfferingContext(offeringIdentifier)
+        val presentedOfferingContext = getPresentedOfferingContext(offeringIdentifier, offeringMap)
 
         setOfferingId(view, offeringIdentifier, presentedOfferingContext)
+    }
+
+    private fun getPresentedOfferingContext(offeringIdentifier: String, offeringMap: ReadableMap?) : PresentedOfferingContext {
+        val availablePackages = offeringMap?.getArray(OPTION_OFFERING_AVAILABLE_PACKAGES)?.toArrayList()
+        val firstAvailablePackage = availablePackages?.firstOrNull() as? Map<*, *>;
+        val presentedOfferingContextMap = firstAvailablePackage?.get(OPTION_OFFERING_AVAILABLE_PACKAGES_PRESENTED_OFFERING_CONTEXT) as? Map<*,*>;
+
+        return RNPurchasesConverters.presentedOfferingContext(offeringIdentifier, presentedOfferingContextMap)
     }
 
     private fun setFontFamilyProp(view: T, options: ReadableMap?) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallFooterViewManager.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.react.ui
 
 import androidx.core.view.children
 import com.facebook.react.uimanager.ThemedReactContext
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.react.ui.events.OnMeasureEvent
 import com.revenuecat.purchases.react.ui.views.WrappedPaywallFooterComposeView
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
@@ -72,8 +73,12 @@ internal class PaywallFooterViewManager : BasePaywallViewManager<WrappedPaywallF
         }
     }
 
-    override fun setOfferingId(view: WrappedPaywallFooterComposeView, identifier: String) {
-        view.setOfferingId(identifier)
+    override fun setOfferingId(
+        view: WrappedPaywallFooterComposeView,
+        offeringId: String?,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) {
+        view.setOfferingId(offeringId, presentedOfferingContext)
     }
 
     override fun setFontFamily(view: WrappedPaywallFooterComposeView, customFontProvider: CustomFontProvider) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.react.ui
 
 import com.facebook.react.uimanager.ThemedReactContext
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.react.ui.views.WrappedPaywallComposeView
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 
@@ -26,8 +27,12 @@ internal class PaywallViewManager : BasePaywallViewManager<WrappedPaywallCompose
         return PaywallViewShadowNode()
     }
 
-    override fun setOfferingId(view: WrappedPaywallComposeView, identifier: String) {
-        view.setOfferingId(identifier)
+    override fun setOfferingId(
+        view: WrappedPaywallComposeView,
+        offeringId: String?,
+        presentedOfferingContext: PresentedOfferingContext?
+    ) {
+        view.setOfferingId(offeringId, presentedOfferingContext)
     }
 
     override fun setFontFamily(view: WrappedPaywallComposeView, customFontProvider: CustomFontProvider) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPaywallsModule.kt
@@ -97,9 +97,8 @@ internal class RNPaywallsModule(
         }
 
         val paywallSource: PaywallSource = offeringIdentifier?.let { offeringIdentifier ->
-            RNPurchasesConverters.presentedOfferingContext(offeringIdentifier, presentedOfferingContext?.toHashMap())?.let {
-                PaywallSource.OfferingIdentifierWithPresentedOfferingContext(offeringIdentifier, presentedOfferingContext=it)
-            }
+            val presentedOfferingContextMap = RNPurchasesConverters.presentedOfferingContext(offeringIdentifier, presentedOfferingContext?.toHashMap())
+            PaywallSource.OfferingIdentifierWithPresentedOfferingContext(offeringIdentifier, presentedOfferingContext=presentedOfferingContextMap)
         } ?: PaywallSource.DefaultOffering
 
         // @ReactMethod is not guaranteed to run on the main thread

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPurchasesConverters.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPurchasesConverters.kt
@@ -49,7 +49,7 @@ internal object RNPurchasesConverters {
         return writableArray
     }
 
-    fun presentedOfferingContext(offeringIdentifier: String, presentedOfferingContext: Map<*,*>?) : PresentedOfferingContext? {
+    fun presentedOfferingContext(offeringIdentifier: String, presentedOfferingContext: Map<*,*>?) : PresentedOfferingContext {
         if (presentedOfferingContext == null) {
             return PresentedOfferingContext(offeringIdentifier)
         }
@@ -64,9 +64,11 @@ internal object RNPurchasesConverters {
             }
         }
 
+        val placementIdentifier = presentedOfferingContext["placementIdentifier"] as? String
+
         return PresentedOfferingContext(
             offeringIdentifier,
-            placementIdentifier = presentedOfferingContext["placementIdentifier"] as? String,
+            placementIdentifier,
             targetingContext
         )
     }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPurchasesConverters.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/RNPurchasesConverters.kt
@@ -1,9 +1,12 @@
 package com.revenuecat.purchases.react.ui
 
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
+import com.revenuecat.purchases.PresentedOfferingContext
+import kotlin.collections.get
 
 internal object RNPurchasesConverters {
 
@@ -44,5 +47,27 @@ internal object RNPurchasesConverters {
             }
         }
         return writableArray
+    }
+
+    fun presentedOfferingContext(offeringIdentifier: String, presentedOfferingContext: Map<*,*>?) : PresentedOfferingContext? {
+        if (presentedOfferingContext == null) {
+            return PresentedOfferingContext(offeringIdentifier)
+        }
+
+        var targetingContext: PresentedOfferingContext.TargetingContext? = null;
+        val targetingContextMap = presentedOfferingContext["targetingContext"] as? Map<*, *>
+        if (targetingContextMap != null) {
+            val revision = (targetingContextMap["revision"] as? Number)?.toInt()
+            val ruleId = targetingContextMap["ruleId"] as? String
+            if (revision != null && ruleId != null) {
+                targetingContext = PresentedOfferingContext.TargetingContext(revision, ruleId)
+            }
+        }
+
+        return PresentedOfferingContext(
+            offeringIdentifier,
+            placementIdentifier = presentedOfferingContext["placementIdentifier"] as? String,
+            targetingContext
+        )
     }
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallComposeView.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallComposeView.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.react.ui.views
 
 import android.content.Context
 import android.util.AttributeSet
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.fonts.FontProvider
 import com.revenuecat.purchases.ui.revenuecatui.views.PaywallView
@@ -20,8 +21,8 @@ class WrappedPaywallComposeView(context: Context) : ComposeViewWrapper<PaywallVi
         wrappedView?.setDismissHandler(dismissHandler)
     }
 
-    fun setOfferingId(offeringId: String?) {
-        wrappedView?.setOfferingId(offeringId)
+    fun setOfferingId(offeringId: String?, presentedOfferingContext: PresentedOfferingContext? = null) {
+        wrappedView?.setOfferingId(offeringId, presentedOfferingContext)
     }
 
     fun setFontProvider(fontProvider: FontProvider?) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallFooterComposeView.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallFooterComposeView.kt
@@ -16,9 +16,14 @@ open class WrappedPaywallFooterComposeView(context: Context) : ComposeViewWrappe
 
     @OptIn(InternalRevenueCatAPI::class)
     fun setOfferingId(offeringId: String?, presentedOfferingContext: PresentedOfferingContext? = null) {
-        val offeringId = offeringId ?: "default"
-        val presentedOfferingContext = presentedOfferingContext ?: PresentedOfferingContext(offeringId)
-        wrappedView?.setOfferingIdAndPresentedOfferingContext(offeringId, presentedOfferingContext)
+        if (offeringId == null) {
+            // We'll get rid of this deprecated API usage once https://github.com/RevenueCat/purchases-android/pull/2658 is merged
+            wrappedView?.setOfferingId(null)
+        }
+        else {
+            val presentedOfferingContext = presentedOfferingContext ?: PresentedOfferingContext(offeringId)
+            wrappedView?.setOfferingIdAndPresentedOfferingContext(offeringId, presentedOfferingContext)
+        }
     }
 
     fun setFontProvider(customFontProvider: CustomFontProvider) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallFooterComposeView.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/views/WrappedPaywallFooterComposeView.kt
@@ -2,6 +2,8 @@ package com.revenuecat.purchases.react.ui.views
 
 import android.content.Context
 import android.util.AttributeSet
+import com.revenuecat.purchases.InternalRevenueCatAPI
+import com.revenuecat.purchases.PresentedOfferingContext
 import com.revenuecat.purchases.ui.revenuecatui.PaywallListener
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import com.revenuecat.purchases.ui.revenuecatui.views.OriginalTemplatePaywallFooterView
@@ -12,8 +14,11 @@ open class WrappedPaywallFooterComposeView(context: Context) : ComposeViewWrappe
         return OriginalTemplatePaywallFooterView(context, attrs)
     }
 
-    fun setOfferingId(identifier: String) {
-        wrappedView?.setOfferingId(identifier)
+    @OptIn(InternalRevenueCatAPI::class)
+    fun setOfferingId(offeringId: String?, presentedOfferingContext: PresentedOfferingContext? = null) {
+        val offeringId = offeringId ?: "default"
+        val presentedOfferingContext = presentedOfferingContext ?: PresentedOfferingContext(offeringId)
+        wrappedView?.setOfferingIdAndPresentedOfferingContext(offeringId, presentedOfferingContext)
     }
 
     fun setFontProvider(customFontProvider: CustomFontProvider) {

--- a/react-native-purchases-ui/ios/RNPaywalls.m
+++ b/react-native-purchases-ui/ios/RNPaywalls.m
@@ -62,6 +62,7 @@ RCT_EXPORT_MODULE();
 // MARK: -
 
 RCT_EXPORT_METHOD(presentPaywall:(nullable NSString *)offeringIdentifier
+                  presentedOfferingContext:(nullable NSDictionary *)presentedOfferingContext
                   shouldDisplayCloseButton:(BOOL)displayCloseButton
                   withFontFamily:(nullable NSString *)fontFamily
                   withResolve:(RCTPromiseResolveBlock)resolve
@@ -70,6 +71,9 @@ RCT_EXPORT_METHOD(presentPaywall:(nullable NSString *)offeringIdentifier
         NSMutableDictionary *options = [NSMutableDictionary dictionary];
         if (offeringIdentifier != nil) {
             options[PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier;
+        }
+        if (presentedOfferingContext != nil) {
+            options[PaywallOptionsKeys.presentedOfferingContext] = presentedOfferingContext;
         }
         options[PaywallOptionsKeys.displayCloseButton] = @(displayCloseButton);
         if (fontFamily) {
@@ -87,6 +91,7 @@ RCT_EXPORT_METHOD(presentPaywall:(nullable NSString *)offeringIdentifier
 
 RCT_EXPORT_METHOD(presentPaywallIfNeeded:(NSString *)requiredEntitlementIdentifier
                   withOfferingIdentifier:(nullable NSString *)offeringIdentifier
+                  presentedOfferingContext:(nullable NSDictionary *)presentedOfferingContext
                   shouldDisplayCloseButton:(BOOL)displayCloseButton
                   withFontFamily:(nullable NSString *)fontFamily
                   withResolve:(RCTPromiseResolveBlock)resolve
@@ -95,6 +100,9 @@ RCT_EXPORT_METHOD(presentPaywallIfNeeded:(NSString *)requiredEntitlementIdentifi
         NSMutableDictionary *options = [NSMutableDictionary dictionary];
         if (offeringIdentifier != nil) {
             options[PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier;
+        }
+        if (presentedOfferingContext != nil) {
+            options[PaywallOptionsKeys.presentedOfferingContext] = presentedOfferingContext;
         }
         options[PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier;
         options[PaywallOptionsKeys.displayCloseButton] = @(displayCloseButton);

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -380,6 +380,7 @@ export default class RevenueCatUI {
     RevenueCatUI.logWarningIfPreviewAPIMode("presentPaywall");
     return RNPaywalls.presentPaywall(
       offering?.identifier ?? null,
+      offering?.availablePackages?.[0]?.presentedOfferingContext,
       displayCloseButton,
       fontFamily,
     )
@@ -408,6 +409,7 @@ export default class RevenueCatUI {
     return RNPaywalls.presentPaywallIfNeeded(
       requiredEntitlementIdentifier,
       offering?.identifier ?? null,
+      offering?.availablePackages?.[0]?.presentedOfferingContext,
       displayCloseButton,
       fontFamily,
     )


### PR DESCRIPTION
Passing the `PresentedOfferingContext` from the Offering to the PHC APIs when navigating to a paywall. For context see [PHC MR](https://github.com/RevenueCat/purchases-hybrid-common/pull/1246)