### PR TITLE
Use Ruby 3.2 for `update-hybrid-common-versions` CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   rn: react-native-community/react-native@8.0.1
   revenuecat: revenuecat/sdks-common-config@2.2.0
-  ruby: circleci/ruby@2.5.4
 
 aliases:
   release-tags: &release-tags
@@ -89,6 +88,16 @@ commands:
       - run:
           name: Copy npmrc sample file to final location
           command: cp .npmrc.SAMPLE .npmrc
+
+  install-ruby-3-2-0:
+    steps:
+      - run:
+          name: Set Ruby 3.2.0
+          command: |
+            eval "$(rbenv init -)"
+            rbenv install -s 3.2.0
+            rbenv global 3.2.0
+            rbenv rehash
 
 jobs:
   analyse_js:
@@ -243,8 +252,7 @@ jobs:
       - checkout
       - rn/ios_simulator_start:
           device: iPhone 15
-      - ruby/install:
-          version: '3.2.0'
+      - install-ruby-3-2-0
       - install-dependencies-ios-build
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v2
@@ -280,8 +288,7 @@ jobs:
     <<: *base-mac-job
     steps:
       - checkout
-      - ruby/install:
-          version: '3.2.0'
+      - install-ruby-3-2-0
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v2
       - revenuecat/trust-github-key


### PR DESCRIPTION
The CI job `update-hybrid-common-versions` [has started to fail](https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/5550/workflows/e6cb0139-3551-478d-a9ec-959c7ddbcf2a/jobs/23436) since we updated the CI machine from Xcode 15.2 (defaults to Ruby 3.2.0) to Xcode 15.4 (defaults to Ruby 3.3.0) due to the Xcode 15.2 Circle CI machines being deprecated (see https://github.com/RevenueCat/react-native-purchases/pull/1454).

The error message was:
```
The terminfo database could not be found
```

This PR locks the Ruby version of the job to v3.2.0, as suggested in https://github.com/fastlane/fastlane/issues/21794

Successful dry run with the branch of this PR: https://app.circleci.com/pipelines/github/RevenueCat/react-native-purchases/5552/workflows/6982d804-e1e2-4732-903c-85250dbdfecd