### PR TITLE
[EXTERNAL] fix: wrong npx command in DEVELOPMENT.md (#1775) via @mervivian

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ That will link the local package so that changes are automatically applied to th
 
 To run purchaseTesterTypescript on a device run the following from the root of the repository:
 
-`yarn example android` or `npx example ios`
+`yarn example android` or `yarn example ios`
 
 If you have a connected device, the app will run on that device. If not, it will run on a simulator. If you get issues when running iOS try opening the xcworkspace with xcode and build the project, it might point to what the error is, like for example a missing Team for signing.
 


### PR DESCRIPTION
## Summary
`DEVELOPMENT.md` tells developers to run `npx example ios` to launch the iOS example app, but `example` is a yarn workspace script defined in `package.json`. `npx` can't run workspace scripts, so this command fails. The correct command is `yarn example ios`, which is also what `CLAUDE.md` documents and what appears later in the same file.

## How to reproduce
1. Clone the repo and run `yarn bootstrap`
2. Follow the instructions on line 15 of `DEVELOPMENT.md`: `npx example ios`
3. `npx` errors because there's no `example` binary to invoke

## Test plan
- Replace `npx example ios` with `yarn example ios` and confirm the example app builds and runs on an iOS simulator.
