### PR TITLE
Fix Paywall component blank screen due to layout timing

### DIFF
--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -53,6 +53,20 @@ API_AVAILABLE(ios(15.0))
     [super reactSetFrame: frame];
 }
 
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+
+    // When the view is added to a window, it gains a parentViewController via the
+    // responder chain. If options were already received but the view wasn't in the
+    // hierarchy yet (parentViewController was nil), we need to retry adding the
+    // paywall view controller now.
+    // See: https://github.com/RevenueCat/react-native-purchases/issues/1644
+    if (self.window && self.didReceiveInitialOptions && !self.addedToHierarchy) {
+        [self setNeedsLayout];
+        [self layoutIfNeeded];
+    }
+}
+
 - (void)layoutSubviews {
     [super layoutSubviews];
 
@@ -130,7 +144,12 @@ API_AVAILABLE(ios(15.0))
         } else {
             // View is not yet in hierarchy, trigger layout to apply options.
             // Custom variables will be applied before adding to hierarchy in layoutSubviews.
+            // Use setNeedsLayout + layoutIfNeeded to force a synchronous layout pass,
+            // because setNeedsLayout alone may not reliably trigger layoutSubviews
+            // (e.g., when the view has a zero frame or under Fabric's layout batching).
+            // See: https://github.com/RevenueCat/react-native-purchases/issues/1644
             [self setNeedsLayout];
+            [self layoutIfNeeded];
         }
     } else {
         NSLog(@"Error: attempted to present paywalls on unsupported iOS version.");


### PR DESCRIPTION
## Summary

- Fix a timing issue where the `<RevenueCatUI.Paywall />` component could render blank on iOS
- The `#1622` fix introduced a `didReceiveInitialOptions` gate in `layoutSubviews` that creates a timing dependency between `setOptions:` and the view hierarchy setup
- If `setOptions:` arrives after the initial layout pass and `setNeedsLayout` doesn't reliably trigger another `layoutSubviews` (e.g., zero initial frame, Fabric layout batching), the paywall view controller is never added to the hierarchy

### Changes

1. **`didMoveToWindow` override** — retries adding the paywall when the view enters a window (gaining a `parentViewController` via the responder chain), covering the case where `setOptions:` arrived before the view was in the hierarchy
2. **`layoutIfNeeded` after `setNeedsLayout` in `setOptions:`** — forces a synchronous layout pass instead of deferring to the next cycle, which may not fire reliably

Both changes preserve the `#1622` fix — custom variables are still applied before `viewDidLoad`.

## Test plan

- [ ] Build and run the purchase tester app
- [ ] Navigate to a paywall screen and verify it renders correctly
- [ ] Test with custom variables and verify they are applied
- [ ] Simulate delayed `setOptions:` (add `dispatch_after` in `setOptions:`) and verify the paywall still renders after the delay