### PR TITLE
Add PaywallListener convenience prop to PaywallView components

### DIFF
--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -6,9 +6,11 @@ import RevenueCatUI, {
   FooterPaywallViewOptions,
   FullScreenPaywallViewOptions,
   PAYWALL_RESULT,
+  PaywallListener,
   PaywallViewOptions,
   PresentPaywallIfNeededParams,
   PresentPaywallParams,
+  PurchaseResumable,
 } from "../react-native-purchases-ui";
 import {
   CustomerInfo,
@@ -356,5 +358,93 @@ const OriginalTemplateFooterPaywallScreenNoOptions = () => {
 const FooterPaywallScreenNoOptions = () => {
   return (
     <RevenueCatUI.PaywallFooterContainerView></RevenueCatUI.PaywallFooterContainerView>
+  );
+};
+
+// PaywallListener and PurchaseResumable type checks
+
+function checkPaywallListener() {
+  const listener: PaywallListener = {
+    onPurchaseStarted: (args: { packageBeingPurchased: PurchasesPackage }) => {
+      const pkg: PurchasesPackage = args.packageBeingPurchased;
+    },
+    onPurchaseCompleted: (args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => {
+      const info: CustomerInfo = args.customerInfo;
+      const txn: PurchasesStoreTransaction = args.storeTransaction;
+    },
+    onPurchaseError: (args: { error: PurchasesError }) => {
+      const err: PurchasesError = args.error;
+    },
+    onPurchaseCancelled: () => {},
+    onRestoreStarted: () => {},
+    onRestoreCompleted: (args: { customerInfo: CustomerInfo }) => {
+      const info: CustomerInfo = args.customerInfo;
+    },
+    onRestoreError: (args: { error: PurchasesError }) => {
+      const err: PurchasesError = args.error;
+    },
+    onPurchaseInitiated: (args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => {
+      const pkg: PurchasesPackage = args.packageBeingPurchased;
+      const r: PurchaseResumable = args.resumable;
+      args.resumable.resume();
+      args.resumable.resume(true);
+      args.resumable.resume(false);
+    },
+  };
+}
+
+const PaywallScreenWithListener = () => {
+  const listener: PaywallListener = {
+    onPurchaseStarted: (args: { packageBeingPurchased: PurchasesPackage }) => {},
+    onPurchaseCompleted: (args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => {},
+    onPurchaseError: (args: { error: PurchasesError }) => {},
+    onPurchaseCancelled: () => {},
+    onRestoreStarted: () => {},
+    onRestoreCompleted: (args: { customerInfo: CustomerInfo }) => {},
+    onRestoreError: (args: { error: PurchasesError }) => {},
+    onPurchaseInitiated: (args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => {
+      args.resumable.resume(true);
+    },
+  };
+
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      listener={listener}
+    />
+  );
+};
+
+const PaywallScreenWithListenerAndIndividualProps = () => {
+  // Individual props should take precedence over listener
+  const listener: PaywallListener = {
+    onPurchaseStarted: (args: { packageBeingPurchased: PurchasesPackage }) => {},
+    onPurchaseCompleted: (args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => {},
+  };
+
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      listener={listener}
+      onPurchaseStarted={onPurchaseStarted}
+    />
+  );
+};
+
+const FooterPaywallScreenWithListener = () => {
+  const listener: PaywallListener = {
+    onPurchaseStarted: (args: { packageBeingPurchased: PurchasesPackage }) => {},
+    onPurchaseCompleted: (args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => {},
+    onPurchaseError: (args: { error: PurchasesError }) => {},
+    onPurchaseCancelled: () => {},
+    onRestoreStarted: () => {},
+    onRestoreCompleted: (args: { customerInfo: CustomerInfo }) => {},
+    onRestoreError: (args: { error: PurchasesError }) => {},
+  };
+
+  return (
+    <RevenueCatUI.OriginalTemplatePaywallFooterContainerView
+      listener={listener}
+    ></RevenueCatUI.OriginalTemplatePaywallFooterContainerView>
   );
 };

--- a/react-native-purchases-ui/apitesters/paywalls.tsx
+++ b/react-native-purchases-ui/apitesters/paywalls.tsx
@@ -9,6 +9,8 @@ import type {
   PresentPaywallIfNeededParams,
   PresentPaywallParams,
   CustomVariables,
+  PaywallListener,
+  PurchaseResumable,
 } from "react-native-purchases-ui";
 import type {
   CustomerInfo,
@@ -509,6 +511,61 @@ const FooterPaywallScreenNoOptions = () => {
   return <RevenueCatUI.PaywallFooterContainerView />;
 };
 
+const PaywallScreenWithListener = () => {
+  const listener: PaywallListener = {
+    onPurchaseStarted: ({ packageBeingPurchased }) => {
+      const pkg: PurchasesPackage = packageBeingPurchased;
+      void pkg;
+    },
+    onPurchaseCompleted: ({ customerInfo, storeTransaction }) => {
+      const info: CustomerInfo = customerInfo;
+      const txn: PurchasesStoreTransaction = storeTransaction;
+      void info;
+      void txn;
+    },
+    onPurchaseError: ({ error }) => {
+      const err: PurchasesError = error;
+      void err;
+    },
+    onPurchaseCancelled: () => {},
+    onRestoreStarted: () => {},
+    onRestoreCompleted: ({ customerInfo }) => {
+      const info: CustomerInfo = customerInfo;
+      void info;
+    },
+    onRestoreError: ({ error }) => {
+      const err: PurchasesError = error;
+      void err;
+    },
+    onPurchaseInitiated: ({ packageBeingPurchased, resumable }) => {
+      const pkg: PurchasesPackage = packageBeingPurchased;
+      const res: PurchaseResumable = resumable;
+      void pkg;
+      res.resume();
+      res.resume(true);
+      res.resume(false);
+    },
+  };
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      listener={listener}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
+const PaywallScreenWithListenerAndIndividualProps = () => {
+  return (
+    <RevenueCatUI.Paywall
+      style={{ marginBottom: 10 }}
+      listener={{ onPurchaseStarted: () => {} }}
+      onPurchaseCompleted={onPurchaseCompleted}
+      onDismiss={onDismiss}
+    />
+  );
+};
+
 export {
   FooterPaywallScreen,
   FooterPaywallScreenNoOptions,
@@ -526,4 +583,6 @@ export {
   PaywallScreenWithFontFamily,
   PaywallScreenWithOffering,
   PaywallScreenWithOfferingAndEvents,
+  PaywallScreenWithListener,
+  PaywallScreenWithListenerAndIndividualProps,
 };

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -33,6 +33,52 @@ export { CustomVariableValue, type CustomVariables } from "./customVariables";
 export { convertCustomVariablesToStringMap, transformOptionsForNative } from "./customVariables";
 
 /**
+ * Object passed to onPurchaseInitiated that allows the developer to
+ * control when (and whether) the purchase flow continues.
+ * The developer can store this and call resume() asynchronously
+ * (e.g., after an auth flow on a different screen).
+ */
+export interface PurchaseResumable {
+  /** Call to proceed with or cancel the purchase. Defaults to true (proceed). */
+  resume(shouldProceed?: boolean): void;
+}
+
+/**
+ * Callbacks for observing paywall lifecycle events such as purchases,
+ * restores, and errors. All callbacks are optional.
+ *
+ * Pass as `listener` to PaywallView components to receive events
+ * while the paywall is displayed.
+ */
+export interface PaywallListener {
+  /** Called when a purchase begins for a package. */
+  onPurchaseStarted?: (args: { packageBeingPurchased: PurchasesPackage }) => void;
+  /** Called when a purchase completes successfully. */
+  onPurchaseCompleted?: (args: { customerInfo: CustomerInfo; storeTransaction: PurchasesStoreTransaction }) => void;
+  /** Called when a purchase fails with an error. */
+  onPurchaseError?: (args: { error: PurchasesError }) => void;
+  /** Called when the user cancels a purchase. */
+  onPurchaseCancelled?: () => void;
+  /** Called when a restore operation begins. */
+  onRestoreStarted?: () => void;
+  /** Called when a restore operation completes successfully. */
+  onRestoreCompleted?: (args: { customerInfo: CustomerInfo }) => void;
+  /** Called when a restore operation fails with an error. */
+  onRestoreError?: (args: { error: PurchasesError }) => void;
+  /**
+   * Called before the payment sheet is displayed, allowing the app to gate
+   * the purchase flow (e.g., require authentication first).
+   *
+   * The developer receives a {@link PurchaseResumable} that can be stored
+   * and called asynchronously. Call `resumable.resume(true)` to proceed
+   * with the purchase, or `resumable.resume(false)` to cancel it.
+   *
+   * If this callback is not provided, the purchase proceeds automatically.
+   */
+  onPurchaseInitiated?: (args: { packageBeingPurchased: PurchasesPackage; resumable: PurchaseResumable }) => void;
+}
+
+/**
  * The result of a purchase or restore operation performed by custom app-based logic.
  * Used when `purchasesAreCompletedBy` is set to `MY_APP`.
  * @readonly
@@ -392,6 +438,12 @@ type FullScreenPaywallViewProps = {
   children?: ReactNode;
   options?: FullScreenPaywallViewOptions;
   purchaseLogic?: PurchaseLogic;
+  /**
+   * Optional listener for paywall lifecycle events such as purchase
+   * completion, restoration, and errors.
+   * Individual callback props take precedence over listener callbacks.
+   */
+  listener?: PaywallListener;
   onPurchaseStarted?: ({packageBeingPurchased}: { packageBeingPurchased: PurchasesPackage }) => void;
   onPurchaseCompleted?: ({
                            customerInfo,
@@ -404,7 +456,7 @@ type FullScreenPaywallViewProps = {
   onRestoreError?: ({error}: { error: PurchasesError }) => void;
   onDismiss?: () => void;
   onPurchasePackageInitiated?: ({
-    packageBeingPurchased, 
+    packageBeingPurchased,
     resume
   }: { packageBeingPurchased: PurchasesPackage, resume: (shouldResume: boolean) => void}) => void;
 };
@@ -413,6 +465,12 @@ type FooterPaywallViewProps = {
   style?: StyleProp<ViewStyle>;
   children?: ReactNode;
   options?: FooterPaywallViewOptions;
+  /**
+   * Optional listener for paywall lifecycle events such as purchase
+   * completion, restoration, and errors.
+   * Individual callback props take precedence over listener callbacks.
+   */
+  listener?: PaywallListener;
   onPurchaseStarted?: ({packageBeingPurchased}: { packageBeingPurchased: PurchasesPackage }) => void;
   onPurchaseCompleted?: ({
                            customerInfo,
@@ -437,6 +495,44 @@ type InternalFooterPaywallViewProps = FooterPaywallViewProps & {
 type WithNativeCustomVariables<T extends { customVariables?: CustomVariables }> =
   Omit<T, 'customVariables'> & { customVariables?: NativeCustomVariables | null };
 
+
+/**
+ * Merges individual callback props with a PaywallListener.
+ * Individual props take precedence over listener callbacks.
+ * @internal
+ */
+function resolvePaywallCallbacks(props: {
+  listener?: PaywallListener;
+  onPurchaseStarted?: FullScreenPaywallViewProps['onPurchaseStarted'];
+  onPurchaseCompleted?: FullScreenPaywallViewProps['onPurchaseCompleted'];
+  onPurchaseError?: FullScreenPaywallViewProps['onPurchaseError'];
+  onPurchaseCancelled?: FullScreenPaywallViewProps['onPurchaseCancelled'];
+  onRestoreStarted?: FullScreenPaywallViewProps['onRestoreStarted'];
+  onRestoreCompleted?: FullScreenPaywallViewProps['onRestoreCompleted'];
+  onRestoreError?: FullScreenPaywallViewProps['onRestoreError'];
+  onPurchasePackageInitiated?: FullScreenPaywallViewProps['onPurchasePackageInitiated'];
+}) {
+  const { listener } = props;
+  return {
+    onPurchaseStarted: props.onPurchaseStarted ?? listener?.onPurchaseStarted,
+    onPurchaseCompleted: props.onPurchaseCompleted ?? listener?.onPurchaseCompleted,
+    onPurchaseError: props.onPurchaseError ?? listener?.onPurchaseError,
+    onPurchaseCancelled: props.onPurchaseCancelled ?? listener?.onPurchaseCancelled,
+    onRestoreStarted: props.onRestoreStarted ?? listener?.onRestoreStarted,
+    onRestoreCompleted: props.onRestoreCompleted ?? listener?.onRestoreCompleted,
+    onRestoreError: props.onRestoreError ?? listener?.onRestoreError,
+    onPurchasePackageInitiated: props.onPurchasePackageInitiated ?? (
+      listener?.onPurchaseInitiated
+        ? ({ packageBeingPurchased, resume }: { packageBeingPurchased: PurchasesPackage; resume: (shouldResume: boolean) => void }) => {
+            listener.onPurchaseInitiated!({
+              packageBeingPurchased,
+              resumable: { resume: (shouldProceed = true) => resume(shouldProceed) },
+            });
+          }
+        : undefined
+    ),
+  };
+}
 
 const InternalCustomerCenterView = !usingPreviewAPIMode && UIManager.getViewManagerConfig('CustomerCenterView') != null
     ? requireNativeComponent<CustomerCenterViewProps>('CustomerCenterView')
@@ -607,6 +703,7 @@ export default class RevenueCatUI {
                                                                    children,
                                                                    options,
                                                                    purchaseLogic,
+                                                                   listener,
                                                                    onPurchaseStarted,
                                                                    onPurchaseCompleted,
                                                                    onPurchaseError,
@@ -617,20 +714,31 @@ export default class RevenueCatUI {
                                                                    onDismiss,
                                                                    onPurchasePackageInitiated,
                                                                  }) => {
+    const resolved = resolvePaywallCallbacks({
+      listener,
+      onPurchaseStarted,
+      onPurchaseCompleted,
+      onPurchaseError,
+      onPurchaseCancelled,
+      onRestoreStarted,
+      onRestoreCompleted,
+      onRestoreError,
+      onPurchasePackageInitiated,
+    });
     return (
       <InternalPaywall
         options={options}
         children={children}
         purchaseLogic={purchaseLogic}
-        onPurchaseStarted={onPurchaseStarted}
-        onPurchaseCompleted={onPurchaseCompleted}
-        onPurchaseError={onPurchaseError}
-        onPurchaseCancelled={onPurchaseCancelled}
-        onRestoreStarted={onRestoreStarted}
-        onRestoreCompleted={onRestoreCompleted}
-        onRestoreError={onRestoreError}
+        onPurchaseStarted={resolved.onPurchaseStarted}
+        onPurchaseCompleted={resolved.onPurchaseCompleted}
+        onPurchaseError={resolved.onPurchaseError}
+        onPurchaseCancelled={resolved.onPurchaseCancelled}
+        onRestoreStarted={resolved.onRestoreStarted}
+        onRestoreCompleted={resolved.onRestoreCompleted}
+        onRestoreError={resolved.onRestoreError}
         onDismiss={onDismiss}
-        onPurchasePackageInitiated={onPurchasePackageInitiated}
+        onPurchasePackageInitiated={resolved.onPurchasePackageInitiated}
         style={[{flex: 1}, style]}
       />
     );
@@ -640,6 +748,7 @@ export default class RevenueCatUI {
                                                                                                   style,
                                                                                                   children,
                                                                                                   options,
+                                                                                                  listener,
                                                                                                   onPurchaseStarted,
                                                                                                   onPurchaseCompleted,
                                                                                                   onPurchaseError,
@@ -649,6 +758,17 @@ export default class RevenueCatUI {
                                                                                                   onRestoreError,
                                                                                                   onDismiss,
                                                                                                 }) => {
+    const resolved = resolvePaywallCallbacks({
+      listener,
+      onPurchaseStarted,
+      onPurchaseCompleted,
+      onPurchaseError,
+      onPurchaseCancelled,
+      onRestoreStarted,
+      onRestoreCompleted,
+      onRestoreError,
+    });
+
     // We use 20 as the default paddingBottom because that's the corner radius in the Android native SDK.
     // We also listen to safeAreaInsetsDidChange which is only sent from iOS and which is triggered when the
     // safe area insets change. Not adding this extra padding on iOS will cause the content of the scrollview
@@ -687,13 +807,13 @@ export default class RevenueCatUI {
             android: {marginTop: -20, height}
           })}
           options={options}
-          onPurchaseStarted={onPurchaseStarted}
-          onPurchaseCompleted={onPurchaseCompleted}
-          onPurchaseError={onPurchaseError}
-          onPurchaseCancelled={onPurchaseCancelled}
-          onRestoreStarted={onRestoreStarted}
-          onRestoreCompleted={onRestoreCompleted}
-          onRestoreError={onRestoreError}
+          onPurchaseStarted={resolved.onPurchaseStarted}
+          onPurchaseCompleted={resolved.onPurchaseCompleted}
+          onPurchaseError={resolved.onPurchaseError}
+          onPurchaseCancelled={resolved.onPurchaseCancelled}
+          onRestoreStarted={resolved.onRestoreStarted}
+          onRestoreCompleted={resolved.onRestoreCompleted}
+          onRestoreError={resolved.onRestoreError}
           onDismiss={onDismiss}
           onMeasure={(event: any) => setHeight(event.nativeEvent.measurements.height)}
         />


### PR DESCRIPTION
## Summary
- Adds `PaywallListener` and `PurchaseResumable` interfaces matching the [Capacitor SDK](https://github.com/RevenueCat/purchases-capacitor/blob/main/purchases-capacitor-ui/src/definitions.ts) definitions
- Adds `listener` prop to `PaywallView` and `PaywallFooterContainerView` as a convenience alternative to passing individual callback props
- Individual callback props take precedence over listener callbacks when both are provided
- No native changes required — purely TypeScript-level convenience

## Related PRs
- Based on: #1607 (PurchaseLogic support for PaywallView)
- Capacitor equivalent: https://github.com/RevenueCat/purchases-capacitor/pull/688

## Test plan
- [x] Verify TypeScript compiles without errors
- [x] Verify API testers pass type-checking
- [x] Test `listener` prop on `PaywallView` — purchase/restore callbacks fire
- [x] Test that individual callback props override listener callbacks
- [x] Test that omitting `listener` doesn't regress existing behavior (existing "Go to Paywall Screen" works as before)