### PR TITLE
Fix `react-native-purchases-ui` preview mode

### DIFF
--- a/examples/purchaseTesterExpo/app/(tabs)/index.tsx
+++ b/examples/purchaseTesterExpo/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import Constants from 'expo-constants';
 export default function TabOneScreen() {
   const [lastResult, setLastResult] = useState<string>('No method called yet');
   const [showModalPaywall, setShowModalPaywall] = useState(false);
+  const [showModalCustomerCenter, setShowModalCustomerCenter] = useState(false);
 
   const getPlatformInfo = (): string => {
     if (Platform.OS === 'web') {
@@ -369,6 +370,13 @@ export default function TabOneScreen() {
             }
           }))} 
         />
+        <MethodButton 
+          title="Show Modal Customer Center (Fullscreen)" 
+          onPress={() => {
+            setLastResult('[' + new Date().toLocaleTimeString() + '] Opening modal customer center...');
+            setShowModalCustomerCenter(true);
+          }} 
+        />
 
         <View style={styles.bottomPadding} />
       </ScrollView>
@@ -412,6 +420,26 @@ export default function TabOneScreen() {
             onDismiss={() => {
               setLastResult(`[${new Date().toLocaleTimeString()}] Modal paywall dismissed`);
               setShowModalPaywall(false);
+            }}
+          />
+        </View>
+      </Modal>
+
+      {/* Modal Customer Center */}
+      <Modal
+        visible={showModalCustomerCenter}
+        animationType="slide"
+        presentationStyle="fullScreen"
+        onRequestClose={() => setShowModalCustomerCenter(false)}
+      >
+        <View style={styles.modalContainer}>
+          <RevenueCatUI.CustomerCenterView
+            onDismiss={() => {
+              setLastResult(`[${new Date().toLocaleTimeString()}] Modal customer center dismissed`);
+              setShowModalCustomerCenter(false);
+            }}
+            onCustomActionSelected={({ actionId }) => {
+              setLastResult(`[${new Date().toLocaleTimeString()}] Custom action selected: ${actionId}`);
             }}
           />
         </View>

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -19,7 +19,7 @@ import {
 import React, { type ReactNode, useEffect, useState } from "react";
 import { shouldUsePreviewAPIMode } from "./utils/environment";
 import { previewNativeModuleRNCustomerCenter, previewNativeModuleRNPaywalls } from "./preview/nativeModules";
-import { PreviewPaywall } from "./preview/previewComponents";
+import { PreviewCustomerCenter, PreviewPaywall } from "./preview/previewComponents";
 
 export { PAYWALL_RESULT } from "@revenuecat/purchases-typescript-internal";
 
@@ -260,12 +260,9 @@ type InternalFooterPaywallViewProps = FooterPaywallViewProps & {
   onMeasure?: ({height}: { height: number }) => void;
 };
 
-const InternalCustomerCenterView =
-  UIManager.getViewManagerConfig('CustomerCenterView') != null
+const InternalCustomerCenterView = !usingPreviewAPIMode && UIManager.getViewManagerConfig('CustomerCenterView') != null
     ? requireNativeComponent<CustomerCenterViewProps>('CustomerCenterView')
-    : () => {
-        throw new Error(LINKING_ERROR);
-      };
+    : null;
 
 export interface CustomerCenterViewProps {
   style?: StyleProp<ViewStyle>;
@@ -536,13 +533,28 @@ export default class RevenueCatUI {
     style,
     onDismiss,
     onCustomActionSelected,
-  }) => (
-    <InternalCustomerCenterView
-      onDismiss={() => onDismiss && onDismiss()}
-      onCustomActionSelected={(event: any) => onCustomActionSelected && onCustomActionSelected(event.nativeEvent)}
-      style={[{ flex: 1 }, style]}
-    />
-  );
+  }) => {
+    if (usingPreviewAPIMode) {
+      return (
+        <PreviewCustomerCenter
+          onDismiss={() => onDismiss && onDismiss()}
+          style={[{ flex: 1 }, style]}
+        />
+      );
+    }
+    
+    if (!InternalCustomerCenterView) {
+      throw new Error(LINKING_ERROR);
+    }
+    
+    return (
+      <InternalCustomerCenterView
+        onDismiss={() => onDismiss && onDismiss()}
+        onCustomActionSelected={(event: any) => onCustomActionSelected && onCustomActionSelected(event.nativeEvent)}
+        style={[{ flex: 1 }, style]}
+      />
+    );
+  };
 
   /**
    * Presents the customer center to the user.

--- a/react-native-purchases-ui/src/preview/previewComponents.tsx
+++ b/react-native-purchases-ui/src/preview/previewComponents.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, type ViewStyle, type StyleProp } from 'react-native';
 import {
   type CustomerInfo,
   type PurchasesError,
@@ -168,4 +168,49 @@ const styles = StyleSheet.create({
     color: '#999999',
     textAlign: 'center',
   },
-}); 
+});
+
+export interface PreviewCustomerCenterProps {
+  style?: StyleProp<ViewStyle>;
+  onDismiss?: () => void;
+}
+
+export const PreviewCustomerCenter: React.FC<PreviewCustomerCenterProps> = ({
+  style,
+  onDismiss,
+}) => {
+  const handleClose = () => {
+    onDismiss?.();
+  };
+
+  return (
+    <View style={[styles.container, style]}>
+      <View style={styles.header}>
+        <Text style={[styles.title]}>
+          Preview Customer Center
+        </Text>
+        <TouchableOpacity onPress={handleClose} style={styles.closeButton}>
+          <Text style={styles.closeButtonText}>✕</Text>
+        </TouchableOpacity>
+      </View>
+      
+      <View style={styles.content}>
+        <Text style={[styles.notSupportedMessage]}>
+          Web customer center is not supported yet.
+        </Text>
+        <Text style={[styles.fakeMessage]}>
+          This is a fake preview implementation.
+        </Text>
+        <Text style={[styles.previewMode]}>
+          Currently in preview mode
+        </Text>
+        
+        <TouchableOpacity style={styles.closePaywallButton} onPress={handleClose}>
+          <Text style={[styles.closePaywallButtonText]}>
+            Close Customer Center
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};


### PR DESCRIPTION
This adds a preview UI for the Customer center to be used when on preview mode (on web mostly). This UI is just a dummy UI used as a placeholder while in this mode. This broke in [#1209](https://github.com/RevenueCat/react-native-purchases/pull/1209/files#diff-d13cb7cc4c8c4d19c22ebd27a4d83b5962c60891a42931f833fb6ee16b5e4dd8R264) 
<img width="423" height="559" alt="image" src="https://github.com/user-attachments/assets/65127ff9-407e-4eaa-b800-db3fb289018a" />
