### PR TITLE
Consider new Error Code in API tests

### DIFF
--- a/apitesters/errors.ts
+++ b/apitesters/errors.ts
@@ -72,6 +72,8 @@ function checkErrorCodes(errorCode: PURCHASES_ERROR_CODE): boolean {
       return true;
     case PURCHASES_ERROR_CODE.OFFLINE_CONNECTION_ERROR:
       return true;
+    case PURCHASES_ERROR_CODE.TEST_STORE_SIMULATED_PURCHASE_ERROR:
+      return true;
   }
 }
 


### PR DESCRIPTION
PHC v17.10.0 adds a new error code to the public API that needs to be considered in the API tests:
```
PURCHASES_ERROR_CODE.TEST_STORE_SIMULATED_PURCHASE_ERROR
```