### PR TITLE
feat: Add apitester coverage for new `SubscriptionInfo` fields

### DIFF
--- a/apitesters/customerInfo.ts
+++ b/apitesters/customerInfo.ts
@@ -3,7 +3,8 @@ import {
   CustomerInfo,
   PurchasesEntitlementInfo,
   PurchasesEntitlementInfos,
-  PurchasesStoreTransaction
+  PurchasesStoreTransaction,
+  PurchasesSubscriptionInfo
 } from "../src";
 
 function checkLoginResult(result: LogInResult) {
@@ -25,6 +26,29 @@ function checkCustomerInfo(info: CustomerInfo) {
   const originalPurchaseDate: string | null = info.originalPurchaseDate;
   const managementURL: string | null = info.managementURL;
   const nonSubscriptionTransactions: PurchasesStoreTransaction[] = info.nonSubscriptionTransactions;
+  const subscriptionsByProductIdentifier: { [p: string]: PurchasesSubscriptionInfo } = info.subscriptionsByProductIdentifier;
+}
+
+function checkSubscriptionInfo(info: PurchasesSubscriptionInfo) {
+  const productIdentifier: string = info.productIdentifier;
+  const purchaseDate: string = info.purchaseDate;
+  const originalPurchaseDate: string | null = info.originalPurchaseDate;
+  const expiresDate: string | null = info.expiresDate;
+  const store: string = info.store;
+  const unsubscribeDetectedAt: string | null = info.unsubscribeDetectedAt;
+  const isSandbox: boolean = info.isSandbox;
+  const billingIssuesDetectedAt: string | null = info.billingIssuesDetectedAt;
+  const gracePeriodExpiresDate: string | null = info.gracePeriodExpiresDate;
+  const ownershipType: string = info.ownershipType;
+  const periodType: string = info.periodType;
+  const refundedAt: string | null = info.refundedAt;
+  const storeTransactionId: string | null = info.storeTransactionId;
+  const isActive: boolean = info.isActive;
+  const willRenew: boolean = info.willRenew;
+  const autoResumeDate: string | null = info.autoResumeDate;
+  const displayName: string | null = info.displayName;
+  const managementURL: string | null = info.managementURL;
+  const productPlanIdentifier: string | null = info.productPlanIdentifier;
 }
 
 function checkEntitlementInfos(infos: PurchasesEntitlementInfos) {


### PR DESCRIPTION
Adds apitester coverage for the new SubscriptionInfo fields (autoResumeDate, displayName, managementURL, productPlanIdentifier) and subscriptionsByProductIdentifier on CustomerInfo. 

The field exposure itself shipped via the 18.18.0 auto-bump (#1830, https://github.com/RevenueCat/purchases-hybrid-common/pull/1698). Since this repo just passes that through, this PR just adds tests to verify the API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only TypeScript apitester updates with no production code, auth, or data-path changes.
> 
> **Overview**
> Extends **`apitesters/customerInfo.ts`** so CI’s `tsc -p apitesters` checks the public TypeScript surface for subscription data that arrived via the hybrid-common bump.
> 
> **`checkCustomerInfo`** now reads **`subscriptionsByProductIdentifier`**. A new **`checkSubscriptionInfo`** helper assigns every **`PurchasesSubscriptionInfo`** field, including **`autoResumeDate`**, **`displayName`**, **`managementURL`**, and **`productPlanIdentifier`**, plus the existing subscription metadata fields. No SDK or runtime behavior changes—only compile-time API verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee97978cd540164b755eb6c802121dc2222e571c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->