### PR TITLE
Fix PHC bumping of purchases-js-hybrid-mappings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,7 @@ files_to_update_phc_version = {
     'react-native-purchases-ui/RNPaywalls.podspec' => ['"PurchasesHybridCommon", \'{x}\'', '"PurchasesHybridCommonUI", \'{x}\''],
     'android/build.gradle' => ['com.revenuecat.purchases:purchases-hybrid-common:{x}'],
     'react-native-purchases-ui/android/build.gradle' => ['com.revenuecat.purchases:purchases-hybrid-common-ui:{x}'],
-    'package.json' => ['"@revenuecat/purchases-typescript-internal": "{x}"'],
+    'package.json' => ['"@revenuecat/purchases-typescript-internal": "{x}"', '"@revenuecat/purchases-js-hybrid-mappings": "{x}"'],
     'react-native-purchases-ui/package.json' => ['"@revenuecat/purchases-typescript-internal": "{x}"']
 }
 files_to_update_on_latest_stable_releases = {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     ]
   },
   "dependencies": {
-    "@revenuecat/purchases-js-hybrid-mappings": "16.2.1",
-    "@revenuecat/purchases-typescript-internal": "16.2.1"
+    "@revenuecat/purchases-js-hybrid-mappings": "17.0.0",
+    "@revenuecat/purchases-typescript-internal": "17.0.0"
   }
 }


### PR DESCRIPTION
We were missing to update the `purchases-js-hybrid-mappings` in the automation.

Also, this updates that and `purchases-typescript-internal` to version 17.0.0, which is the latest.
