### PR TITLE
Add presentedOfferingContext support to custom paywall impression events

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1982,6 +1982,15 @@ describe("Purchases", () => {
   });
 
   describe("trackCustomPaywallImpression", () => {
+    const presentedOfferingContext = {
+      offeringIdentifier: "offering",
+      placementIdentifier: "onboarding",
+      targetingContext: {
+        revision: 7,
+        ruleId: "rule_1",
+      },
+    };
+
     describe("when Purchases is not configured", () => {
       it("it rejects", async () => {
         NativeModules.RNPurchases.isConfigured.mockResolvedValueOnce(false);
@@ -1999,35 +2008,171 @@ describe("Purchases", () => {
       await Purchases.trackCustomPaywallImpression();
 
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({});
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: null,
+        offeringId: null,
+        presentedOfferingContext: null,
+      });
+    });
+
+    it("passes null values with empty params", async () => {
+      await Purchases.trackCustomPaywallImpression({});
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: null,
+        offeringId: null,
+        presentedOfferingContext: null,
+      });
     });
 
     it("makes right call with paywallId", async () => {
       await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall" });
 
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ paywallId: "my_paywall" });
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "my_paywall",
+        offeringId: null,
+        presentedOfferingContext: null,
+      });
     });
 
-    it("makes right call with null paywallId", async () => {
+    it("sends null value with null paywallId", async () => {
       await Purchases.trackCustomPaywallImpression({ paywallId: null });
 
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ paywallId: null });
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: null,
+        offeringId: null,
+        presentedOfferingContext: null,
+      });
     });
 
     it("makes right call with offeringId only", async () => {
       await Purchases.trackCustomPaywallImpression({ offeringId: "my_offering" });
 
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ offeringId: "my_offering" });
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: null,
+        offeringId: "my_offering",
+        presentedOfferingContext: null,
+      });
+    });
+
+    it("sends null value with null offeringId", async () => {
+      await Purchases.trackCustomPaywallImpression({ offeringId: null });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: null,
+        offeringId: null,
+        presentedOfferingContext: null,
+      });
     });
 
     it("makes right call with paywallId and offeringId", async () => {
       await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall", offeringId: "my_offering" });
 
       expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({ paywallId: "my_paywall", offeringId: "my_offering" });
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "my_paywall",
+        offeringId: "my_offering",
+        presentedOfferingContext: null,
+      });
+    });
+
+    it("derives offering id and context from an offering", async () => {
+      const offering = {
+        identifier: "offering",
+        availablePackages: [
+          {
+            presentedOfferingContext,
+          },
+        ],
+      };
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: "paywall",
+        offering,
+      });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "paywall",
+        offeringId: "offering",
+        presentedOfferingContext,
+      });
+    });
+
+    it("preserves nullable fields in offering-derived presented offering context", async () => {
+      const nullablePresentedOfferingContext = {
+        offeringIdentifier: "offering",
+        placementIdentifier: null,
+        targetingContext: null,
+      };
+      const offering = {
+        identifier: "offering",
+        availablePackages: [
+          {
+            presentedOfferingContext: nullablePresentedOfferingContext,
+          },
+        ],
+      };
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: "paywall",
+        offering,
+      });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "paywall",
+        offeringId: "offering",
+        presentedOfferingContext: nullablePresentedOfferingContext,
+      });
+    });
+
+    it("derives offering id without context from an offering with no available packages", async () => {
+      const offering = {
+        identifier: "offering",
+        availablePackages: [],
+      };
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: "paywall",
+        offering,
+      });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "paywall",
+        offeringId: "offering",
+        presentedOfferingContext: null,
+      });
+    });
+
+    it("prefers offering-derived data over legacy offeringId", async () => {
+      const offering = {
+        identifier: "offering",
+        availablePackages: [
+          {
+            presentedOfferingContext,
+          },
+        ],
+      };
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: "paywall",
+        offering,
+        offeringId: "legacy_offering",
+      });
+
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.trackCustomPaywallImpression).toBeCalledWith({
+        paywallId: "paywall",
+        offeringId: "offering",
+        presentedOfferingContext,
+      });
     });
 
   });

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -145,13 +145,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     @ReactMethod
     public void setAppstackAttributionParams(ReadableMap data, final Promise promise) {
-        HashMap<String, Object> dataMap = new HashMap<>();
-        for (Map.Entry<String, Object> entry : data.toHashMap().entrySet()) {
-            if (entry.getValue() != null) {
-                dataMap.put(entry.getKey(), entry.getValue());
-            }
-        }
-        CommonKt.setAppstackAttributionParams(dataMap, getOnResult(promise));
+        CommonKt.setAppstackAttributionParams(toNonNullHashMap(data), getOnResult(promise));
     }
 
     @ReactMethod
