### PR TITLE
Fix `onCustomActionSelected` callback not firing on Android

### DIFF
--- a/react-native-purchases-ui/package.json
+++ b/react-native-purchases-ui/package.json
@@ -92,14 +92,20 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/lib/"
     ],
+    "moduleFileExtensions": [
+      "js"
+    ],
+    "transform": {
+      "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
+    },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.js$",
     "testPathIgnorePatterns": [
       "\\.snap$",
       "<rootDir>/node_modules/"
     ],
     "cacheDirectory": ".jest/cache",
-    "transformIgnorePatterns": [
-      "node_modules/(?!(@revenuecat|@react-native|react-native)/)"
+    "setupFiles": [
+      "./scripts/setupJest.js"
     ]
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
## Summary
Fixes a bug where the `onCustomActionSelected` callback was not being triggered on Android when custom actions were selected in the Customer Center. The Android native code was incorrectly emitting events under the `onManagementOptionSelected` event name instead of `onCustomActionSelected`.
