### PR TITLE
[V8] [CI] `bump` pipeline action won't trigger `deploy` workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,8 +210,11 @@ workflows:
 
   deploy:
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+      - not:
+          equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      - not:
+          equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
       - hold:
           type: approval


### PR DESCRIPTION
When triggering the CI pipeline with the `bump` action, what we intend is to deploy **the next version** of this dependency. Therefore, the `deploy` workflow should never be triggered in this scenario, since it starts the deployment of **the current version** of the dependency.

This happened to me when trying to release a new version for an older major of PHC. I wanted to release PHC v14.3.0 starting off of v14.2.0. For that I created a `release/14.2.0` branch at the `14.2.0` tag and run the pipeline with the `bump` action. That triggered the `trigger_bump` workflow (as expected) that created the `14.3.0` tag. However, it also triggered the `deploy` workflow because the branch was called `release/X.Y.Z`. 

With this new condition, the `deploy` workflow would'n have been triggered, which is what we want.