@@ -633,7 +627,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     @ReactMethod
     public void trackCustomPaywallImpression(ReadableMap data) {
-        CommonKt.trackCustomPaywallImpression(data.toHashMap());
+        CommonKt.trackCustomPaywallImpression(mapWithoutNullValues(data));
     }
 
     @ReactMethod
@@ -740,5 +734,55 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
             default:
                 return null;
         }
+    }
+
+    private static HashMap<String, Object> toNonNullHashMap(ReadableMap data) {
+        HashMap<String, Object> dataMap = new HashMap<>();
+        for (Map.Entry<String, Object> entry : data.toHashMap().entrySet()) {
+            if (entry.getValue() != null) {
+                dataMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return dataMap;
+    }
+
+    private static HashMap<String, Object> mapWithoutNullValues(ReadableMap data) {
+        return mapWithoutNullValues(data.toHashMap());
+    }
+
+    private static HashMap<String, Object> mapWithoutNullValues(Map<String, Object> data) {
+        HashMap<String, Object> dataMap = new HashMap<>();
+        for (Map.Entry<String, Object> entry : data.entrySet()) {
+            Object value = valueWithoutNullValues(entry.getValue());
+            if (value != null) {
+                dataMap.put(entry.getKey(), value);
+            }
+        }
+        return dataMap;
+    }
+
+    private static Object valueWithoutNullValues(@Nullable Object value) {
+        if (value instanceof Map) {
+            HashMap<String, Object> dataMap = new HashMap<>();
+            Map<?, ?> originalMap = (Map<?, ?>) value;
+            for (Map.Entry<?, ?> entry : originalMap.entrySet()) {
+                Object filteredValue = valueWithoutNullValues(entry.getValue());
+                if (entry.getKey() instanceof String && filteredValue != null) {
+                    dataMap.put((String) entry.getKey(), filteredValue);
+                }
+            }
+            return dataMap;
+        }
+        if (value instanceof List) {
+            ArrayList<Object> filteredList = new ArrayList<>();
+            for (Object item : (List<?>) value) {
+                Object filteredItem = valueWithoutNullValues(item);
+                if (filteredItem != null) {
+                    filteredList.add(filteredItem);
+                }
+            }
+            return filteredList;
+        }
+        return value;
     }
 }

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -145,7 +145,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     @ReactMethod
     public void setAppstackAttributionParams(ReadableMap data, final Promise promise) {
-        CommonKt.setAppstackAttributionParams(toNonNullHashMap(data), getOnResult(promise));
+        CommonKt.setAppstackAttributionParams(mapWithoutNullValues(data), getOnResult(promise));
     }
 
     @ReactMethod
@@ -736,26 +736,16 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
         }
     }
 
