### PR TITLE
Add APITests for UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
           name: API Tests
           command: yarn tsc -p apitesters
       - run:
+          name: UI API Tests
+          command: yarn workspace react-native-purchases-ui apitest
+      - run:
           name: Linter
           command: yarn run tslint
 

--- a/react-native-purchases-ui/apitesters/customer_center.tsx
+++ b/react-native-purchases-ui/apitesters/customer_center.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import type { ComponentProps } from "react";
+
+import RevenueCatUI from "react-native-purchases-ui";
+import type {
+  CustomerCenterCallbacks,
+  CustomerCenterManagementOption,
+  CustomerCenterManagementOptionEvent,
+  PresentCustomerCenterParams,
+} from "react-native-purchases-ui";
+import type {
+  CustomerInfo,
+  PurchasesError,
+  REFUND_REQUEST_STATUS,
+} from "@revenuecat/purchases-typescript-internal";
+
+async function checkPresentCustomerCenter() {
+  await RevenueCatUI.presentCustomerCenter();
+}
+
+async function checkPresentCustomerCenterWithCallbacks(
+  callbacks: CustomerCenterCallbacks,
+) {
+  await RevenueCatUI.presentCustomerCenter({
+    callbacks,
+  });
+}
+
+const customerCenterCallbacks: CustomerCenterCallbacks = {
+  onFeedbackSurveyCompleted: ({ feedbackSurveyOptionId }) => {
+    const optionId: string = feedbackSurveyOptionId;
+    void optionId;
+  },
+  onShowingManageSubscriptions: () => {},
+  onRestoreStarted: () => {},
+  onRestoreCompleted: ({ customerInfo }) => {
+    const info: CustomerInfo = customerInfo;
+    void info;
+  },
+  onRestoreFailed: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onRefundRequestStarted: ({ productIdentifier }) => {
+    const identifier: string = productIdentifier;
+    void identifier;
+  },
+  onRefundRequestCompleted: ({ productIdentifier, refundRequestStatus }) => {
+    const identifier: string = productIdentifier;
+    const status: REFUND_REQUEST_STATUS = refundRequestStatus;
+    void identifier;
+    void status;
+  },
+  onManagementOptionSelected: (event) => {
+    const managementOptionEvent: CustomerCenterManagementOptionEvent = event;
+    handleManagementOptionEvent(managementOptionEvent);
+  },
+  onCustomActionSelected: ({ actionId }) => {
+    const id: string = actionId;
+    void id;
+  },
+};
+
+function handleManagementOptionEvent(
+  event: CustomerCenterManagementOptionEvent,
+) {
+  if (typeof event.url === "string") {
+    const option: CustomerCenterManagementOption = event.option;
+    const url: string = event.url;
+    void option;
+    void url;
+  } else {
+    const option: Exclude<CustomerCenterManagementOption, "custom_url"> = event.option;
+    const url: null = event.url;
+    void option;
+    void url;
+  }
+}
+
+const customerCenterElement = (
+  <RevenueCatUI.CustomerCenterView
+    shouldShowCloseButton={false}
+    onDismiss={() => {}}
+    onCustomActionSelected={({ actionId }) => {
+      const id: string = actionId;
+      void id;
+    }}
+    style={{ flex: 1 }}
+  />
+);
+
+type CustomerCenterViewProps = ComponentProps<typeof RevenueCatUI.CustomerCenterView>;
+
+const customerCenterViewProps: CustomerCenterViewProps = {
+  onDismiss: () => {},
+  onCustomActionSelected: ({ actionId }) => {
+    const id: string = actionId;
+    void id;
+  },
+  shouldShowCloseButton: true,
+  style: { flex: 1 },
+};
+
+void customerCenterViewProps;
+
+const presentCustomerCenterParams: PresentCustomerCenterParams = {
+  callbacks: customerCenterCallbacks,
+};
+
+void customerCenterElement;
+void presentCustomerCenterParams;
+
+export {
+  checkPresentCustomerCenter,
+  checkPresentCustomerCenterWithCallbacks,
+  customerCenterCallbacks,
+  presentCustomerCenterParams,
+};

