### PR TITLE
Add offeringId override to trackCustomPaywallImpression

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1538,5 +1538,19 @@ describe("Purchases", () => {
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ paywallId: null });
     });
 
+    it("makes right call with offeringId only", async () => {
+      await Purchases.trackCustomPaywallImpression({ offeringId: "my_offering" });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ offeringId: "my_offering" });
+    });
+
+    it("makes right call with paywallId and offeringId", async () => {
+      await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall", offeringId: "my_offering" });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ paywallId: "my_paywall", offeringId: "my_offering" });
+    });
+
   });
 });

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -460,7 +460,10 @@ async function checkTrackCustomPaywallImpression() {
   await Purchases.trackCustomPaywallImpression({});
   await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall" });
   await Purchases.trackCustomPaywallImpression({ paywallId: null });
-  const options: TrackCustomPaywallImpressionOptions = { paywallId: "test" };
+  await Purchases.trackCustomPaywallImpression({ offeringId: "my_offering" });
+  await Purchases.trackCustomPaywallImpression({ offeringId: null });
+  await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall", offeringId: "my_offering" });
+  const options: TrackCustomPaywallImpressionOptions = { paywallId: "test", offeringId: "offering" };
   await Purchases.trackCustomPaywallImpression(options);
 }
 

--- a/examples/purchaseTesterTypescript/app/screens/CustomPaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/CustomPaywallScreen.tsx
@@ -4,6 +4,7 @@ import {
   SafeAreaView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -16,24 +17,23 @@ type Props = NativeStackScreenProps<RootStackParamList, 'CustomPaywall'>;
 
 const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
   const [status, setStatus] = useState<string | null>(null);
+  const [paywallId, setPaywallId] = useState('');
+  const [offeringId, setOfferingId] = useState('');
 
-  const trackImpressionNoId = async () => {
+  const trackImpression = async () => {
     try {
-      await Purchases.trackCustomPaywallImpression();
-      setStatus('trackCustomPaywallImpression (no id) succeeded');
-      console.log('[CustomPaywall] Tracked custom paywall impression (no id)');
-    } catch (e) {
-      setStatus(`Error: ${e}`);
-    }
-  };
+      const trimmedPaywallId = paywallId.trim() || undefined;
+      const trimmedOfferingId = offeringId.trim() || undefined;
 
-  const trackImpressionWithId = async () => {
-    try {
-      await Purchases.trackCustomPaywallImpression({
-        paywallId: 'my-test-paywall',
-      });
-      setStatus('trackCustomPaywallImpression (paywallId) succeeded');
-      console.log('[CustomPaywall] Tracked custom paywall impression (paywallId)');
+      if (!trimmedPaywallId && !trimmedOfferingId) {
+        await Purchases.trackCustomPaywallImpression();
+      } else {
+        await Purchases.trackCustomPaywallImpression({
+          paywallId: trimmedPaywallId,
+          offeringId: trimmedOfferingId,
+        });
+      }
+      setStatus(`Tracked (paywallId: ${trimmedPaywallId ?? 'nil'}, offeringId: ${trimmedOfferingId ?? 'nil'})`);
     } catch (e) {
       setStatus(`Error: ${e}`);
     }
@@ -47,19 +47,27 @@ const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
           Use this screen to test tracking custom paywall impressions.
         </Text>
 
-        <TouchableOpacity
-          style={styles.button}
-          onPress={trackImpressionNoId}>
-          <Text style={styles.buttonText}>
-            Track impression (no params)
-          </Text>
-        </TouchableOpacity>
+        <TextInput
+          style={styles.input}
+          placeholder="Paywall ID (optional)"
+          placeholderTextColor="#868e96"
+          value={paywallId}
+          onChangeText={setPaywallId}
+        />
+
+        <TextInput
+          style={styles.input}
+          placeholder="Offering ID (optional)"
+          placeholderTextColor="#868e96"
+          value={offeringId}
+          onChangeText={setOfferingId}
+        />
 
         <TouchableOpacity
           style={styles.button}
-          onPress={trackImpressionWithId}>
+          onPress={trackImpression}>
           <Text style={styles.buttonText}>
-            Track impression (paywallId only)
+            Track Custom Paywall Impression
           </Text>
         </TouchableOpacity>
 
@@ -114,6 +122,17 @@ const styles = StyleSheet.create({
     color: '#868e96',
     marginBottom: 24,
     textAlign: 'center',
+  },
+  input: {
+    width: '100%',
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#ced4da',
+    borderRadius: 12,
+    fontSize: 16,
+    color: '#212529',
+    backgroundColor: '#ffffff',
+    marginBottom: 12,
   },
   button: {
     width: '100%',

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -146,6 +146,11 @@ export type DebugEventListener = (event: DebugEvent) => void;
  */
 export interface TrackCustomPaywallImpressionOptions {
   paywallId?: string | null;
+  /**
+   * An optional identifier for the offering associated with the custom paywall.
+   * If not provided, the SDK will use the current offering identifier from the cache.
+   */
+  offeringId?: string | null;
 }
 
 let debugEventListeners: DebugEventListener[] = [];
@@ -1845,6 +1850,8 @@ export default class Purchases {
    *
    * @param params - Optional parameters for the impression event.
    * @param params.paywallId - Optional identifier for the custom paywall being shown.
+   * @param params.offeringId - Optional identifier for the offering associated with the custom paywall.
+   *   If not provided, the SDK will use the current offering identifier from the cache.
    */
   public static async trackCustomPaywallImpression(
     params?: TrackCustomPaywallImpressionOptions


### PR DESCRIPTION
## Summary
- Add optional `offeringId` parameter to `TrackCustomPaywallImpressionOptions`
- If not provided, the SDK uses the current offering identifier from the cache
- Update purchase tester demo screen with text fields for both paywall ID and offering ID

## Related PRs
- purchases-hybrid-common: https://github.com/RevenueCat/purchases-hybrid-common/pull/1565
- purchases-unity: https://github.com/RevenueCat/purchases-unity/pull/863