-    private static HashMap<String, Object> toNonNullHashMap(ReadableMap data) {
-        HashMap<String, Object> dataMap = new HashMap<>();
-        for (Map.Entry<String, Object> entry : data.toHashMap().entrySet()) {
-            if (entry.getValue() != null) {
-                dataMap.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return dataMap;
-    }
-
     private static HashMap<String, Object> mapWithoutNullValues(ReadableMap data) {
         return mapWithoutNullValues(data.toHashMap());
     }
 
-    private static HashMap<String, Object> mapWithoutNullValues(Map<String, Object> data) {
+    private static HashMap<String, Object> mapWithoutNullValues(Map<?, ?> data) {
         HashMap<String, Object> dataMap = new HashMap<>();
-        for (Map.Entry<String, Object> entry : data.entrySet()) {
+        for (Map.Entry<?, ?> entry : data.entrySet()) {
             Object value = valueWithoutNullValues(entry.getValue());
-            if (value != null) {
-                dataMap.put(entry.getKey(), value);
+            if (entry.getKey() instanceof String && value != null) {
+                dataMap.put((String) entry.getKey(), value);
             }
         }
         return dataMap;
@@ -763,15 +753,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
 
     private static Object valueWithoutNullValues(@Nullable Object value) {
         if (value instanceof Map) {
-            HashMap<String, Object> dataMap = new HashMap<>();
-            Map<?, ?> originalMap = (Map<?, ?>) value;
-            for (Map.Entry<?, ?> entry : originalMap.entrySet()) {
-                Object filteredValue = valueWithoutNullValues(entry.getValue());
-                if (entry.getKey() instanceof String && filteredValue != null) {
-                    dataMap.put((String) entry.getKey(), filteredValue);
-                }
-            }
-            return dataMap;
+            return mapWithoutNullValues((Map<?, ?>) value);
         }
         if (value instanceof List) {
             ArrayList<Object> filteredList = new ArrayList<>();

--- a/apitesters/purchases.ts
+++ b/apitesters/purchases.ts
@@ -60,6 +60,16 @@ async function checkPurchases(purchases: Purchases) {
 
   await Purchases.presentCodeRedemptionSheet();
   await Purchases.invalidateCustomerInfoCache();
+  await Purchases.trackCustomPaywallImpression();
+  await Purchases.trackCustomPaywallImpression({
+    paywallId: "paywall",
+  });
+  if (currentOfferingForPlacement) {
+    await Purchases.trackCustomPaywallImpression({
+      paywallId: "paywall",
+      offering: currentOfferingForPlacement,
+    });
+  }
 }
 
 async function checkUsers(purchases: Purchases) {
@@ -88,6 +98,10 @@ async function checkPurchasing(
   const features: BILLING_FEATURE[] = [];
   const messageTypes: IN_APP_MESSAGE_TYPE[] = [];
   const googleIsPersonalizedPrice: boolean = false;
+  const customPaywallImpressionParams: TrackCustomPaywallImpressionOptions = {
+    paywallId: "paywall",
+    offeringId: pack.presentedOfferingContext.offeringIdentifier,
+  };
 
   const paymentDiscount2: PurchasesPromotionalOffer | undefined =
     await Purchases.getPromotionalOffer(product, discount);
@@ -175,6 +189,7 @@ async function checkPurchasing(
   await Purchases.showInAppMessages(messageTypes);
 
   const manageSubscriptions: void = await Purchases.showManageSubscriptions();
+  await Purchases.trackCustomPaywallImpression(customPaywallImpressionParams);
 }
 
 async function checkConfigure() {
@@ -484,7 +499,10 @@ async function checkTrackCustomPaywallImpression() {
   await Purchases.trackCustomPaywallImpression({ offeringId: "my_offering" });
   await Purchases.trackCustomPaywallImpression({ offeringId: null });
   await Purchases.trackCustomPaywallImpression({ paywallId: "my_paywall", offeringId: "my_offering" });
-  const options: TrackCustomPaywallImpressionOptions = { paywallId: "test", offeringId: "offering" };
+  const options: TrackCustomPaywallImpressionOptions = {
+    paywallId: "test",
+    offeringId: "offering",
+  };
   await Purchases.trackCustomPaywallImpression(options);
 }
 

--- a/examples/purchaseTesterTypescript/app/screens/CustomPaywallScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/CustomPaywallScreen.tsx
@@ -1,7 +1,9 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {
+  Alert,
   SafeAreaView,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -9,7 +11,10 @@ import {
   View,
 } from 'react-native';
 
-import Purchases from 'react-native-purchases';
+import Purchases, {
+  PurchasesOffering,
+  TrackedEvent,
+} from 'react-native-purchases';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
 import RootStackParamList from '../RootStackParamList';
 
@@ -17,23 +22,117 @@ type Props = NativeStackScreenProps<RootStackParamList, 'CustomPaywall'>;
 
 const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
   const [status, setStatus] = useState<string | null>(null);
+  const [lastTrackedEvent, setLastTrackedEvent] = useState<string | null>(null);
+  const [currentOfferingId, setCurrentOfferingId] = useState<string | null>(null);
   const [paywallId, setPaywallId] = useState('');
-  const [offeringId, setOfferingId] = useState('');
 
-  const trackImpression = async () => {
+  const getPaywallId = () => paywallId.trim() || undefined;
+
+  const loadOfferings = async () => {
+    const offerings = await Purchases.getOfferings();
+    setCurrentOfferingId(offerings.current?.identifier ?? null);
+    return offerings;
+  };
+
+  useEffect(() => {
+    const listener = (event: TrackedEvent) => {
+      setLastTrackedEvent(JSON.stringify(event.eventDictionary, null, 2));
+    };
+
+    Purchases.addTrackedEventListener(listener).catch(e => {
+      setStatus(`Error: ${e}`);
+    });
+
+    return () => Purchases.removeTrackedEventListener(listener);
+  }, []);
+
+  useEffect(() => {
+    loadOfferings().catch(e => {
+      console.log('[RCCustomPaywallTester] Could not preload offerings:', e);
+    });
+  }, []);
+
+  const trackImpressionWithoutOffering = async () => {
     try {
-      const trimmedPaywallId = paywallId.trim() || undefined;
-      const trimmedOfferingId = offeringId.trim() || undefined;
+      const trimmedPaywallId = getPaywallId();
+      const offerings = await loadOfferings();
+      const currentOffering = offerings.current;
 
-      if (!trimmedPaywallId && !trimmedOfferingId) {
-        await Purchases.trackCustomPaywallImpression();
-      } else {
+      if (!currentOffering) {
+        setStatus(
+          'No current offering configured. The native SDK cannot infer an offering for this call.',
+        );
+        Alert.alert(
+          'No current offering configured',
+          'The native SDK can only infer an offering when getOfferings().current is non-null. Use Track with Offering for this project.',
+        );
+        return;
+      }
+
+      if (trimmedPaywallId) {
         await Purchases.trackCustomPaywallImpression({
           paywallId: trimmedPaywallId,
-          offeringId: trimmedOfferingId,
         });
+      } else {
+        await Purchases.trackCustomPaywallImpression();
       }
-      setStatus(`Tracked (paywallId: ${trimmedPaywallId ?? 'nil'}, offeringId: ${trimmedOfferingId ?? 'nil'})`);
+
+      setStatus(
+        `Tracked without offering (paywallId: ${trimmedPaywallId ?? 'nil'}, current offering: ${currentOffering.identifier})`,
+      );
+    } catch (e) {
+      setStatus(`Error: ${e}`);
+    }
+  };
+
+  const trackImpressionWithOffering = async (offering: PurchasesOffering) => {
+    try {
+      const trimmedPaywallId = getPaywallId();
+
+      await Purchases.trackCustomPaywallImpression({
+        paywallId: trimmedPaywallId,
+        offering,
+      });
+
+      setStatus(
+        `Tracked with offering: ${offering.identifier} (paywallId: ${trimmedPaywallId ?? 'nil'})`,
+      );
+    } catch (e) {
+      setStatus(`Error: ${e}`);
+    }
+  };
+
+  const showOfferingPicker = async () => {
+    try {
+      setStatus('Loading offerings...');
+
+      const offerings = await loadOfferings();
+      const offeringOptions = Object.values(offerings.all).sort((a, b) =>
+        a.identifier.localeCompare(b.identifier),
+      );
+
+      if (offeringOptions.length === 0) {
+        setStatus('No offerings available');
+        Alert.alert('No offerings available');
+        return;
+      }
+
+      Alert.alert(
+        'Select Offering',
+        'Choose the offering to send with the custom paywall impression.',
+        [
+          ...offeringOptions.map(offering => ({
+            text: offering.identifier,
+            onPress: () => trackImpressionWithOffering(offering),
+          })),
+          {
+            text: 'Cancel',
+            style: 'cancel' as const,
+            onPress: () => setStatus(null),
+          },
+        ],
+        {cancelable: true, onDismiss: () => setStatus(null)},
+      );
     } catch (e) {
       setStatus(`Error: ${e}`);
     }
@@ -41,10 +140,13 @@ const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
+      <ScrollView contentContainerStyle={styles.content}>
         <Text style={styles.title}>Custom Paywall Impression</Text>
         <Text style={styles.description}>
           Use this screen to test tracking custom paywall impressions.
+        </Text>
+        <Text style={styles.currentOfferingText}>
+          Current offering: {currentOfferingId ?? 'nil'}
         </Text>
 
         <TextInput
@@ -55,19 +157,23 @@ const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
           onChangeText={setPaywallId}
         />
 
-        <TextInput
-          style={styles.input}
-          placeholder="Offering ID (optional)"
-          placeholderTextColor="#868e96"
-          value={offeringId}
-          onChangeText={setOfferingId}
-        />
+        <TouchableOpacity
+          accessibilityLabel="Track custom paywall impression without offering"
+          accessibilityRole="button"
+          style={styles.button}
+          onPress={trackImpressionWithoutOffering}>
+          <Text style={styles.buttonText}>
+            Track without Offering
+          </Text>
+        </TouchableOpacity>
 
         <TouchableOpacity
+          accessibilityLabel="Track custom paywall impression with offering"
+          accessibilityRole="button"
           style={styles.button}
-          onPress={trackImpression}>
+          onPress={showOfferingPicker}>
           <Text style={styles.buttonText}>
-            Track Custom Paywall Impression
+            Track with Offering
           </Text>
         </TouchableOpacity>
 
@@ -90,12 +196,19 @@ const CustomPaywallScreen: React.FC<Props> = ({navigation}) => {
           </View>
         )}
 
+        {lastTrackedEvent && (
+          <View style={styles.eventContainer}>
+            <Text style={styles.eventTitle}>Last tracked event</Text>
+            <Text style={styles.eventText}>{lastTrackedEvent}</Text>
+          </View>
+        )}
+
         <TouchableOpacity
           style={styles.closeButton}
           onPress={() => navigation.goBack()}>
           <Text style={styles.closeButtonText}>Close</Text>
         </TouchableOpacity>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -106,7 +219,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#f8f9fa',
   },
   content: {
-    flex: 1,
+    flexGrow: 1,
     padding: 24,
     alignItems: 'center',
     justifyContent: 'center',
@@ -120,6 +233,12 @@ const styles = StyleSheet.create({
   description: {
     fontSize: 14,
     color: '#868e96',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  currentOfferingText: {
+    color: '#495057',
+    fontSize: 13,
     marginBottom: 24,
     textAlign: 'center',
   },
@@ -171,6 +290,26 @@ const styles = StyleSheet.create({
   errorText: {
     color: '#c92a2a',
     fontSize: 14,
+  },
+  eventContainer: {
+    width: '100%',
+    padding: 12,
+    borderRadius: 8,
+    backgroundColor: '#ffffff',
+    borderColor: '#ced4da',
+    borderWidth: 1,
+    marginBottom: 12,
+  },
+  eventTitle: {
+    color: '#212529',
+    fontSize: 14,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  eventText: {
+    color: '#495057',
+    fontFamily: 'Menlo',
+    fontSize: 11,
   },
   closeButton: {
     padding: 12,

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -602,6 +602,8 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
         <Divider />
         <View>
           <TouchableOpacity
+            accessibilityLabel="Custom Paywall Screen"
+            accessibilityRole="button"
             onPress={() => navigation.navigate('CustomPaywall')}>
             <Text style={styles.otherActions}>Custom Paywall Screen (track impression)</Text>
           </TouchableOpacity>

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -656,7 +656,8 @@ RCT_EXPORT_METHOD(recordPurchaseForProductID:(nonnull NSString *)productID
 
 RCT_EXPORT_METHOD(trackCustomPaywallImpression:(NSDictionary *)data) {
     if (@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)) {
-        [RCCommonFunctionality trackCustomPaywallImpression:data];
+        NSDictionary *eventData = data.mappingNSNullToNil ?: @{};
+        [RCCommonFunctionality trackCustomPaywallImpression:eventData];
     } else {
         NSLog(@"[Purchases] Warning: tried to call trackCustomPaywallImpression, but it's only available on iOS 15.0 or greater.");
     }

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -773,6 +773,7 @@ NativeModules.RNPurchases = {
   setDebugLogsEnabled: jest.fn(),
   setLogLevel: jest.fn(),
   setLogHandler: jest.fn(),
+  trackCustomPaywallImpression: jest.fn(),
   getCustomerInfo: jest.fn(),
   logIn: jest.fn(),
   logOut: jest.fn(),

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -102,6 +102,9 @@ export const browserNativeModuleRNPurchases = {
   setLogHandler: async (handler: (level: string, message: string) => void) => {
     PurchasesCommon.setLogHandler(handler);
   },
+  trackCustomPaywallImpression: async (_data: any) => {
+    methodNotSupportedOnWeb('trackCustomPaywallImpression');
+  },
   getCustomerInfo: async () => {
     ensurePurchasesConfigured();
     const customerInfo = await PurchasesCommon.getInstance().getCustomerInfo();

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -171,8 +171,17 @@ export type DebugEventListener = (event: DebugEvent) => void;
 export interface TrackCustomPaywallImpressionOptions {
   paywallId?: string | null;
   /**
+   * The offering associated with the custom paywall.
+   *
+   * Prefer passing the offering object when available so RevenueCat can track placement
+   * and targeting context for placement-resolved offerings.
+   */
+  offering?: PurchasesOffering | null;
+  /**
    * An optional identifier for the offering associated with the custom paywall.
    * If not provided, the SDK will use the current offering identifier from the cache.
+   *
+   * @deprecated Prefer passing `offering` when available.
    */
   offeringId?: string | null;
 }
@@ -2029,14 +2038,27 @@ export default class Purchases {
    *
    * @param params - Optional parameters for the impression event.
    * @param params.paywallId - Optional identifier for the custom paywall being shown.
-   * @param params.offeringId - Optional identifier for the offering associated with the custom paywall.
-   *   If not provided, the SDK will use the current offering identifier from the cache.
+   * @param params.offering - Optional offering associated with the custom paywall.
+   * @param params.offeringId - Deprecated. Prefer passing `offering` when available.
+   *   Optional identifier for the offering associated with the custom paywall. If not provided,
+   *   the SDK will use the current offering identifier from the cache.
    */
   public static async trackCustomPaywallImpression(
     params?: TrackCustomPaywallImpressionOptions
   ): Promise<void> {
     await throwIfNotConfigured();
-    RNPurchases.trackCustomPaywallImpression(params ?? {});
+
+    const options: TrackCustomPaywallImpressionOptions = params ?? {};
+    const presentedOfferingContext =
+      options.offering?.availablePackages?.[0]?.presentedOfferingContext;
+    const offeringId =
+      options.offering?.identifier ??
+      options.offeringId;
+    RNPurchases.trackCustomPaywallImpression({
+      paywallId: options.paywallId ?? null,
+      offeringId: offeringId ?? null,
+      presentedOfferingContext: presentedOfferingContext ?? null,
+    });
   }
 
   private static async throwIfAndroidPlatform() {


### PR DESCRIPTION
Based on PHC PR https://github.com/RevenueCat/purchases-hybrid-common/pull/1665.

## API

We will now send the `presentedOfferingContext` from the passed `Offering` along with the event. This PR adds the new API variant that takes an `Offering` instead of a plain string `offeringId`. The latter is now deprecated in favor of this new API variant. We will derive the `presentedOfferingContext` from this `Offering` and send it along with the request.

```
await Purchases.trackCustomPaywallImpression({ paywallId: "", offering })
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics event shape and bridge null-handling for paywall impressions; backward compatible via deprecated `offeringId` but incorrect offering/package data could skew placement analytics.
> 
> **Overview**
> **Custom paywall impression tracking** now accepts a `PurchasesOffering` via `trackCustomPaywallImpression({ offering, paywallId })`. The JS layer derives `offeringId` and `presentedOfferingContext` from the offering’s first available package (placement/targeting), prefers that over legacy `offeringId`, and always forwards a normalized native payload with explicit `null` fields.
> 
> **Native bridges** strip nulls before hybrid common on Android (`mapWithoutNullValues`, also reused for `setAppstackAttributionParams`) and map `NSNull` to omitted keys on iOS for this call. Tests, API testers, Jest mocks, web stub, and the purchase tester **Custom Paywall** screen were updated to exercise offering-based tracking and show the last tracked event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14227268e64d79467fed77c7d625e5d9bea2c4a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->