### PR TITLE
Add PaywallListener and PurchaseLogic support to presentPaywall APIs

### DIFF
--- a/examples/purchaseTesterExpo/app/_layout.tsx
+++ b/examples/purchaseTesterExpo/app/_layout.tsx
@@ -9,8 +9,9 @@ import { Platform } from 'react-native';
 import { useColorScheme } from '@/components/useColorScheme';
 import { CustomVariablesProvider } from '@/components/CustomVariablesContext';
 import CustomVariablesEditor from '@/components/CustomVariablesEditor';
-import Purchases from 'react-native-purchases';
+import Purchases, { PURCHASES_ARE_COMPLETED_BY_TYPE, PurchasesAreCompletedBy, STOREKIT_VERSION } from 'react-native-purchases';
 import APIKeys from '@/constants/APIKeys';
+import ConfigOptions from '@/constants/ConfigOptions';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -53,10 +54,14 @@ export default function RootLayout() {
         if (apiKey) {
           // Initialize the RevenueCat Purchases SDK
           // appUserID is null, so an anonymous ID will be generated automatically
+          const purchasesAreCompletedBy: PurchasesAreCompletedBy = ConfigOptions.usePurchasesCompletedByMyApp
+            ? { type: PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP, storeKitVersion: STOREKIT_VERSION.STOREKIT_2 }
+            : PURCHASES_ARE_COMPLETED_BY_TYPE.REVENUECAT;
           Purchases.configure({
             apiKey: apiKey,
             appUserID: null,
-            useAmazon: false
+            useAmazon: false,
+            purchasesAreCompletedBy: purchasesAreCompletedBy,
           });
           // @ts-expect-error - addTrackedEventListener is internal
           await Purchases.addTrackedEventListener((event: Record<string, unknown>) => {

--- a/examples/purchaseTesterExpo/constants/ConfigOptions.ts
+++ b/examples/purchaseTesterExpo/constants/ConfigOptions.ts
@@ -1,0 +1,7 @@
+const ConfigOptions = {
+  // Set to true to configure the SDK with purchasesAreCompletedBy: MY_APP.
+  // This enables the PurchaseLogic button in the tester UI.
+  usePurchasesCompletedByMyApp: false,
+};
+
+export default ConfigOptions;

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -449,6 +449,44 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
           </TouchableOpacity>
           <TouchableOpacity
             onPress={async () => {
+              const paywallResult = await RevenueCatUI.presentPaywall({
+                displayCloseButton: true,
+                listener: {
+                  onPurchaseStarted: ({packageBeingPurchased}) => {
+                    console.log('🛒 PAYWALL - Purchase started for package:', packageBeingPurchased?.identifier);
+                  },
+                  onPurchaseCompleted: ({customerInfo, storeTransaction}) => {
+                    console.log('✅ PAYWALL - Purchase completed:', storeTransaction?.transactionIdentifier);
+                    console.log('   Active entitlements:', Object.keys(customerInfo.entitlements.active).join(', ') || 'none');
+                  },
+                  onPurchaseError: ({error}) => {
+                    console.log('❌ PAYWALL - Purchase error:', error.code, error.message);
+                  },
+                  onPurchaseCancelled: () => {
+                    console.log('🚫 PAYWALL - Purchase cancelled');
+                  },
+                  onRestoreStarted: () => {
+                    console.log('🔄 PAYWALL - Restore started');
+                  },
+                  onRestoreCompleted: ({customerInfo}) => {
+                    console.log('✅ PAYWALL - Restore completed. Active entitlements:', Object.keys(customerInfo.entitlements.active).join(', ') || 'none');
+                  },
+                  onRestoreError: ({error}) => {
+                    console.log('❌ PAYWALL - Restore error:', error.code, error.message);
+                  },
+                  onPurchaseInitiated: ({packageBeingPurchased, resumable}) => {
+                    console.log('⏳ PAYWALL - Purchase initiated for:', packageBeingPurchased?.identifier, '- auto-proceeding');
+                    // Example: you could show an auth screen here, then call resume
+                    resumable.resume(true);
+                  },
+                },
+              });
+              console.log('Paywall with listener result: ', paywallResult);
+            }}>
+            <Text style={styles.otherActions}>Present paywall with listener</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={async () => {
               try {
                 await RevenueCatUI.presentCustomerCenter({
                   callbacks: {

--- a/react-native-purchases-ui/ios/RNPaywalls.h
+++ b/react-native-purchases-ui/ios/RNPaywalls.h
@@ -7,6 +7,20 @@
 
 static NSString *const safeAreaInsetsDidChangeEvent = @"safeAreaInsetsDidChange";
 
+// PaywallListener event names
+static NSString *const onPurchaseStartedEvent = @"onPurchaseStarted";
+static NSString *const onPurchaseCompletedEvent = @"onPurchaseCompleted";
+static NSString *const onPurchaseErrorEvent = @"onPurchaseError";
+static NSString *const onPurchaseCancelledEvent = @"onPurchaseCancelled";
+static NSString *const onRestoreStartedEvent = @"onRestoreStarted";
+static NSString *const onRestoreCompletedEvent = @"onRestoreCompleted";
+static NSString *const onRestoreErrorEvent = @"onRestoreError";
+static NSString *const onPurchaseInitiatedEvent = @"onPurchaseInitiated";
+
+// PurchaseLogic event names
+static NSString *const onPerformPurchaseRequestEvent = @"onPerformPurchaseRequest";
+static NSString *const onPerformRestoreRequestEvent = @"onPerformRestoreRequest";
+
 @interface RNPaywalls : RCTEventEmitter <RCTBridgeModule>
 
 @end

--- a/react-native-purchases-ui/ios/RNPaywalls.m
+++ b/react-native-purchases-ui/ios/RNPaywalls.m
@@ -9,9 +9,94 @@
 @import PurchasesHybridCommonUI;
 @import RevenueCat;
 
+// MARK: - PaywallDelegateAdapter
+
+API_AVAILABLE(ios(15.0))
+@interface RNPaywallDelegateAdapter : NSObject <RCPaywallViewControllerDelegateWrapper>
+@property (nonatomic, weak) RNPaywalls *module;
+@end
+
+@implementation RNPaywallDelegateAdapter
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+     didStartPurchaseWithPackage:(NSDictionary *)packageDictionary {
+    [self.module sendEventWithName:onPurchaseStartedEvent
+                              body:@{@"packageBeingPurchased": packageDictionary}];
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+didFinishPurchasingWithCustomerInfoDictionary:(NSDictionary *)customerInfoDictionary
+          transactionDictionary:(NSDictionary *)transactionDictionary {
+    NSMutableDictionary *data = [NSMutableDictionary dictionaryWithDictionary:@{@"customerInfo": customerInfoDictionary}];
+    if (transactionDictionary) {
+        data[@"storeTransaction"] = transactionDictionary;
+    }
+    [self.module sendEventWithName:onPurchaseCompletedEvent body:data];
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+ didFailPurchasingWithErrorDictionary:(NSDictionary *)errorDictionary {
+    [self.module sendEventWithName:onPurchaseErrorEvent body:@{@"error": errorDictionary}];
+}
+
+- (void)paywallViewControllerDidCancelPurchase:(RCPaywallViewController *)controller {
+    [self.module sendEventWithName:onPurchaseCancelledEvent body:@{}];
+}
+
+- (void)paywallViewControllerDidStartRestore:(RCPaywallViewController *)controller {
+    [self.module sendEventWithName:onRestoreStartedEvent body:@{}];
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+didFinishRestoringWithCustomerInfoDictionary:(NSDictionary *)customerInfoDictionary {
+    [self.module sendEventWithName:onRestoreCompletedEvent body:@{@"customerInfo": customerInfoDictionary}];
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+ didFailRestoringWithErrorDictionary:(NSDictionary *)errorDictionary {
+    [self.module sendEventWithName:onRestoreErrorEvent body:@{@"error": errorDictionary}];
+}
+
+- (void)paywallViewControllerRequestedDismissal:(RCPaywallViewController *)controller {
+    // No-op for modal presentation; dismissal is handled by the result handler
+}
+
+- (void)paywallViewController:(RCPaywallViewController *)controller
+didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
+                     requestId:(NSString *)requestId {
+    [self.module sendEventWithName:onPurchaseInitiatedEvent
+                              body:@{
+                                  @"package": packageDictionary,
+                                  @"requestId": requestId
+                              }];
+}
+
+- (void)paywallViewControllerDidRequestPerformPurchase:(RCPaywallViewController *)controller
+                                     packageDictionary:(NSDictionary *)packageDictionary
+                                             requestId:(NSString *)requestId {
+    [self.module sendEventWithName:onPerformPurchaseRequestEvent
+                              body:@{
+                                  @"requestId": requestId,
+                                  @"packageBeingPurchased": packageDictionary
+                              }];
+}
+
+- (void)paywallViewControllerDidRequestPerformRestore:(RCPaywallViewController *)controller
+                                            requestId:(NSString *)requestId {
+    [self.module sendEventWithName:onPerformRestoreRequestEvent
+                              body:@{
+                                  @"requestId": requestId
+                              }];
+}
+
+@end
+
+// MARK: - RNPaywalls
+
 @interface RNPaywalls ()
 
 @property (nonatomic, strong) id paywallProxy;
+@property (nonatomic, strong) id delegateAdapter;
 
 @end
 
@@ -39,16 +124,34 @@ RCT_EXPORT_MODULE();
 // `RCTEventEmitter` does not implement designated iniitializers correctly so we have to duplicate the call in both constructors.
 - (void)initializePaywalls {
     if (@available(iOS 15.0, *)) {
-        self.paywallProxy = [PaywallProxy new];
+        PaywallProxy *proxy = [PaywallProxy new];
+        RNPaywallDelegateAdapter *adapter = [RNPaywallDelegateAdapter new];
+        adapter.module = self;
+        proxy.delegate = adapter;
+        self.paywallProxy = proxy;
+        self.delegateAdapter = adapter; // Retain strongly since PaywallProxy.delegate is weak
     } else {
         self.paywallProxy = nil;
+        self.delegateAdapter = nil;
     }
 }
 
 // MARK: -
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[safeAreaInsetsDidChangeEvent];
+    return @[
+        safeAreaInsetsDidChangeEvent,
+        onPurchaseStartedEvent,
+        onPurchaseCompletedEvent,
+        onPurchaseErrorEvent,
+        onPurchaseCancelledEvent,
+        onRestoreStartedEvent,
+        onRestoreCompletedEvent,
+        onRestoreErrorEvent,
+        onPurchaseInitiatedEvent,
+        onPerformPurchaseRequestEvent,
+        onPerformRestoreRequestEvent,
+    ];
 }
 
 - (dispatch_queue_t)methodQueue {
@@ -59,32 +162,28 @@ RCT_EXPORT_MODULE();
     return self.paywallProxy;
 }
 
-// MARK: -
+// MARK: - presentPaywall / presentPaywallIfNeeded
 
 RCT_EXPORT_METHOD(presentPaywall:(nullable NSString *)offeringIdentifier
                   presentedOfferingContext:(nullable NSDictionary *)presentedOfferingContext
                   shouldDisplayCloseButton:(BOOL)displayCloseButton
                   withFontFamily:(nullable NSString *)fontFamily
                   customVariables:(nullable NSDictionary *)customVariables
+                  hasPaywallListener:(BOOL)hasPaywallListener
+                  hasPurchaseLogic:(BOOL)hasPurchaseLogic
                   withResolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     if (@available(iOS 15.0, *)) {
-        NSMutableDictionary *options = [NSMutableDictionary dictionary];
-        if (offeringIdentifier != nil) {
-            options[PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier;
-        }
-        if (presentedOfferingContext != nil) {
-            options[PaywallOptionsKeys.presentedOfferingContext] = presentedOfferingContext;
-        }
-        options[PaywallOptionsKeys.displayCloseButton] = @(displayCloseButton);
-        if (fontFamily) {
-            options[PaywallOptionsKeys.fontName] = fontFamily;
-        }
-        if (customVariables) {
-            options[PaywallOptionsKeys.customVariables] = customVariables;
-        }
+        NSMutableDictionary *options = [self buildOptionsWithOfferingIdentifier:offeringIdentifier
+                                                     presentedOfferingContext:presentedOfferingContext
+                                                          displayCloseButton:displayCloseButton
+                                                                  fontFamily:fontFamily
+                                                             customVariables:customVariables];
+
+        HybridPurchaseLogicBridge *bridge = hasPurchaseLogic ? [self createPurchaseLogicBridge] : nil;
 
         [self.paywalls presentPaywallWithOptions:options
+                            purchaseLogicBridge:bridge
                             paywallResultHandler:^(NSString *result) {
             resolve(result);
         }];
@@ -99,26 +198,22 @@ RCT_EXPORT_METHOD(presentPaywallIfNeeded:(NSString *)requiredEntitlementIdentifi
                   shouldDisplayCloseButton:(BOOL)displayCloseButton
                   withFontFamily:(nullable NSString *)fontFamily
                   customVariables:(nullable NSDictionary *)customVariables
+                  hasPaywallListener:(BOOL)hasPaywallListener
+                  hasPurchaseLogic:(BOOL)hasPurchaseLogic
                   withResolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     if (@available(iOS 15.0, *)) {
-        NSMutableDictionary *options = [NSMutableDictionary dictionary];
-        if (offeringIdentifier != nil) {
-            options[PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier;
-        }
-        if (presentedOfferingContext != nil) {
-            options[PaywallOptionsKeys.presentedOfferingContext] = presentedOfferingContext;
-        }
+        NSMutableDictionary *options = [self buildOptionsWithOfferingIdentifier:offeringIdentifier
+                                                     presentedOfferingContext:presentedOfferingContext
+                                                          displayCloseButton:displayCloseButton
+                                                                  fontFamily:fontFamily
+                                                             customVariables:customVariables];
         options[PaywallOptionsKeys.requiredEntitlementIdentifier] = requiredEntitlementIdentifier;
-        options[PaywallOptionsKeys.displayCloseButton] = @(displayCloseButton);
-        if (fontFamily) {
-            options[PaywallOptionsKeys.fontName] = fontFamily;
-        }
-        if (customVariables) {
-            options[PaywallOptionsKeys.customVariables] = customVariables;
-        }
+
+        HybridPurchaseLogicBridge *bridge = hasPurchaseLogic ? [self createPurchaseLogicBridge] : nil;
 
         [self.paywalls presentPaywallIfNeededWithOptions:options
+                                    purchaseLogicBridge:bridge
                                     paywallResultHandler:^(NSString *result) {
             resolve(result);
         }];
@@ -127,11 +222,71 @@ RCT_EXPORT_METHOD(presentPaywallIfNeeded:(NSString *)requiredEntitlementIdentifi
     }
 }
 
+// MARK: - Resume methods
+
 RCT_EXPORT_METHOD(resumePurchasePackageInitiated:(NSString *)requestId
                   shouldProceed:(BOOL)shouldProceed) {
     if (@available(iOS 15.0, *)) {
         [PaywallProxy resumePurchasePackageInitiatedWithRequestId:requestId shouldProceed:shouldProceed];
     }
+}
+
+RCT_EXPORT_METHOD(resumePurchaseLogicPurchase:(NSString *)requestId
+                  result:(NSString *)resultString
+                  error:(nullable NSDictionary *)error) {
+    if (@available(iOS 15.0, *)) {
+        NSString *errorMessage = error[@"message"];
+        [HybridPurchaseLogicBridge resolveResultWithRequestId:requestId
+                                                 resultString:resultString
+                                                 errorMessage:errorMessage];
+    }
+}
+
+RCT_EXPORT_METHOD(resumePurchaseLogicRestore:(NSString *)requestId
+                  result:(NSString *)resultString
+                  error:(nullable NSDictionary *)error) {
+    if (@available(iOS 15.0, *)) {
+        NSString *errorMessage = error[@"message"];
+        [HybridPurchaseLogicBridge resolveResultWithRequestId:requestId
+                                                 resultString:resultString
+                                                 errorMessage:errorMessage];
+    }
+}
+
+// MARK: - Helpers
+
+- (NSMutableDictionary *)buildOptionsWithOfferingIdentifier:(nullable NSString *)offeringIdentifier
+                                   presentedOfferingContext:(nullable NSDictionary *)presentedOfferingContext
+                                        displayCloseButton:(BOOL)displayCloseButton
+                                                fontFamily:(nullable NSString *)fontFamily
+                                           customVariables:(nullable NSDictionary *)customVariables
+API_AVAILABLE(ios(15.0)) {
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    if (offeringIdentifier != nil) {
+        options[PaywallOptionsKeys.offeringIdentifier] = offeringIdentifier;
+    }
+    if (presentedOfferingContext != nil) {
+        options[PaywallOptionsKeys.presentedOfferingContext] = presentedOfferingContext;
+    }
+    options[PaywallOptionsKeys.displayCloseButton] = @(displayCloseButton);
+    if (fontFamily) {
+        options[PaywallOptionsKeys.fontName] = fontFamily;
+    }
+    if (customVariables) {
+        options[PaywallOptionsKeys.customVariables] = customVariables;
+    }
+    return options;
+}
+
+- (HybridPurchaseLogicBridge *)createPurchaseLogicBridge API_AVAILABLE(ios(15.0)) {
+    __weak typeof(self) weakSelf = self;
+    return [[HybridPurchaseLogicBridge alloc]
+        initOnPerformPurchase:^(NSDictionary<NSString *, id> * _Nonnull eventData) {
+            [weakSelf sendEventWithName:onPerformPurchaseRequestEvent body:eventData];
+        }
+        onPerformRestore:^(NSDictionary<NSString *, id> * _Nonnull eventData) {
+            [weakSelf sendEventWithName:onPerformRestoreRequestEvent body:eventData];
+        }];
 }
 
 - (void)rejectPaywallsUnsupportedError:(RCTPromiseRejectBlock)reject {


### PR DESCRIPTION
## Summary

- Adds `PaywallListener` and `PurchaseLogic` support to `presentPaywall` / `presentPaywallIfNeeded` modal APIs
- **PaywallListener**: observe paywall lifecycle events (purchase started/completed/error/cancelled, restore started/completed/error, purchase initiated with gate/resume)
- **PurchaseLogic**: intercept and handle purchases/restores for `purchasesAreCompletedBy: MY_APP` mode
- Both parameters are optional — existing code without them works unchanged
- Follows the same architecture as the Capacitor SDK implementation (PR #688)

### Files changed

| File | Changes |
|------|---------|
| `react-native-purchases-ui/src/index.tsx` | New types (`PaywallListener`, `PurchaseLogic`, `PurchaseResumable`, `PURCHASE_LOGIC_RESULT`), unified `presentPaywallInternal` that registers NativeEventEmitter listeners and cleans up in `finally` |
| `react-native-purchases-ui/ios/RNPaywalls.h` | Event name constants |
| `react-native-purchases-ui/ios/RNPaywalls.m` | `RNPaywallDelegateAdapter` (implements `PaywallViewControllerDelegateWrapper`), `HybridPurchaseLogicBridge` creation, resume methods |
| `react-native-purchases-ui/android/.../RNPaywallsModule.kt` | `PaywallListenerWrapper` + `HybridPurchaseLogicBridge` creation, event emission via `DeviceEventManagerModule`, resume methods |
| `apitesters/paywalls.tsx` | Type-checking coverage for all new APIs |
| `examples/purchaseTesterTypescript` | "Present paywall with listener" button |
| `examples/purchaseTesterExpo` | "Present paywall with listener" + "Present paywall with PurchaseLogic" (disabled unless `MY_APP` mode) buttons |

### Dependencies

- **Requires** `@nonobjc` fix in `purchases-hybrid-common` for `HybridPurchaseLogicBridge.makePerformPurchase()` / `makePerformRestore()` — without it the class is silently excluded from the generated ObjC header because those methods return Swift-only async closure types

### Related PRs

- purchases-capacitor: [#688](https://github.com/RevenueCat/purchases-capacitor/pull/688) (reference implementation)
- purchases-hybrid-common: `@nonobjc` fix needed (pending)

## Test plan

- [ ] iOS build succeeds (after hybrid-common fix)
- [ ] Android build succeeds
- [ ] `presentPaywall()` without listener/purchaseLogic works unchanged
- [ ] `presentPaywall({ listener: {...} })` fires all lifecycle callbacks
- [ ] `presentPaywall({ purchaseLogic: {...} })` intercepts purchase/restore and resolves via requestId
- [ ] `onPurchaseInitiated` auto-resumes when no callback provided
- [ ] Listener subscriptions are cleaned up after paywall dismissal
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)