### PR TITLE
Update Xcode versions to avoid CircleCI deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,12 @@ aliases:
     executor:
       name: rn/macos
       resource_class: macos.m1.medium.gen1
-      xcode_version: '15.2'
+      xcode_version: '15.4'
   base-mac-job-xcode-16: &base-mac-job-xcode-16
     executor:
       name: rn/macos
       resource_class: macos.m1.medium.gen1
-      xcode_version: '16.3'
+      xcode_version: '16.4'
 
 parameters:
   action:


### PR DESCRIPTION
## Summary
- Update base-mac-job: Xcode 15.2 → 15.4
- Update base-mac-job-xcode-16: Xcode 16.3 → 16.4

## Details
These changes address the CircleCI deprecation of EoL Xcode versions (13.4.1, 15.1.0, 15.2.0, 15.3.0, 16.0.0, 16.1.0) announced at https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

The updated versions stay within the same major version where possible and use iOS simulator versions that are available in the respective Xcode VM images according to https://circleci.com/docs/guides/test/testing-ios/#supported-xcode-versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)