### PR TITLE
fix: move commit_current_changes outside Dir.chdir in update_sample_podfile_lock_with_retry

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -373,21 +373,22 @@ private_lane :update_sample_podfile_lock_with_retry do |options|
   pod_name = options[:pod_name]
 
   retry_attempts = 4 # Total of 4 retries, with the first attempt considered, equals 5 attempts over 20 minutes
-  Dir.chdir(File.expand_path("#{sample_path}/ios", get_root_folder)) do
-    begin
-      UI.message("ℹ️  Updating Podfile.lock with new version for #{pod_name}")
+  ios_dir = File.expand_path("#{sample_path}/ios", get_root_folder)
+  begin
+    UI.message("ℹ️  Updating Podfile.lock with new version for #{pod_name}")
+    Dir.chdir(ios_dir) do
       sh("pod update #{pod_name}")
-      commit_current_changes(commit_message: "Update Podfile.lock for #{pod_name}")
-    rescue => e
-      if retry_attempts > 0
-        UI.message("⚠️  Failed to update Podfile.lock for #{pod_name}: #{e.message}")
-        UI.message("⚠️  Retrying in 5 minutes...")
-        sleep(300) # wait for 5 minutes
-        retry_attempts -= 1
-        retry
-      else
-        UI.message("⚠️  Final attempt to update Podfile.lock for #{pod_name} failed. It's possible the pod has not been distributed yet. Proceeding without update.")
-      end
+    end
+    commit_current_changes(commit_message: "Update Podfile.lock for #{pod_name}")
+  rescue => e
+    if retry_attempts > 0
+      UI.message("⚠️  Failed to update Podfile.lock for #{pod_name}: #{e.message}")
+      UI.message("⚠️  Retrying in 5 minutes...")
+      sleep(300) # wait for 5 minutes
+      retry_attempts -= 1
+      retry
+    else
+      UI.message("⚠️  Final attempt to update Podfile.lock for #{pod_name} failed. It's possible the pod has not been distributed yet. Proceeding without update.")
     end
   end
 end


### PR DESCRIPTION
Same fastlane `Dir.chdir` + action bug as RevenueCat/purchases-flutter#1799.

`commit_current_changes` was called inside `Dir.chdir(<sample>/ios)`. fastlane's `Runner#execute_action` does its own `Dir.chdir("..")` before every action, expecting lane cwd = `fastlane/`. With the wrapper at `<sample>/ios`, `..` lands on `<sample>` (no `.git`), so `git add -u` fails with `fatal: not a git repository`.

Fix: extract `ios_dir`, wrap only `sh("pod update …")` in `Dir.chdir`, and move `commit_current_changes` outside so it runs at the normal lane cwd.

Introduced in #1591 (2026-02-12); latent until a bump-branch iOS retry actually triggers the lane.