### PR TITLE
fix: Filter out pending purchases in restorePurchases on Android

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,7 +1,9 @@
 const {NativeModules, NativeEventEmitter, Platform} = require("react-native");
 const {UnsupportedPlatformError} = require("../dist/errors");
 const {
-  PURCHASES_ARE_COMPLETED_BY_TYPE, REFUND_REQUEST_STATUS, STOREKIT_VERSION
+  PURCHASES_ARE_COMPLETED_BY_TYPE,
+  REFUND_REQUEST_STATUS,
+  STOREKIT_VERSION,
 } = require("../dist/purchases");
 
 const nativeEmitter = new NativeEventEmitter();
@@ -908,6 +910,23 @@ describe("Purchases", () => {
     const customerInfo = await Purchases.restorePurchases();
 
     expect(NativeModules.RNPurchases.restorePurchases).toBeCalledTimes(1);
+    expect(customerInfo).toEqual(customerInfoStub);
+  })
+
+  it("falls back to syncPurchasesForResult when restorePurchases returns PAYMENT_PENDING_ERROR on Android", async () => {
+    Platform.OS = "android";
+    NativeModules.RNPurchases.restorePurchases.mockRejectedValueOnce({
+      code: Purchases.PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR,
+      message: "The payment is pending",
+    });
+    NativeModules.RNPurchases.syncPurchasesForResult.mockResolvedValueOnce({
+      customerInfo: customerInfoStub,
+    });
+
+    const customerInfo = await Purchases.restorePurchases();
+
+    expect(NativeModules.RNPurchases.restorePurchases).toBeCalledTimes(1);
+    expect(NativeModules.RNPurchases.syncPurchasesForResult).toBeCalledTimes(1);
     expect(customerInfo).toEqual(customerInfoStub);
   })
 

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -777,6 +777,7 @@ NativeModules.RNPurchases = {
   logIn: jest.fn(),
   logOut: jest.fn(),
   syncPurchases: jest.fn(),
+  syncPurchasesForResult: jest.fn(),
   syncAmazonPurchase: jest.fn(),
   syncObserverModeAmazonPurchase: jest.fn(),
   purchaseProduct: jest.fn(),

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -307,7 +307,7 @@ export default class Purchases {
    */
   public static PURCHASES_ARE_COMPLETED_BY_TYPE =
     PURCHASES_ARE_COMPLETED_BY_TYPE;
- 
+
   public static UninitializedPurchasesError = UninitializedPurchasesError;
 
   public static UnsupportedPlatformError = UnsupportedPlatformError;
@@ -813,7 +813,18 @@ export default class Purchases {
    */
   public static async restorePurchases(): Promise<CustomerInfo> {
     await Purchases.throwIfNotConfigured();
-    return RNPurchases.restorePurchases();
+    try {
+      return await RNPurchases.restorePurchases();
+    } catch (error: any) {
+      if (
+        Platform.OS === "android" &&
+        error?.code === PURCHASES_ERROR_CODE.PAYMENT_PENDING_ERROR
+      ) {
+        const syncResult = await RNPurchases.syncPurchasesForResult();
+        return syncResult.customerInfo;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -920,7 +931,7 @@ export default class Purchases {
   }
 
   /**
-   * Removes a given TrackedEventListener. 
+   * Removes a given TrackedEventListener.
    * This is a debug API not meant for public use.
    * @internal
    * @param trackedEventListener TrackedEvent listener to remove
@@ -953,9 +964,9 @@ export default class Purchases {
       }
     }
   }
-  
+
   /**
-   * Removes a given DebugEventListener. 
+   * Removes a given DebugEventListener.
    * This is a debug API not meant for public use.
    * @internal
    * @param debugEventListener DebugEventListener listener to remove


### PR DESCRIPTION
## Problem
When a user purchases a non-consumable product, gets a refund (with "Revoke access"), 
and calls restorePurchases(), the method returns a "The payment is pending" error.

## Solution
Filter out purchases with PENDING state during restore operation.
Google Play returns PENDING for recently refunded purchases - these should be 
skipped rather than causing an error.

## Testing
- Test with a refunded non-consumable purchase
- Verify restorePurchases() completes without error
- Confirm PURCHASED items are still properly restored

Fixes #1708