### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   rn: react-native-community/react-native@8.0.1
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@3.16.0
+  revenuecat: revenuecat/sdks-common-config@3.21.2
 
 aliases:
   release-tags: &release-tags


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no runtime or application code changes, with low blast radius beyond pipeline behavior.
> 
> **Overview**
> Updates the CircleCI **`revenuecat/sdks-common-config`** orb from **3.16.0** to **3.21.2** in `.circleci/config.yml`.
> 
> This picks up upstream fixes (including for **`merge-release-pr`** failing after a successful merge) while keeping existing orb-backed jobs—release tagging, gem/Maestro setup, Danger, automatic bump, and hybrid-common upgrade—on the shared SDK config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3952e14ac0a7caf02e408ea4b62f7fbee415d8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->