### PR TITLE
Update Maestro iOS e2e tests to run on Xcode 26.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
     executor:
       name: rn/macos
       resource_class: m4pro.medium
-      xcode_version: '26.3'
+      xcode_version: '26.5'
     steps:
       - checkout
       - install-ruby-3-2-0


### PR DESCRIPTION
### Motivation
Bump the Xcode version used by the iOS Maestro e2e CI job.

### Summary
- Updates the `run-maestro-e2e-tests-ios` executor to Xcode 26.5 (was 26.3).

Made with [Cursor](https://cursor.com)