### PR TITLE
feat(ads): reward-verification primitives for react-native

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2177,6 +2177,82 @@ describe("Purchases", () => {
 
   });
 
+  describe("generateRewardVerificationToken", () => {
+    describe("when Purchases is not configured", () => {
+      it("rejects", async () => {
+        NativeModules.RNPurchases.isConfigured.mockResolvedValueOnce(false);
+
+        try {
+          await Purchases.generateRewardVerificationToken("impression_1");
+          fail("expected error");
+        } catch (error) {}
+
+        expect(NativeModules.RNPurchases.generateRewardVerificationToken).toBeCalledTimes(0);
+      });
+    });
+
+    it("passes the impression id and returns the token", async () => {
+      const token = {
+        customData: "custom_data",
+        clientTransactionId: "client_transaction_1",
+        appUserID: "app_user_1",
+      };
+      NativeModules.RNPurchases.generateRewardVerificationToken.mockResolvedValueOnce(token);
+
+      const result = await Purchases.generateRewardVerificationToken("impression_1");
+
+      expect(NativeModules.RNPurchases.generateRewardVerificationToken).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.generateRewardVerificationToken).toBeCalledWith("impression_1");
+      expect(result).toEqual(token);
+    });
+  });
+
+  describe("pollRewardVerification", () => {
+    describe("when Purchases is not configured", () => {
+      it("rejects", async () => {
+        NativeModules.RNPurchases.isConfigured.mockResolvedValueOnce(false);
+
+        try {
+          await Purchases.pollRewardVerification("client_transaction_1");
+          fail("expected error");
+        } catch (error) {}
+
+        expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledTimes(0);
+      });
+    });
+
+    it("passes the transaction id and returns the verification result", async () => {
+      const verificationResult = {
+        failed: false,
+        reward: { type: "virtual_currency", code: "GOLD", amount: 100 },
+        moreRewards: [
+          {
+            type: "entitlement",
+            identifier: "premium",
+            expiresAt: "2026-07-01T00:00:00Z",
+            expiresAtMillis: 1782518400000,
+          },
+        ],
+      };
+      NativeModules.RNPurchases.pollRewardVerification.mockResolvedValueOnce(verificationResult);
+
+      const result = await Purchases.pollRewardVerification("client_transaction_1");
+
+      expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledTimes(1);
+      expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledWith("client_transaction_1");
+      expect(result).toEqual(verificationResult);
+    });
+
+    it("returns a failed result without rejecting", async () => {
+      const verificationResult = { failed: true, moreRewards: [] };
+      NativeModules.RNPurchases.pollRewardVerification.mockResolvedValueOnce(verificationResult);
+
+      const result = await Purchases.pollRewardVerification("client_transaction_1");
+
+      expect(result).toEqual(verificationResult);
+    });
+  });
+
   describe("adTracker", () => {
     const requiredDisplayedData = {
       mediatorName: "AdMob",

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -659,6 +659,16 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
         CommonKt.trackAdFailedToLoad(data.toHashMap());
     }
 
+    @ReactMethod
+    public void generateRewardVerificationToken(String impressionId, final Promise promise) {
+        promise.resolve(convertMapToWriteableMap(CommonKt.generateRewardVerificationToken(impressionId)));
+    }
+
+    @ReactMethod
+    public void pollRewardVerification(String clientTransactionId, final Promise promise) {
+        CommonKt.pollRewardVerification(clientTransactionId, getOnResult(promise));
+    }
+
     // endregion
 
     //================================================================================

--- a/apitesters/rewardVerification.ts
+++ b/apitesters/rewardVerification.ts
@@ -1,0 +1,51 @@
+import Purchases, {
+  RewardVerificationToken,
+  RewardVerificationResult,
+  VerifiedReward,
+  VerifiedVirtualCurrencyReward,
+  VerifiedEntitlementReward,
+  VerifiedNoReward,
+  VerifiedUnsupportedReward,
+} from "../src";
+
+async function checkGenerateRewardVerificationToken() {
+  const token: RewardVerificationToken =
+    await Purchases.generateRewardVerificationToken("imp-1");
+  const _customData: string = token.customData;
+  const _clientTransactionId: string = token.clientTransactionId;
+  const _appUserID: string = token.appUserID;
+}
+
+async function checkPollRewardVerification() {
+  const result: RewardVerificationResult =
+    await Purchases.pollRewardVerification("client-transaction-id");
+  const _failed: boolean = result.failed;
+  const _reward: VerifiedReward | undefined = result.reward;
+  const _moreRewards: VerifiedReward[] = result.moreRewards;
+}
+
+function checkVerifiedRewardTypes(reward: VerifiedReward) {
+  switch (reward.type) {
+    case "virtual_currency": {
+      const _r: VerifiedVirtualCurrencyReward = reward;
+      const _code: string = reward.code;
+      const _amount: number = reward.amount;
+      break;
+    }
+    case "entitlement": {
+      const _r: VerifiedEntitlementReward = reward;
+      const _identifier: string = reward.identifier;
+      const _expiresAt: string = reward.expiresAt;
+      const _expiresAtMillis: number = reward.expiresAtMillis;
+      break;
+    }
+    case "no_reward": {
+      const _r: VerifiedNoReward = reward;
+      break;
+    }
+    case "unsupported_reward": {
+      const _r: VerifiedUnsupportedReward = reward;
+      break;
+    }
+  }
+}

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -711,6 +711,20 @@ RCT_EXPORT_METHOD(trackAdFailedToLoad:(NSDictionary *)data) {
     }
 }
 
+RCT_EXPORT_METHOD(generateRewardVerificationToken:(NSString *)impressionId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    resolve([RCCommonFunctionality generateRewardVerificationTokenWithImpressionId:impressionId]);
+}
+
+RCT_EXPORT_METHOD(pollRewardVerification:(NSString *)clientTransactionId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
+                                                             completion:[self getResponseCompletionBlockWithResolve:resolve
+                                                                                                             reject:reject]];
+}
+
 #pragma mark -
 #pragma mark Delegate Methods
 - (void)purchases:(RCPurchases *)purchases receivedUpdatedCustomerInfo:(RCCustomerInfo *)customerInfo {

--- a/scripts/setupJest.js
+++ b/scripts/setupJest.js
@@ -816,7 +816,9 @@ NativeModules.RNPurchases = {
   trackAdOpened: jest.fn(),
   trackAdLoaded: jest.fn(),
   trackAdRevenue: jest.fn(),
-  trackAdFailedToLoad: jest.fn()
+  trackAdFailedToLoad: jest.fn(),
+  generateRewardVerificationToken: jest.fn(),
+  pollRewardVerification: jest.fn()
 };
 
 jest.mock(

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -361,4 +361,10 @@ export const browserNativeModuleRNPurchases = {
   trackAdFailedToLoad: async (_data: any) => {
     methodNotSupportedOnWeb('trackAdFailedToLoad');
   },
+  generateRewardVerificationToken: async (_impressionId: string) => {
+    methodNotSupportedOnWeb('generateRewardVerificationToken');
+  },
+  pollRewardVerification: async (_clientTransactionId: string) => {
+    methodNotSupportedOnWeb('pollRewardVerification');
+  },
 };

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -278,6 +278,68 @@ export interface AdFailedToLoadData {
   placement?: string | null;
 }
 
+/**
+ * Token generated for a rewarded ad impression. Pass `clientTransactionId` to
+ * the ad network as server-side verification custom data, then to
+ * {@link Purchases.pollRewardVerification} to await the reward.
+ * @beta
+ */
+export interface RewardVerificationToken {
+  customData: string;
+  clientTransactionId: string;
+  appUserID: string;
+}
+
+/**
+ * A reward granted after a verified rewarded ad. Discriminated by `type`.
+ * @beta
+ */
+export type VerifiedReward =
+  | VerifiedVirtualCurrencyReward
+  | VerifiedEntitlementReward
+  | VerifiedNoReward
+  | VerifiedUnsupportedReward;
+
+/** @beta */
+export interface VerifiedVirtualCurrencyReward {
+  type: "virtual_currency";
+  code: string;
+  amount: number;
+}
+
+/** @beta */
+export interface VerifiedEntitlementReward {
+  type: "entitlement";
+  identifier: string;
+  /** ISO 8601 expiration date string. */
+  expiresAt: string;
+  /** Expiration date in milliseconds since epoch. */
+  expiresAtMillis: number;
+}
+
+/** Verification completed but nothing was granted. @beta */
+export interface VerifiedNoReward {
+  type: "no_reward";
+}
+
+/** Verification completed but the reward type isn't modeled by this SDK version. @beta */
+export interface VerifiedUnsupportedReward {
+  type: "unsupported_reward";
+}
+
+/**
+ * Result of polling for reward verification.
+ * @beta
+ */
+export interface RewardVerificationResult {
+  /** The primary reward when verification succeeded; absent on failure. */
+  reward?: VerifiedReward;
+  /** Additional rewards granted alongside the primary; never repeats it; empty on failure. */
+  moreRewards: VerifiedReward[];
+  /** True when verification did not complete (rejected / timeout / network). */
+  failed: boolean;
+}
+
 let debugEventListeners: DebugEventListener[] = [];
 
 eventEmitter?.addListener(
@@ -2063,6 +2125,43 @@ export default class Purchases {
       offeringId: offeringId ?? null,
       presentedOfferingContext: presentedOfferingContext ?? null,
     });
+  }
+
+  /**
+   * Generates a reward verification token for a rewarded ad impression.
+   *
+   * Pass the returned `clientTransactionId` to the ad network as the
+   * server-side verification custom data. After the ad completes, pass the same
+   * id to {@link Purchases.pollRewardVerification} to await the reward.
+   *
+   * @param impressionId - The impression identifier of the rewarded ad.
+   * @returns {Promise<RewardVerificationToken>} promise with the generated token.
+   * @beta
+   */
+  public static async generateRewardVerificationToken(
+    impressionId: string
+  ): Promise<RewardVerificationToken> {
+    await throwIfNotConfigured();
+    return RNPurchases.generateRewardVerificationToken(impressionId);
+  }
+
+  /**
+   * Polls RevenueCat for the reward verification result of a rewarded ad.
+   *
+   * The returned promise stays pending while the native poller runs (up to
+   * ~10-30s) and resolves once verification completes or times out. A timed-out
+   * or rejected verification resolves with `failed: true` rather than rejecting.
+   *
+   * @param clientTransactionId - The `clientTransactionId` from
+   *   {@link Purchases.generateRewardVerificationToken}.
+   * @returns {Promise<RewardVerificationResult>} promise with the verification result.
+   * @beta
+   */
+  public static async pollRewardVerification(
+    clientTransactionId: string
+  ): Promise<RewardVerificationResult> {
+    await throwIfNotConfigured();
+    return RNPurchases.pollRewardVerification(clientTransactionId);
   }
 
   private static async throwIfAndroidPlatform() {


### PR DESCRIPTION
## Description

Exposes the rewarded ad verification primitives so it can be used with react-native admob libraries.

Verified locally e2e with ios simulators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New beta ad-reward path can affect entitlements and virtual currency when misused, but it follows existing ad-tracking bridge patterns and gates on SDK configuration.
> 
> **Overview**
> Adds **beta** rewarded-ad verification to the React Native SDK so apps can pair RevenueCat with AdMob-style server-side verification.
> 
> **`Purchases.generateRewardVerificationToken(impressionId)`** returns a token (`customData`, `clientTransactionId`, `appUserID`). The app passes `clientTransactionId` to the ad network as SSV custom data.
> 
> **`Purchases.pollRewardVerification(clientTransactionId)`** waits on the native poller and resolves with **`RewardVerificationResult`** (`failed`, optional `reward`, `moreRewards`). Failed verification resolves with `failed: true` instead of rejecting the promise.
> 
> New exported types include **`VerifiedReward`** (virtual currency, entitlement, no reward, unsupported) and related interfaces. iOS and Android native modules delegate to hybrid **`CommonKt` / `RCCommonFunctionality`**; web stubs report not supported. Jest mocks, unit tests, and **`apitesters/rewardVerification.ts`** cover the surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8589528be1be8167a11d6f2776f009b6538a96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->