### PR TITLE
Fix `parseAsWebPurchaseRedemption` always returning the url that was passed

### DIFF
--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -1578,7 +1578,7 @@ export default class Purchases {
   public static async parseAsWebPurchaseRedemption(
     urlString: string
   ): Promise<WebPurchaseRedemption | null> {
-    if (RNPurchases.isWebPurchaseRedemptionURL(urlString)) {
+    if (await RNPurchases.isWebPurchaseRedemptionURL(urlString)) {
       return { redemptionLink: urlString };
     }
     return null;


### PR DESCRIPTION
`isWebPurchaseRedemptionURL` is async, but we were not awaiting it, so it was returning the unfinished promise, which is considered truth-y, so we were always returning the url passed regardless of whether it really was a redemption link or not.