### PR TITLE
Handle numeric web purchase cancellation error codes

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -729,6 +729,25 @@ describe("Purchases", () => {
     });
   });
 
+  it("cancelled purchasePackage sets userCancelled when code is numeric", async () => {
+    NativeModules.RNPurchases.purchasePackage.mockRejectedValueOnce({
+      code: 1,
+      message: "",
+      readableErrorCode: "USER_CANCELLED",
+      underlyingErrorMessage: undefined,
+    });
+
+    return expect(async () => {
+      await Purchases.purchasePackage("onemonth_freetrial")
+    }).rejects.toEqual({
+      code: 1,
+      message: "",
+      readableErrorCode: "USER_CANCELLED",
+      underlyingErrorMessage: undefined,
+      userCancelled: true
+    });
+  });
+
   it("successful purchase works", () => {
     NativeModules.RNPurchases.purchaseProduct.mockResolvedValueOnce({
       purchasedProductIdentifier: "123",

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -615,7 +615,7 @@ export default class Purchases {
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -651,7 +651,7 @@ export default class Purchases {
       product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -686,7 +686,7 @@ export default class Purchases {
       product.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -723,7 +723,7 @@ export default class Purchases {
         : { isPersonalizedPrice: googleIsPersonalizedPrice }
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -760,7 +760,7 @@ export default class Purchases {
       subscriptionOption.presentedOfferingContext
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -791,7 +791,7 @@ export default class Purchases {
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -1226,7 +1226,7 @@ export default class Purchases {
       winBackOffer.identifier
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }
@@ -1260,7 +1260,7 @@ export default class Purchases {
       winBackOffer.identifier
     ).catch((error: PurchasesError) => {
       error.userCancelled =
-        error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
+        String(error.code) === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
       throw error;
     });
   }


### PR DESCRIPTION
## Summary

Adds a defensive fix for web purchase cancellation handling in `react-native-purchases`.

Related issue: RevenueCat/react-native-purchases#1756

## Changes

- coerce incoming purchase error codes to string before checking for cancellation
- add a regression test covering numeric cancellation code `1`

## Context

The underlying root cause is fixed in `purchases-js-hybrid-mappings`, where web cancellation errors were being forwarded with numeric code `1` instead of string `"1"`. This React Native change keeps cancellation handling correct even if a numeric code reaches this layer.

## Validation

- Added regression test in `__tests__/index.test.js`
- Local JS build/test execution is currently blocked in this workspace because `corepack yarn install` fails on the repo's patched `typescript@5.2.2` dependency with `Cannot apply hunk #4`
