### PR TITLE
Update sdks-common-config orb to 3.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   rn: react-native-community/react-native@8.0.1
-  revenuecat: revenuecat/sdks-common-config@2.2.0
+  revenuecat: revenuecat/sdks-common-config@3.13.0
 
 aliases:
   release-tags: &release-tags


### PR DESCRIPTION
Updates the revenuecat/sdks-common-config CircleCI orb to version 3.13.0.