### PR TITLE
Merge release PR after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,11 @@ workflows:
           <<: *release-tags
           requires:
             - make-release
+      - revenuecat/merge-release-pr:
+          repo_name: react-native-purchases
+          requires:
+            - docs-deploy
+          <<: *release-tags
 
   danger:
     when:


### PR DESCRIPTION
## Motivation

After a release is deployed, the release PR should be automatically merged to avoid manual intervention and potential delays.

## Description

Adds a `revenuecat/merge-release-pr` job that runs after `docs-deploy` completes to automatically merge the release PR.