### PR TITLE
feat: Add setAppsFlyerConversionData

### DIFF
--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -552,6 +552,11 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
+    public void setAppsFlyerConversionData(ReadableMap data) {
+        SubscriberAttributesKt.setAppsFlyerConversionData(data == null ? null : data.toHashMap());
+    }
+
+    @ReactMethod
     public void canMakePayments(ReadableArray features, final Promise promise) {
         ArrayList<Integer> featureList = new ArrayList<>();
 

--- a/apitesters/attributes.ts
+++ b/apitesters/attributes.ts
@@ -27,6 +27,19 @@ async function checkAttributes(purchases: Purchases) {
   await Purchases.setKeyword(stringOrNull);
   await Purchases.setCreative(stringOrNull);
 
+  // Asserts the full AppsFlyer onInstallConversionData callback object is accepted as-is.
+  const conversionData = {
+    status: "success" as const,
+    type: "onInstallConversionDataLoaded" as const,
+    data: {
+      is_first_launch: "true",
+      media_source: "",
+      campaign: "",
+      af_status: "Organic",
+    } as { [key: string]: any },
+  };
+  await Purchases.setAppsFlyerConversionData(conversionData);
+
   await Purchases.collectDeviceIdentifiers();
   await Purchases.enableAdServicesAttributionTokenCollection();
 }

--- a/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
+++ b/examples/purchaseTesterTypescript/app/screens/HomeScreen.tsx
@@ -176,6 +176,31 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
     }
   };
 
+  const setAppsFlyerConversionData = async () => {
+    try {
+      // Mimics the object AppsFlyer's onInstallConversionData callback returns.
+      const conversionData = {
+        status: 'success',
+        type: 'onInstallConversionDataLoaded',
+        data: {
+          af_status: 'Non-organic',
+          media_source: 'test_media_source',
+          campaign: 'test_campaign',
+          adgroup: 'test_adgroup',
+          af_ad: 'test_ad',
+          af_keywords: 'test_keyword',
+          creative: 'test_creative',
+          is_first_launch: 'true',
+        },
+      };
+      await Purchases.setAppsFlyerConversionData(conversionData);
+      Alert.alert('Success', 'AppsFlyer conversion data set');
+    } catch (error) {
+      console.log('error setting AppsFlyer conversion data', error);
+      Alert.alert('Error', String(error));
+    }
+  };
+
   const setAppstackAttribution = () => {
     setPromptAppstackVisible(true);
   };
@@ -385,6 +410,12 @@ const HomeScreen: React.FC<Props> = ({navigation}) => {
           <TouchableOpacity onPress={setAppstackAttribution}>
             <Text style={styles.otherActions}>
               Set Appstack Attribution Params
+            </Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity onPress={setAppsFlyerConversionData}>
+            <Text style={styles.otherActions}>
+              Set AppsFlyer Conversion Data
             </Text>
           </TouchableOpacity>
 

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -475,6 +475,10 @@ RCT_EXPORT_METHOD(setCreative:(NSString *)creative) {
     [RCCommonFunctionality setCreative:creative.mappingNSNullToNil];
 }
 
+RCT_EXPORT_METHOD(setAppsFlyerConversionData:(NSDictionary *)data) {
+    [RCCommonFunctionality setAppsFlyerConversionData:data.mappingNSNullToNil];
+}
+
 RCT_EXPORT_METHOD(overridePreferredLocale:(nullable NSString *)locale) {
     [RCCommonFunctionality overridePreferredLocale:locale.mappingNSNullToNil];
 }

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -295,6 +295,9 @@ export const browserNativeModuleRNPurchases = {
   setCreative: async (_creative: string) => {
     methodNotSupportedOnWeb('setCreative');
   },
+  setAppsFlyerConversionData: async (_data: Record<string, any> | null) => {
+    methodNotSupportedOnWeb('setAppsFlyerConversionData');
+  },
   overridePreferredLocale: async (_locale: string | null) => {
     methodNotSupportedOnWeb('overridePreferredLocale');
   },

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -1763,6 +1763,25 @@ export default class Purchases {
   }
 
   /**
+   * Sets conversion data from AppsFlyer's onInstallConversionData callback. This extracts the
+   * relevant attribution fields from the AppsFlyer conversion data and sets the corresponding
+   * RevenueCat subscriber attributes ($mediaSource, $campaign, $adGroup, $ad, $keyword, $creative).
+   * Note that this method will never unset any attributes.
+   *
+   * Pass the object received in AppsFlyer's onInstallConversionData listener directly; the nested
+   * `data` field holds the conversion data that is forwarded to RevenueCat.
+   *
+   * @param conversionData The object from AppsFlyer's onInstallConversionData callback.
+   * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
+   */
+  public static async setAppsFlyerConversionData(conversionData: {
+    data: { [key: string]: any };
+  }): Promise<void> {
+    await throwIfNotConfigured();
+    RNPurchases.setAppsFlyerConversionData(conversionData?.data ?? null);
+  }
+
+  /**
    * Overrides the preferred UI locale used by RevenueCat UI components.
    * Pass null to clear the override and use the device's locale.
    *

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -1769,16 +1769,26 @@ export default class Purchases {
    * Note that this method will never unset any attributes.
    *
    * Pass the object received in AppsFlyer's onInstallConversionData listener directly; the nested
-   * `data` field holds the conversion data that is forwarded to RevenueCat.
+   * `data` field holds the conversion data that is forwarded to RevenueCat. The data is only
+   * forwarded when `status` is `"success"`; otherwise it is ignored.
    *
    * @param conversionData The object from AppsFlyer's onInstallConversionData callback.
    * @returns {Promise<void>} The promise will be rejected if configure has not been called yet.
    */
   public static async setAppsFlyerConversionData(conversionData: {
+    status: string;
     data: { [key: string]: any };
   }): Promise<void> {
     await throwIfNotConfigured();
-    RNPurchases.setAppsFlyerConversionData(conversionData?.data ?? null);
+    if (conversionData?.status !== 'success') {
+      // tslint:disable-next-line:no-console
+      console.warn(
+        `[RevenueCat] Ignoring AppsFlyer conversion data with status "${conversionData?.status}". ` +
+          `Conversion data is only forwarded when status is "success".`,
+      );
+      return;
+    }
+    RNPurchases.setAppsFlyerConversionData(conversionData.data ?? null);
   }
 
   /**


### PR DESCRIPTION
Adds `Purchases.setAppsFlyerConversionData`. Apps can pass the object received in AppsFlyer's `onInstallConversionData` listener directly; the SDK forwards the nested `data` to RevenueCat, which maps the conversion data onto the corresponding subscriber attributes.

```ts
appsFlyer.onInstallConversionData((res) => {
  Purchases.setAppsFlyerConversionData(res);
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive attribution API with status gating; no changes to purchases, auth, or billing flows. Mapping logic lives in the shared native hybrid layer.
> 
> **Overview**
> Adds **`Purchases.setAppsFlyerConversionData`** so apps can pass the AppsFlyer `onInstallConversionData` callback object through the React Native SDK. The JS layer only forwards the nested **`data`** payload when **`status`** is `"success"` (otherwise it logs a warning and returns); native iOS/Android bridge into hybrid **`SubscriberAttributesKt` / `RCCommonFunctionality`**, which map fields onto campaign subscriber attributes. Web gets an unsupported stub; API typings and the TypeScript purchase tester gain a manual test action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbcbb523427aee7c67ba9da9fd2874e575cd672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->