### PR TITLE
Removed the async keyword from setupPurchases since no async calls are being made

### DIFF
--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -15,7 +15,7 @@ const packageVersion = '9.1.0';
  * Browser implementation of the native module. This will be used in the browser and Expo Go.
  */
 export const browserNativeModuleRNPurchases = {
-  setupPurchases: async (
+  setupPurchases: (
     apiKey: string,
     appUserID: string | null,
     _purchasesAreCompletedBy: string | null,


### PR DESCRIPTION
While working on unrelated unit tests I noticed that exceptions thrown inside `setupPurchases` were not being caught by Jest using `.expect().toThrow()`. It turns out this is because `setupPurchases()` is marked as `async`, even though it's not making any `async` calls and it's not being awaited in [purchases.ts](https://github.com/RevenueCat/react-native-purchases/blob/main/src/purchases.ts#L320). 

Since this is not a public API this change should not have any other side effects.