### PR TITLE
fix(ios): dispatch completion callbacks to main queue to prevent New Architecture crash

### DIFF
--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -300,15 +300,17 @@ RCT_EXPORT_METHOD(eligibleWinBackOffersForProductIdentifier:(nonnull NSString *)
     if (@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)) {
         [RCCommonFunctionality eligibleWinBackOffersForProductIdentifier:productID
                                                          completionBlock:^(NSArray<NSDictionary *> * _Nullable offers, RCErrorContainer * _Nullable errorContainer) {
-            if (errorContainer) {
-                reject(
-                    [NSString stringWithFormat:@"%ld", (long)errorContainer.code],
-                    errorContainer.message,
-                    errorContainer.error
-                );
-            } else {
-                resolve(offers ?: @[]);
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (errorContainer) {
+                    reject(
+                        [NSString stringWithFormat:@"%ld", (long)errorContainer.code],
+                        errorContainer.message,
+                        errorContainer.error
+                    );
+                } else {
+                    resolve(offers ?: @[]);
+                }
+            });
         }];
     } else {
         NSError *error = [self createUnsupportedErrorWithDescription:@"iOS win-back offers are only available on iOS 18.0 or greater."];
@@ -515,15 +517,17 @@ RCT_EXPORT_METHOD(showManageSubscriptions:
     #if TARGET_OS_IPHONE && !TARGET_OS_TV
     if (@available(iOS 13.0, macOS 10.15, visionOS 1.0, *)) {
         [RCCommonFunctionality showManageSubscriptions:^(RCErrorContainer * _Nullable errorContainer) {
-            if (errorContainer) {
-                reject(
-                    [NSString stringWithFormat:@"%ld", (long)errorContainer.code],
-                    errorContainer.message,
-                    errorContainer.error
-                );
-            } else {
-                resolve(nil);
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (errorContainer) {
+                    reject(
+                        [NSString stringWithFormat:@"%ld", (long)errorContainer.code],
+                        errorContainer.message,
+                        errorContainer.error
+                    );
+                } else {
+                    resolve(nil);
+                }
+            });
         }];
     } else {
         NSLog(@"[Purchases] Warning: tried to showManageSubscriptions in non supported iOS devices. Only available on iOS 13.0 or greater.");
@@ -662,27 +666,34 @@ readyForPromotedProduct:(RCStoreProduct *)product
 
 - (void (^)(NSDictionary *, RCErrorContainer *))getResponseCompletionBlockWithResolve:(RCTPromiseResolveBlock)resolve
                                                                                reject:(RCTPromiseRejectBlock)reject {
+    // RCCommonFunctionality delivers completion blocks on a background thread. In New Architecture's
+    // interop layer, calling resolve/reject off the declared methodQueue (main) causes a use-after-free
+    // in convertNSExceptionToJSError → Hermes memory corruption. Always dispatch back to main queue.
     return ^(NSDictionary *_Nullable responseDictionary, RCErrorContainer *_Nullable error) {
-        if (error) {
-            [self rejectPromiseWithBlock:reject error:error];
-        } else if (responseDictionary) {
-            resolve([NSDictionary dictionaryWithDictionary:responseDictionary]);
-        } else {
-            resolve(nil);
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error) {
+                [self rejectPromiseWithBlock:reject error:error];
+            } else if (responseDictionary) {
+                resolve([NSDictionary dictionaryWithDictionary:responseDictionary]);
+            } else {
+                resolve(nil);
+            }
+        });
     };
 }
 
 - (void (^)(RCErrorContainer *))getBeginRefundResponseCompletionBlockWithResolve:(RCTPromiseResolveBlock)resolve
                                                                           reject:(RCTPromiseRejectBlock)reject {
     return ^(RCErrorContainer * _Nullable error) {
-        if (error == nil) {
-            resolve(@0);
-        } else if ([error.info[@"userCancelled"] isEqual:@YES]) {
-            resolve(@1);
-        } else {
-            [self rejectPromiseWithBlock:reject error:error];
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (error == nil) {
+                resolve(@0);
+            } else if ([error.info[@"userCancelled"] isEqual:@YES]) {
+                resolve(@1);
+            } else {
+                [self rejectPromiseWithBlock:reject error:error];
+            }
+        });
     };
 }
 


### PR DESCRIPTION
## What's broken

`Purchases.logIn()` (and other async methods) crash iOS apps 100% of the time when React Native's New Architecture is enabled. The crash manifests as Hermes memory corruption (`EXC_BAD_ACCESS` / SIGSEGV) in `hermes::vm::DictPropertyMap::allocatePropertySlot`, with a faulting address whose bytes are ASCII text — a classic use-after-free.

The crash stack is always: `TurboModuleConvertUtils::convertNSExceptionToJSError` → `ObjCTurboModule::performVoidMethodInvocation`.

## Root cause

`RNPurchases.m` declares `methodQueue = dispatch_get_main_queue()`, telling React Native: "my methods run on main, and so do my callbacks." But `RCCommonFunctionality` delivers async completion blocks on whatever background thread it's running on, not the main thread.

In the **Old Architecture**, `resolve`/`reject` blocks were thread-safe — calling them from a background thread was harmless. In the **New Architecture interop layer**, they are not. Calling `reject` from a background thread accesses JSI off-thread, which throws an ObjC exception. `convertNSExceptionToJSError` then tries to read the exception's `reason` string, but the backing memory has already been freed. Hermes reads garbage bytes (`0x6874696b` = `"kith"`) as a pointer and crashes.

## Fix

Wrap every async `resolve`/`reject` call in `dispatch_async(dispatch_get_main_queue(), ...)` so callbacks always honour the `methodQueue` contract. Four completion blocks changed:

- `getResponseCompletionBlockWithResolve:reject:` — shared helper used by `logIn`, `logOut`, `getCustomerInfo`, `purchasePackage`, `redeemWebPurchase`, and more
- `getBeginRefundResponseCompletionBlockWithResolve:reject:` — refund flow
- `eligibleWinBackOffersForProductIdentifier` inline block
- `showManageSubscriptions` inline block

## What this does NOT fix

Issues #1739 / #1747, where `NativeModules.RNPurchases` is entirely `null` on RN 0.81+ New Architecture. That is a separate problem requiring TurboModule codegen support.

## Manual testing

There is no automated test that can verify thread-dispatch behaviour in ObjC. To validate:

1. Create a React Native app with `newArchEnabled: true` (Expo SDK 54+ or bare RN 0.79+)
2. Install this branch's build of `react-native-purchases`
3. Call `Purchases.configure({ apiKey })` at startup
4. Call `Purchases.logIn("some-user-id")` after configure
5. **Before fix:** app crashes ~1-2 seconds after `logIn` with SIGSEGV
6. **After fix:** `logIn` completes normally, no crash

Closes #1776