--- a/react-native-purchases-ui/apitesters/paywalls.tsx
+++ b/react-native-purchases-ui/apitesters/paywalls.tsx
@@ -1,0 +1,473 @@
+import React from "react";
+import type { ComponentProps } from "react";
+
+import RevenueCatUI, { PAYWALL_RESULT } from "react-native-purchases-ui";
+import type {
+  FooterPaywallViewOptions,
+  FullScreenPaywallViewOptions,
+  PaywallViewOptions,
+  PresentPaywallIfNeededParams,
+  PresentPaywallParams,
+} from "react-native-purchases-ui";
+import type {
+  CustomerInfo,
+  PurchasesError,
+  PurchasesOffering,
+  PurchasesPackage,
+  PurchasesStoreTransaction,
+} from "@revenuecat/purchases-typescript-internal";
+
+const paywallResultEnum: typeof PAYWALL_RESULT = RevenueCatUI.PAYWALL_RESULT;
+
+void paywallResultEnum;
+
+type PaywallComponentProps = ComponentProps<typeof RevenueCatUI.Paywall>;
+
+const paywallComponentProps: PaywallComponentProps = {
+  options: {
+    offering: null,
+    displayCloseButton: true,
+    fontFamily: "Roboto",
+  },
+  onPurchaseStarted: ({ packageBeingPurchased }) => {
+    const selectedPackage: PurchasesPackage = packageBeingPurchased;
+    void selectedPackage;
+  },
+  onPurchaseCompleted: ({ customerInfo, storeTransaction }) => {
+    const info: CustomerInfo = customerInfo;
+    const transaction: PurchasesStoreTransaction = storeTransaction;
+    void info;
+    void transaction;
+  },
+  onPurchaseError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onPurchaseCancelled: () => {},
+  onRestoreStarted: () => {},
+  onRestoreCompleted: ({ customerInfo }) => {
+    const info: CustomerInfo = customerInfo;
+    void info;
+  },
+  onRestoreError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onDismiss: () => {},
+};
+
+void paywallComponentProps;
+
+type FooterComponentProps = ComponentProps<
+  typeof RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+>;
+
+const footerComponentProps: FooterComponentProps = {
+  options: {
+    offering: null,
+    fontFamily: "Roboto",
+  },
+  onPurchaseStarted: ({ packageBeingPurchased }) => {
+    const selectedPackage: PurchasesPackage = packageBeingPurchased;
+    void selectedPackage;
+  },
+  onPurchaseCompleted: ({ customerInfo, storeTransaction }) => {
+    const info: CustomerInfo = customerInfo;
+    const transaction: PurchasesStoreTransaction = storeTransaction;
+    void info;
+    void transaction;
+  },
+  onPurchaseError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onPurchaseCancelled: () => {},
+  onRestoreStarted: () => {},
+  onRestoreCompleted: ({ customerInfo }) => {
+    const info: CustomerInfo = customerInfo;
+    void info;
+  },
+  onRestoreError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onDismiss: () => {},
+};
+
+void footerComponentProps;
+
+type DeprecatedFooterComponentProps = ComponentProps<
+  typeof RevenueCatUI.PaywallFooterContainerView
+>;
+
+const deprecatedFooterComponentProps: DeprecatedFooterComponentProps = {
+  options: {
+    offering: null,
+    fontFamily: "Arial",
+  },
+  onPurchaseStarted: ({ packageBeingPurchased }) => {
+    const selectedPackage: PurchasesPackage = packageBeingPurchased;
+    void selectedPackage;
+  },
+  onPurchaseCompleted: ({ customerInfo, storeTransaction }) => {
+    const info: CustomerInfo = customerInfo;
+    const transaction: PurchasesStoreTransaction = storeTransaction;
+    void info;
+    void transaction;
+  },
+  onPurchaseError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onPurchaseCancelled: () => {},
+  onRestoreStarted: () => {},
+  onRestoreCompleted: ({ customerInfo }) => {
+    const info: CustomerInfo = customerInfo;
+    void info;
+  },
+  onRestoreError: ({ error }) => {
+    const purchasesError: PurchasesError = error;
+    void purchasesError;
+  },
+  onDismiss: () => {},
+};
+
+void deprecatedFooterComponentProps;
+
+async function checkPresentPaywall(offering: PurchasesOffering) {
+  let paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywall();
+  paywallResult = await RevenueCatUI.presentPaywall({});
+  paywallResult = await RevenueCatUI.presentPaywall({
+    offering,
+  });
+  paywallResult = await RevenueCatUI.presentPaywall({
+    displayCloseButton: false,
+  });
+  paywallResult = await RevenueCatUI.presentPaywall({
+    offering,
+    displayCloseButton: false,
+  });
+  paywallResult = await RevenueCatUI.presentPaywall({
+    offering,
+    displayCloseButton: false,
+    fontFamily: "Ubuntu",
+  });
+}
+
+async function checkPresentPaywallIfNeeded(offering: PurchasesOffering) {
+  let paywallResult: PAYWALL_RESULT = await RevenueCatUI.presentPaywallIfNeeded({
+    requiredEntitlementIdentifier: "pro_access",
+  });
+  paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
+    requiredEntitlementIdentifier: "pro_access",
+    offering,
+  });
+  paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
+    requiredEntitlementIdentifier: "pro_access",
+    displayCloseButton: false,
+  });
+  paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
+    requiredEntitlementIdentifier: "pro_access",
+    offering,
+    displayCloseButton: false,
+  });
+  paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
+    requiredEntitlementIdentifier: "pro_access",
+    offering,
+    displayCloseButton: false,
+    fontFamily: "Ubuntu",
+  });
+}
+
+function checkPresentPaywallParams(params: PresentPaywallParams) {
+  const offering: PurchasesOffering | undefined = params.offering;
+  const displayCloseButton: boolean | undefined = params.displayCloseButton;
+  const fontFamily: string | null | undefined = params.fontFamily;
+
+  void offering;
+  void displayCloseButton;
+  void fontFamily;
+}
+
+function checkPresentPaywallIfNeededParams(params: PresentPaywallIfNeededParams) {
+  const offering: PurchasesOffering | undefined = params.offering;
+  const displayCloseButton: boolean | undefined = params.displayCloseButton;
+  const fontFamily: string | null | undefined = params.fontFamily;
+  const entitlement: string = params.requiredEntitlementIdentifier;
+
+  void offering;
+  void displayCloseButton;
+  void fontFamily;
+  void entitlement;
+}
+
+function checkFullScreenPaywallViewOptions(
+  options: FullScreenPaywallViewOptions,
+) {
+  const offering: PurchasesOffering | null | undefined = options.offering;
+  const fontFamily: string | null | undefined = options.fontFamily;
+  const displayCloseButton: boolean | undefined = options.displayCloseButton;
+
+  void offering;
+  void fontFamily;
+  void displayCloseButton;
+}
+
+function checkFooterPaywallViewOptions(options: FooterPaywallViewOptions) {
+  const offering: PurchasesOffering | null | undefined = options.offering;
+  const fontFamily: string | null | undefined = options.fontFamily;
+
+  void offering;
+  void fontFamily;
+}
+
+function checkPaywallViewOptions(options: PaywallViewOptions) {
+  const offering: PurchasesOffering | null | undefined = options.offering;
+  const fontFamily: string | null | undefined = options.fontFamily;
+
+  void offering;
+  void fontFamily;
+}
+
+const onPurchaseStarted = ({
+  packageBeingPurchased,
+}: {
+  packageBeingPurchased: PurchasesPackage;
+}) => {
+  const selectedPackage: PurchasesPackage = packageBeingPurchased;
+  void selectedPackage;
+};
+
+const onPurchaseCompleted = ({
+  customerInfo,
+  storeTransaction,
+}: {
+  customerInfo: CustomerInfo;
+  storeTransaction: PurchasesStoreTransaction;
+}) => {
+  const info: CustomerInfo = customerInfo;
+  const transaction: PurchasesStoreTransaction = storeTransaction;
+  void info;
+  void transaction;
+};
+
+const onPurchaseError = ({ error }: { error: PurchasesError }) => {
+  const purchasesError: PurchasesError = error;
+  void purchasesError;
+};
+
+const onPurchaseCancelled = () => {};
+
+const onRestoreStarted = () => {};
+
+const onRestoreCompleted = ({
+  customerInfo,
+}: {
+  customerInfo: CustomerInfo;
+}) => {
+  const info: CustomerInfo = customerInfo;
+  void info;
+};
+
+const onRestoreError = ({ error }: { error: PurchasesError }) => {
+  const purchasesError: PurchasesError = error;
+  void purchasesError;
+};
+
+const onDismiss = () => {};
+
+const PaywallScreen = () => {
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        offering: null,
+      }}
+    />
+  );
+};
+
+const PaywallScreenWithOffering = (offering: PurchasesOffering) => {
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        offering,
+      }}
+    />
+  );
+};
+
+const PaywallScreenWithFontFamily = (fontFamily: string | null | undefined) => {
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        fontFamily,
+      }}
+    />
+  );
+};
+
+const PaywallScreenWithOfferingAndEvents = (
+  offering: PurchasesOffering,
+  fontFamily: string | null | undefined,
+) => {
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      options={{
+        offering,
+        fontFamily,
+      }}
+      onPurchaseStarted={onPurchaseStarted}
+      onPurchaseCompleted={onPurchaseCompleted}
+      onPurchaseError={onPurchaseError}
+      onPurchaseCancelled={onPurchaseCancelled}
+      onRestoreStarted={onRestoreStarted}
+      onRestoreCompleted={onRestoreCompleted}
+      onRestoreError={onRestoreError}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+const PaywallScreenNoOptions = () => {
+  return <RevenueCatUI.Paywall style={{ marginBottom: 10 }} />;
+};
+
+const OriginalTemplatePaywallFooterPaywallScreen = () => {
+  return (
+    <RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+      options={{
+        offering: null,
+      }}
+    />
+  );
+};
+
+const FooterPaywallScreen = () => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        offering: null,
+      }}
+    />
+  );
+};
+
+const OriginalTemplateFooterPaywallScreenWithOffering = (
+  offering: PurchasesOffering,
+) => {
+  return (
+    <RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+      options={{
+        offering,
+      }}
+    />
+  );
+};
+
+const FooterPaywallScreenWithOffering = (offering: PurchasesOffering) => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        offering,
+      }}
+    />
+  );
+};
+
+const OriginalTemplateFooterPaywallScreenWithFontFamily = (
+  fontFamily: string | null | undefined,
+) => {
+  return (
+    <RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+      options={{
+        fontFamily,
+      }}
+    />
+  );
+};
+
+const FooterPaywallScreenWithFontFamily = (
+  fontFamily: string | null | undefined,
+) => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        fontFamily,
+      }}
+    />
+  );
+};
+
+const OriginalTemplateFooterPaywallScreenWithOfferingAndEvents = (
+  offering: PurchasesOffering,
+  fontFamily: string | null | undefined,
+) => {
+  return (
+    <RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+      options={{
+        offering,
+        fontFamily,
+      }}
+      onPurchaseStarted={onPurchaseStarted}
+      onPurchaseCompleted={onPurchaseCompleted}
+      onPurchaseError={onPurchaseError}
+      onPurchaseCancelled={onPurchaseCancelled}
+      onRestoreStarted={onRestoreStarted}
+      onRestoreCompleted={onRestoreCompleted}
+      onRestoreError={onRestoreError}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+const FooterPaywallScreenWithOfferingAndEvents = (
+  offering: PurchasesOffering,
+  fontFamily: string | null | undefined,
+) => {
+  return (
+    <RevenueCatUI.PaywallFooterContainerView
+      options={{
+        offering,
+        fontFamily,
+      }}
+      onPurchaseStarted={onPurchaseStarted}
+      onPurchaseCompleted={onPurchaseCompleted}
+      onPurchaseError={onPurchaseError}
+      onPurchaseCancelled={onPurchaseCancelled}
+      onRestoreStarted={onRestoreStarted}
+      onRestoreCompleted={onRestoreCompleted}
+      onRestoreError={onRestoreError}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+const OriginalTemplateFooterPaywallScreenNoOptions = () => {
+  return <RevenueCatUI.OriginalTemplatePaywallFooterContainerView />;
+};
+
+const FooterPaywallScreenNoOptions = () => {
+  return <RevenueCatUI.PaywallFooterContainerView />;
+};
+
+export {
+  FooterPaywallScreen,
+  FooterPaywallScreenNoOptions,
+  FooterPaywallScreenWithFontFamily,
+  FooterPaywallScreenWithOffering,
+  FooterPaywallScreenWithOfferingAndEvents,
+  OriginalTemplateFooterPaywallScreenNoOptions,
+  OriginalTemplateFooterPaywallScreenWithFontFamily,
+  OriginalTemplateFooterPaywallScreenWithOffering,
+  OriginalTemplateFooterPaywallScreenWithOfferingAndEvents,
+  OriginalTemplatePaywallFooterPaywallScreen,
+  PaywallScreen,
+  PaywallScreenNoOptions,
+  PaywallScreenWithFontFamily,
+  PaywallScreenWithOffering,
+  PaywallScreenWithOfferingAndEvents,
+};

--- a/react-native-purchases-ui/apitesters/tsconfig.json
+++ b/react-native-purchases-ui/apitesters/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["./**/*"]
+}

--- a/react-native-purchases-ui/apitesters/tsconfig.json
+++ b/react-native-purchases-ui/apitesters/tsconfig.json
@@ -5,5 +5,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
-  "include": ["./**/*"]
+  "include": ["./**/*"],
+  "exclude": ["../node_modules", "../lib"]
 }

--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -32,7 +32,8 @@
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "tslint": "tslint -c tslint.json 'src/*.ts'",
-    "prepare": "bob build"
+    "prepare": "bob build",
+    "apitest": "echo \"Running react-native-purchases-ui API type checks\" && tsc --project apitesters/tsconfig.json"
   },
   "repository": {
     "type": "git",

--- a/react-native-purchases-ui/tsconfig.json
+++ b/react-native-purchases-ui/tsconfig.json
@@ -24,5 +24,7 @@
     "strict": true,
     "target": "esnext",
     "verbatimModuleSyntax": true
-  }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "lib", "apitesters"]
 }


### PR DESCRIPTION
## Motivation
We're evolving customer center, so it's worth having some APITests for this.

- Added TypeScript API tester files for `react-native-purchases-ui`, to assert paywall and customer center callback shapes.