### PR TITLE
security: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@v2
+    uses: revenuecat/sdk-github-workflows/.github/workflows/issue-notifications.yml@acb41efc0045b05dd0517dc08200dd4112ea9bae # v2
     secrets:
       ACK_SLACK_WEBHOOK_URL: ${{ secrets.ACK_SLACK_WEBHOOK_URL }}
       ACK_ALERT_KEYWORDS: ${{ secrets.ACK_ALERT_KEYWORDS }}

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -10,7 +10,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2.0.1
+      - uses: dessant/lock-threads@63786a6c74ee3cfc4584f36de4360305c55e5126 # v2.0.1
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: "7"


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html
- Generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact)

## Test plan
- [ ] Verify CI passes with pinned references
- [ ] Spot-check that pinned SHAs match expected release tags