### PR TITLE
Expose RevenueCatUI layout direction opt-in

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,7 @@
 ## RevenueCat SDK
+### ✨ New Features
+* `RevenueCatUI` Paywalls and Customer Center can now opt in to matching right-to-left layout when overriding the preferred UI locale by setting `preferredUILocaleOverrideHonorsLayoutDirection` at configure time or the `honorLayoutDirection` runtime parameter. The default remains false to preserve existing layout behavior.
+
 ### 📦 Dependency Updates
 * [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.1.0 (#1733) via RevenueCat Git Bot (@RCGitBot)
   * [Android 10.2.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.2.0)

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -139,6 +139,14 @@ describe("Purchases", () => {
     }).not.toThrow();
   })
 
+  it("overridePreferredLocale passes the layout direction opt-in", async () => {
+    await Purchases.overridePreferredLocale("he");
+    await Purchases.overridePreferredLocale("ar-SA", true);
+
+    expect(NativeModules.RNPurchases.overridePreferredLocale).toHaveBeenNthCalledWith(1, "he", false);
+    expect(NativeModules.RNPurchases.overridePreferredLocale).toHaveBeenNthCalledWith(2, "ar-SA", true);
+  })
+
   it("allowing sharing store account works", async () => {
     await Purchases.setAllowSharingStoreAccount(true)
 
@@ -615,7 +623,7 @@ describe("Purchases", () => {
     const defaultVerificationMode = "DISABLED"
 
     Purchases.configure({apiKey: "key", appUserID: "user"});
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", undefined, "DEFAULT", false, true, defaultVerificationMode, false, false, true, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", undefined, "DEFAULT", false, true, defaultVerificationMode, false, false, true, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -626,7 +634,7 @@ describe("Purchases", () => {
       },
       storeKitVersion: STOREKIT_VERSION.DEFAULT,
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "MY_APP", undefined, "STOREKIT_1", false, true, defaultVerificationMode, false, false, true, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "MY_APP", undefined, "STOREKIT_1", false, true, defaultVerificationMode, false, false, true, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -635,7 +643,7 @@ describe("Purchases", () => {
       userDefaultsSuiteName: "suite name",
       storeKitVersion: STOREKIT_VERSION.DEFAULT,
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", false, true, defaultVerificationMode, false, false, true, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", false, true, defaultVerificationMode, false, false, true, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -649,7 +657,7 @@ describe("Purchases", () => {
         Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL,
       pendingTransactionsForPrepaidPlansEnabled: true,
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, true, Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL, true, false, true, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, true, Purchases.ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL, true, false, true, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -661,7 +669,7 @@ describe("Purchases", () => {
       shouldShowInAppMessagesAutomatically: false,
       diagnosticsEnabled: true,
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, true, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, true, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -674,7 +682,7 @@ describe("Purchases", () => {
       diagnosticsEnabled: true,
       automaticDeviceIdentifierCollectionEnabled: false,
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, false, undefined);
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, false, undefined, false);
 
     Purchases.configure({
       apiKey: "key",
@@ -688,9 +696,17 @@ describe("Purchases", () => {
       automaticDeviceIdentifierCollectionEnabled: false,
       preferredUILocaleOverride: "es_ES",
     });
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, false, "es_ES");
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", "suite name", "DEFAULT", true, false, defaultVerificationMode, false, true, false, "es_ES", false);
 
-    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(7);
+    Purchases.configure({
+      apiKey: "key",
+      appUserID: "user",
+      preferredUILocaleOverride: "ar_SA",
+      preferredUILocaleOverrideHonorsLayoutDirection: true,
+    });
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledWith("key", "user", "REVENUECAT", undefined, "DEFAULT", false, true, defaultVerificationMode, false, false, true, "ar_SA", true);
+
+    expect(NativeModules.RNPurchases.setupPurchases).toBeCalledTimes(8);
   })
 
   it("cancelled purchaseProduct sets userCancelled in the error", () => {

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -94,7 +94,8 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                boolean pendingTransactionsForPrepaidPlansEnabled,
                                boolean diagnosticsEnabled,
                                boolean automaticDeviceIdentifierCollectionEnabled,
-                               @Nullable String preferredUILocaleOverride) {
+                               @Nullable String preferredUILocaleOverride,
+                               boolean preferredUILocaleOverrideHonorsLayoutDirection) {
         PlatformInfo platformInfo = new PlatformInfo(PLATFORM_NAME, PLUGIN_VERSION);
         Store store = Store.PLAY_STORE;
         if (useAmazon) {
@@ -115,6 +116,9 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             automaticDeviceIdentifierCollectionEnabled,
             preferredUILocaleOverride
         );
+        if (preferredUILocaleOverrideHonorsLayoutDirection) {
+            overridePreferredLocaleIfNeeded(preferredUILocaleOverride, true);
+        }
         Purchases.getSharedInstance().setUpdatedCustomerInfoListener(this);
     }
 
@@ -381,8 +385,24 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
-    public void overridePreferredLocale(@Nullable String locale) {
-        CommonKt.overridePreferredLocale(locale);
+    public void overridePreferredLocale(@Nullable String locale, boolean honorLayoutDirection) {
+        overridePreferredLocaleIfNeeded(locale, honorLayoutDirection);
+    }
+
+    private void overridePreferredLocaleIfNeeded(@Nullable String locale, boolean honorLayoutDirection) {
+        if (!honorLayoutDirection) {
+            CommonKt.overridePreferredLocale(locale);
+            return;
+        }
+
+        try {
+            Purchases purchases = Purchases.getSharedInstance();
+            Purchases.class
+                .getMethod("overridePreferredUILocale", String.class, boolean.class)
+                .invoke(purchases, locale, true);
+        } catch (Exception ignored) {
+            CommonKt.overridePreferredLocale(locale);
+        }
     }
 
     //================================================================================

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -453,6 +453,7 @@ async function checkGetCachedVirtualCurrencies() {
 async function checkOverridePreferredLocale() {
   const preferredUILocaleOverride: string | null = "en-US";
   await Purchases.overridePreferredLocale(preferredUILocaleOverride);
+  await Purchases.overridePreferredLocale(preferredUILocaleOverride, true);
 }
 
 async function checkTrackCustomPaywallImpression() {

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -66,7 +66,8 @@ RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                   pendingTransactionsForPrepaidPlansEnabled:(BOOL)pendingTransactionsForPrepaidPlansEnabled 
                   diagnosticsEnabled:(BOOL)diagnosticsEnabled 
                   automaticDeviceIdentifierCollectionEnabled:(BOOL)automaticDeviceIdentifierCollectionEnabled
-                  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride) {
+                  preferredUILocaleOverride:(nullable NSString *)preferredUILocaleOverride
+                  preferredUILocaleOverrideHonorsLayoutDirection:(BOOL)preferredUILocaleOverrideHonorsLayoutDirection) {
     RCPurchases *purchases = [RCPurchases configureWithAPIKey:apiKey.mappingNSNullToNil
                                                     appUserID:appUserID.mappingNSNullToNil
                                       purchasesAreCompletedBy:purchasesAreCompletedBy.mappingNSNullToNil
@@ -81,6 +82,10 @@ RCT_EXPORT_METHOD(setupPurchases:(NSString *)apiKey
                    automaticDeviceIdentifierCollectionEnabled:automaticDeviceIdentifierCollectionEnabled
                                               preferredLocale:preferredUILocaleOverride.mappingNSNullToNil];
     purchases.delegate = self;
+    if (preferredUILocaleOverrideHonorsLayoutDirection) {
+        [self applyPreferredLocale:preferredUILocaleOverride
+               honorLayoutDirection:YES];
+    }
 }
 
 RCT_EXPORT_METHOD(setAllowSharingStoreAccount:(BOOL)allowSharingStoreAccount) {
@@ -452,8 +457,40 @@ RCT_EXPORT_METHOD(setCreative:(NSString *)creative) {
     [RCCommonFunctionality setCreative:creative.mappingNSNullToNil];
 }
 
-RCT_EXPORT_METHOD(overridePreferredLocale:(nullable NSString *)locale) {
-    [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+RCT_EXPORT_METHOD(overridePreferredLocale:(nullable NSString *)locale
+                  honorLayoutDirection:(BOOL)honorLayoutDirection) {
+    [self applyPreferredLocale:locale
+          honorLayoutDirection:honorLayoutDirection];
+}
+
+- (void)applyPreferredLocale:(nullable NSString *)locale
+        honorLayoutDirection:(BOOL)honorLayoutDirection {
+    if (!honorLayoutDirection) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    if (!RCPurchases.isConfigured) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    RCPurchases *purchases = RCPurchases.sharedPurchases;
+    SEL selector = NSSelectorFromString(@"overridePreferredUILocale:honorLayoutDirection:");
+    if (![purchases respondsToSelector:selector]) {
+        [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
+        return;
+    }
+
+    NSMethodSignature *signature = [purchases methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    NSString *localeArgument = locale.mappingNSNullToNil;
+    BOOL honorLayoutDirectionArgument = YES;
+    invocation.target = purchases;
+    invocation.selector = selector;
+    [invocation setArgument:&localeArgument atIndex:2];
+    [invocation setArgument:&honorLayoutDirectionArgument atIndex:3];
+    [invocation invoke];
 }
 
 RCT_REMAP_METHOD(canMakePayments,

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -810,6 +810,7 @@ NativeModules.RNPurchases = {
   getVirtualCurrencies: jest.fn(),
   invalidateVirtualCurrenciesCache: jest.fn(),
   getCachedVirtualCurrencies: jest.fn(),
+  overridePreferredLocale: jest.fn(),
   trackCustomPaywallImpression: jest.fn()
 };
 

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -27,7 +27,8 @@ export const browserNativeModuleRNPurchases = {
     _pendingTransactionsForPrepaidPlansEnabled: boolean,
     _diagnosticsEnabled: boolean,
     _automaticDeviceIdentifierCollectionEnabled: boolean,
-    _preferredUILocaleOverride: string | null
+    _preferredUILocaleOverride: string | null,
+    _preferredUILocaleOverrideHonorsLayoutDirection: boolean
   ) => {
     try {
       // Make sure that when running in Expo Go or Rork sandbox a web-compatible API key is used, because the underlying purchases-js error message isn't super clear when a non-compatible API key type is used in this case
@@ -293,7 +294,7 @@ export const browserNativeModuleRNPurchases = {
   setCreative: async (_creative: string) => {
     methodNotSupportedOnWeb('setCreative');
   },
-  overridePreferredLocale: async (_locale: string | null) => {
+  overridePreferredLocale: async (_locale: string | null, _honorLayoutDirection: boolean) => {
     methodNotSupportedOnWeb('overridePreferredLocale');
   },
   canMakePayments: async (_features: any[]) => {

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -55,6 +55,14 @@ export interface SyncPurchasesResult {
   customerInfo: CustomerInfo;
 }
 
+export type PurchasesConfigurationWithLayoutDirection = PurchasesConfiguration & {
+  /**
+   * Whether RevenueCat UI components should also derive layout direction from
+   * preferredUILocaleOverride. Defaults to false.
+   */
+  preferredUILocaleOverrideHonorsLayoutDirection?: boolean;
+};
+
 import { shouldUseBrowserMode } from "./utils/environment";
 import { browserNativeModuleRNPurchases } from "./browser/nativeModule";
 
@@ -317,6 +325,7 @@ export default class Purchases {
    * @param {boolean} [diagnosticsEnabled=false] An optional boolean. Set this to true to enable SDK diagnostics.
    * @param {boolean} [automaticDeviceIdentifierCollectionEnabled=true] An optional boolean. Set this to true to allow the collection of identifiers when setting the identifier for an attribution network.
    * @param {String?} [preferredUILocaleOverride] An optional string. Set this to the preferred UI locale to use for RevenueCat UI components.
+   * @param {boolean} [preferredUILocaleOverrideHonorsLayoutDirection=false] An optional boolean. Set this to true for RevenueCat UI components to also derive layout direction from preferredUILocaleOverride.
    *
    * @warning If you use purchasesAreCompletedBy=PurchasesAreCompletedByMyApp, you must also provide a value for storeKitVersion.
    */
@@ -333,7 +342,8 @@ export default class Purchases {
     diagnosticsEnabled = false,
     automaticDeviceIdentifierCollectionEnabled = true,
     preferredUILocaleOverride,
-  }: PurchasesConfiguration): void {
+    preferredUILocaleOverrideHonorsLayoutDirection = false,
+  }: PurchasesConfigurationWithLayoutDirection): void {
     throwIfNativeModuleNotAvailable();
 
     if (!customLogHandler) {
@@ -418,6 +428,7 @@ export default class Purchases {
       diagnosticsEnabled,
       automaticDeviceIdentifierCollectionEnabled,
       preferredUILocaleOverride,
+      preferredUILocaleOverrideHonorsLayoutDirection,
     );
   }
 
@@ -1628,13 +1639,15 @@ export default class Purchases {
    * Pass null to clear the override and use the device's locale.
    *
    * @param locale A BCP 47 locale identifier (e.g., "en-US") or null to clear.
+   * @param honorLayoutDirection Whether RevenueCat UI components should also derive layout direction from this locale. Defaults to false.
    * @returns {Promise<void>}
    */
   public static async overridePreferredLocale(
-    locale: string | null
+    locale: string | null,
+    honorLayoutDirection = false
   ): Promise<void> {
     await Purchases.throwIfNotConfigured();
-    RNPurchases.overridePreferredLocale(locale);
+    RNPurchases.overridePreferredLocale(locale, honorLayoutDirection);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add preferredUILocaleOverrideHonorsLayoutDirection to React Native configuration, defaulting false
- add honorLayoutDirection to overridePreferredLocale runtime API, defaulting false
- bridge the flag to native SDKs with backward-compatible fallbacks
- add Jest/API tester coverage and changelog entry

## Tests
- npx @yarnpkg/cli-dist@3.6.1 typecheck
- npx @yarnpkg/cli-dist@3.6.1 build
- npx @yarnpkg/cli-dist@3.6.1 test __tests__/index.test.js --runInBand

## Notes
- npx @yarnpkg/cli-dist@3.6.1 tsc -p apitesters/tsconfig.json is currently blocked by an existing unresolved ../react-native-purchases-ui import.