### PR TITLE
Add custom PurchaseLogic button to OfferingDetailScreen

### DIFF
--- a/examples/purchaseTesterTypescript/App.tsx
+++ b/examples/purchaseTesterTypescript/App.tsx
@@ -34,7 +34,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 const Stack = createNativeStackNavigator();
 
 // Set to true to use custom purchase logic (purchasesAreCompletedBy: MY_APP).
-export const useCustomPurchaseLogic = true;
+export const purchasesAreCompletedByMyApp = false;
 
 const App = () => {
   const hasKeys = () => {
@@ -87,7 +87,7 @@ const App = () => {
       } else {
         Purchases.configure({
           apiKey: APIKeys.google,
-          ...(useCustomPurchaseLogic && {
+          ...(purchasesAreCompletedByMyApp && {
             purchasesAreCompletedBy: {
               type: Purchases.PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP,
             },
@@ -103,7 +103,7 @@ const App = () => {
     } else {
       Purchases.configure({
         apiKey: APIKeys.apple,
-        ...(useCustomPurchaseLogic && {
+        ...(purchasesAreCompletedByMyApp && {
           purchasesAreCompletedBy: {
             type: Purchases.PURCHASES_ARE_COMPLETED_BY_TYPE.MY_APP,
             storeKitVersion: Purchases.STOREKIT_VERSION.STOREKIT_2,

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -425,14 +425,6 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
             </Text>
           </TouchableOpacity>
           <TouchableOpacity
-            onPress={() =>
-              navigation.navigate('PurchaseLogicPaywall', {offering: null})
-            }>
-            <Text style={styles.otherActions}>
-              Go to Paywall with custom PurchaseLogic
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
             onPress={async () => {
               const paywallResult = await RevenueCatUI.presentPaywallIfNeeded({
                 requiredEntitlementIdentifier: 'pro_cat',

--- a/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/OfferingDetailScreen.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { ScrollView, StyleSheet, Text, TouchableOpacity, useColorScheme, View, } from 'react-native';
-
-import { Colors, } from 'react-native/Libraries/NewAppScreen';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View, } from 'react-native';
 
 import Purchases, {
   PurchasesPackage,
@@ -14,17 +12,13 @@ import RevenueCatUI from 'react-native-purchases-ui';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList'
 import { useCustomVariables } from '../context/CustomVariablesContext';
+import { purchasesAreCompletedByMyApp } from '../../App';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'OfferingDetail'>;
 
 // Taken from https://reactnative.dev/docs/typescript
 const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => {
-  const isDarkMode = useColorScheme() === 'dark';
   const { customVariables } = useCustomVariables();
-
-  const backgroundStyle = {
-    backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
-  };
 
   const purchasePackage = (pkg: PurchasesPackage) => {
     Purchases.purchasePackage(pkg).then(() => {
@@ -57,7 +51,7 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
   return (
     <ScrollView
         contentInsetAdjustmentBehavior="automatic"
-        style={[backgroundStyle, styles.container]}>
+        style={styles.container}>
           <Text style={styles.title}>Description</Text>
           <Text style={styles.value}>
             { route.params.offering?.serverDescription }
@@ -98,6 +92,16 @@ const OfferingDetailScreen: React.FC<Props> = ({ route, navigation }: Props) => 
               onPress={() => navigation.navigate('Paywall', { offering: route.params.offering, customVariables })}>
               <Text>
                 Show paywall
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.actionButton, !purchasesAreCompletedByMyApp && styles.disabledButton]}
+              disabled={!purchasesAreCompletedByMyApp}
+              onPress={() => navigation.navigate('PurchaseLogicPaywall', { offering: route.params.offering })}>
+              <Text style={!purchasesAreCompletedByMyApp && styles.disabledText}>
+                {purchasesAreCompletedByMyApp
+                  ? 'Show paywall with custom PurchaseLogic'
+                  : 'Show paywall with custom PurchaseLogic\n(Enable purchasesAreCompletedByMyApp)'}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
@@ -216,6 +220,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     marginHorizontal: 10,
     borderRadius: 4
+  },
+  disabledButton: {
+    backgroundColor: "#d3d3d3",
+  },
+  disabledText: {
+    color: "#888",
+    textAlign: "center" as const,
   },
   buttonStack: {
     flex: 1,

--- a/examples/purchaseTesterTypescript/app/screens/PurchaseLogicPaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/PurchaseLogicPaywallScreen.tsx
@@ -4,7 +4,7 @@ import RevenueCatUI, {PURCHASE_LOGIC_RESULT, type PurchaseLogicResult} from 'rea
 import {Modal, Pressable, StyleSheet, Text, View} from 'react-native';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList';
-import {useCustomPurchaseLogic} from '../../App';
+import {purchasesAreCompletedByMyApp} from '../../App';
 import {
   CustomerInfo,
   PurchasesError,
@@ -90,7 +90,7 @@ const PurchaseLogicPaywallScreen: React.FC<Props> = ({route, navigation}: Props)
     navigation.pop();
   };
 
-  if (!useCustomPurchaseLogic) {
+  if (!purchasesAreCompletedByMyApp) {
     return (
       <View style={styles.container}>
         <Text style={styles.warningText}>


### PR DESCRIPTION
## Summary
- Added a "Show paywall with custom PurchaseLogic" button to the OfferingDetailScreen in the purchase tester app
- Button is disabled with a hint when `purchasesAreCompletedByMyApp` is `false`, enabled when `true`
- Renamed `useCustomPurchaseLogic` to `purchasesAreCompletedByMyApp` to match the Flutter purchase tester naming
- Removed duplicate button from HomeScreen since it's now in OfferingDetailScreen
- Fixed OfferingDetailScreen dark background

This matches the example in https://github.com/RevenueCat/purchases-flutter/pull/1657

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 14 14 27" src="https://github.com/user-attachments/assets/8e00c775-9cfc-47a4-93c4-12850a78542f" />


## Test plan
- [x] Set `purchasesAreCompletedByMyApp = false` in `App.tsx` — button should be greyed out with hint text
- [x] Set `purchasesAreCompletedByMyApp = true` — button should be enabled and open PurchaseLogicPaywallScreen