### PR TITLE
Add quantity to purchasePackage and purchaseStoreProduct (iOS)

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -228,14 +228,14 @@ describe("Purchases", () => {
 
     await Purchases.purchaseProduct("onemonth_freetrial")
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", undefined, "subs", null, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
       oldSKU: "viejo"
     }, Purchases.PRODUCT_CATEGORY.NON_SUBSCRIPTION)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PRODUCT_CATEGORY.NON_SUBSCRIPTION, null, null, null);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {oldSKU: "viejo"}, Purchases.PRODUCT_CATEGORY.NON_SUBSCRIPTION, null, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(2);
 
     await Purchases.purchaseProduct("onemonth_freetrial", {
@@ -246,7 +246,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith("onemonth_freetrial", {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, Purchases.PURCHASE_TYPE.INAPP, null, null, null);
+    }, Purchases.PURCHASE_TYPE.INAPP, null, null, null, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(3);
   });
 
@@ -280,7 +280,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth",{offeringIdentifier: "offering"}, {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, null, null);
+    }, null, null, null);
   });
 
   it("purchaseStoreProduct works", async () => {
@@ -297,7 +297,7 @@ describe("Purchases", () => {
 
     await Purchases.purchaseStoreProduct(aProduct)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, undefined, Purchases.PRODUCT_CATEGORY.SUBSCRIPTION, null, null, {offeringIdentifier: "the-offerings"});
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, undefined, Purchases.PRODUCT_CATEGORY.SUBSCRIPTION, null, null, {offeringIdentifier: "the-offerings"}, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 
@@ -325,7 +325,8 @@ describe("Purchases", () => {
       Purchases.PRODUCT_CATEGORY.SUBSCRIPTION,
       null,
       null,
-      {offeringIdentifier: "the-offerings"}
+      {offeringIdentifier: "the-offerings"},
+      null
     );
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
@@ -354,7 +355,8 @@ describe("Purchases", () => {
       Purchases.PRODUCT_CATEGORY.SUBSCRIPTION,
       null,
       {isPersonalizedPrice: true},
-      {offeringIdentifier: "the-offerings"}
+      {offeringIdentifier: "the-offerings"},
+      null
     );
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
@@ -383,7 +385,8 @@ describe("Purchases", () => {
       Purchases.PRODUCT_CATEGORY.SUBSCRIPTION,
       null,
       null,
-      {offeringIdentifier: "the-offerings"}
+      {offeringIdentifier: "the-offerings"},
+      null
     );
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
@@ -408,7 +411,34 @@ describe("Purchases", () => {
       Purchases.PRODUCT_CATEGORY.SUBSCRIPTION,
       null,
       null,
-      {offeringIdentifier: "the-offerings"}
+      {offeringIdentifier: "the-offerings"},
+      null
+    );
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
+  });
+
+  it("purchaseStoreProduct forwards quantity", async () => {
+    NativeModules.RNPurchases.purchaseProduct.mockResolvedValue({
+      purchasedProductIdentifier: "123",
+      customerInfo: customerInfoStub,
+      transaction: transactionStub
+    });
+
+    const aProduct = {
+      ...productStub,
+      presentedOfferingContext: {offeringIdentifier: "the-offerings"}
+    }
+
+    await Purchases.purchaseStoreProduct(aProduct, null, null, 3)
+
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(
+      aProduct.identifier,
+      null,
+      Purchases.PRODUCT_CATEGORY.SUBSCRIPTION,
+      null,
+      null,
+      {offeringIdentifier: "the-offerings"},
+      3
     );
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
@@ -437,7 +467,7 @@ describe("Purchases", () => {
         presentedOfferingContext: {offeringIdentifier: "offering"},
       });
 
-    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, undefined, null, null);
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, undefined, null, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
 
     await Purchases.purchasePackage(
@@ -464,7 +494,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, {
       oldSKU: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, null, null);
+    }, null, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(2);
     await Purchases.purchasePackage(
       {
@@ -489,7 +519,7 @@ describe("Purchases", () => {
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith("$rc_onemonth", {offeringIdentifier: "offering"}, {
       oldProductIdentifier: "viejo",
       prorationMode: Purchases.PRORATION_MODE.IMMEDIATE_AND_CHARGE_FULL_PRICE
-    }, null, null);
+    }, null, null, null);
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(3);
   });
 
@@ -517,6 +547,7 @@ describe("Purchases", () => {
       "$rc_onemonth",
       {offeringIdentifier: "offering"},
       productChangeInfo,
+      null,
       null,
       null
     );
@@ -548,7 +579,8 @@ describe("Purchases", () => {
       {offeringIdentifier: "offering"},
       productChangeInfo,
       null,
-      {isPersonalizedPrice: true}
+      {isPersonalizedPrice: true},
+      null
     );
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
   });
@@ -578,6 +610,7 @@ describe("Purchases", () => {
       {offeringIdentifier: "offering"},
       googleProductChangeInfo,
       null,
+      null,
       null
     );
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
@@ -604,7 +637,35 @@ describe("Purchases", () => {
       {offeringIdentifier: "offering"},
       null,
       null,
+      null,
       null
+    );
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
+  });
+
+  it("purchasePackage forwards quantity", async () => {
+    NativeModules.RNPurchases.purchasePackage.mockResolvedValue({
+      purchasedProductIdentifier: "123",
+      customerInfo: customerInfoStub,
+      transaction: transactionStub
+    });
+
+    const aPackage = {
+      identifier: "$rc_onemonth",
+      packageType: Purchases.PACKAGE_TYPE.MONTHLY,
+      product: productStub,
+      presentedOfferingContext: {offeringIdentifier: "offering"},
+    }
+
+    await Purchases.purchasePackage(aPackage, null, null, null, 5)
+
+    expect(NativeModules.RNPurchases.purchasePackage).toBeCalledWith(
+      "$rc_onemonth",
+      {offeringIdentifier: "offering"},
+      null,
+      null,
+      null,
+      5
     );
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);
   });
@@ -1418,7 +1479,7 @@ describe("Purchases", () => {
 
     await Purchases.purchaseDiscountedProduct(aProduct, promotionalOfferStub)
 
-    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null, undefined);
+    expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledWith(aProduct.identifier, null, null, promotionalOfferStub.timestamp.toString(), null, undefined, null);
     expect(NativeModules.RNPurchases.purchaseProduct).toBeCalledTimes(1);
   });
 
@@ -1457,6 +1518,7 @@ describe("Purchases", () => {
       aPackage.presentedOfferingContext,
       null,
       promotionalOfferStub.timestamp.toString(),
+      null,
       null
     );
     expect(NativeModules.RNPurchases.purchasePackage).toBeCalledTimes(1);

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -179,6 +180,10 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
                                 @Nullable final ReadableMap presentedOfferingContext,
+                                // `quantity` is iOS-only. Google Play does not accept a purchase quantity ahead of
+                                // time: for multi-quantity products the user picks the quantity in Google Play's
+                                // purchase UI and the app reads it back via Purchase.getQuantity(). Ignored here.
+                                @Nullable final Dynamic quantity,
                                 final Promise promise) {
         UpgradeInfo upgradeInfo = getUpgradeInfo(googleProductChangeInfo);
 
@@ -211,6 +216,10 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
                                 @Nullable final ReadableMap googleProductChangeInfo,
                                 @Nullable final String discountTimestamp,
                                 @Nullable final ReadableMap googleInfo,
+                                // `quantity` is iOS-only. Google Play does not accept a purchase quantity ahead of
+                                // time: for multi-quantity products the user picks the quantity in Google Play's
+                                // purchase UI and the app reads it back via Purchase.getQuantity(). Ignored here.
+                                @Nullable final Dynamic quantity,
                                 final Promise promise) {
         UpgradeInfo upgradeInfo = getUpgradeInfo(googleProductChangeInfo);
 

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -162,10 +162,12 @@ RCT_REMAP_METHOD(purchaseProduct,
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
                  googleInfo:(NSDictionary *)googleInfo
                  presentedOfferingContext:(NSDictionary *)presentedOfferingDictionary
+                 quantity:(NSNumber *)quantity
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchaseProduct:productIdentifier.mappingNSNullToNil
                    signedDiscountTimestamp:signedDiscountTimestamp.mappingNSNullToNil
+                                  quantity:quantity.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
 }
 
@@ -176,11 +178,13 @@ RCT_REMAP_METHOD(purchasePackage,
                  upgradeInfo:(NSDictionary *)upgradeInfo
                  signedDiscountTimestamp:(NSString *)signedDiscountTimestamp
                  googleInfo:(NSDictionary *)googleInfo
+                 quantity:(NSNumber *)quantity
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality purchasePackage:packageIdentifier.mappingNSNullToNil
                   presentedOfferingContext:presentedOfferingContext.mappingNSNullToNil
                    signedDiscountTimestamp:signedDiscountTimestamp.mappingNSNullToNil
+                                  quantity:quantity.mappingNSNullToNil
                            completionBlock:[self getResponseCompletionBlockWithResolve:resolve reject:reject]];
 }
 

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -156,7 +156,8 @@ export const browserNativeModuleRNPurchases = {
     _type: string,
     _discountTimestamp: string | null,
     _googleInfo: any,
-    _presentedOfferingContext: any
+    _presentedOfferingContext: any,
+    _quantity?: number | null
   ) => {
     methodNotSupportedOnWeb('purchaseProduct');
   },
@@ -165,7 +166,8 @@ export const browserNativeModuleRNPurchases = {
     presentedOfferingContext: any,
     _googleProductChangeInfo: any,
     _discountTimestamp: string | null,
-    _googleInfo: any
+    _googleInfo: any,
+    _quantity?: number | null
   ): Promise<MakePurchaseResult> => {
     ensurePurchasesConfigured();
 

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -760,6 +760,7 @@ export default class Purchases {
       type,
       null,
       null,
+      null,
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
@@ -777,6 +778,10 @@ export default class Purchases {
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customized for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+   * @param {number} quantity iOS only. Optional number of items to purchase, for consumable / one-time products.
+   * Must be between 1 and 10 (inclusive); defaults to the App Store's default quantity (typically 1) when omitted.
+   * Has no effect on Android — Google Play does not accept a purchase quantity ahead of time (for multi-quantity
+   * products the user selects the quantity in Google Play's purchase UI) — and it is ignored on web.
    * @returns {Promise<{ productIdentifier: string, customerInfo:CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code,
    * a boolean indicating if the user cancelled the purchase, and an object with more information. The promise will
@@ -785,7 +790,8 @@ export default class Purchases {
   public static async purchaseStoreProduct(
     product: PurchasesStoreProduct,
     productChangeInfo?: GoogleProductChangeInfo | StoreProductChangeInfo | null,
-    googleIsPersonalizedPrice?: boolean | null
+    googleIsPersonalizedPrice?: boolean | null,
+    quantity?: number | null
   ): Promise<MakePurchaseResult> {
     await throwIfNotConfigured();
     return RNPurchases.purchaseProduct(
@@ -796,7 +802,8 @@ export default class Purchases {
       googleIsPersonalizedPrice == null
         ? null
         : { isPersonalizedPrice: googleIsPersonalizedPrice },
-      product.presentedOfferingContext
+      product.presentedOfferingContext,
+      quantity == null ? null : quantity
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -831,7 +838,8 @@ export default class Purchases {
       null,
       discount.timestamp.toString(),
       null,
-      product.presentedOfferingContext
+      product.presentedOfferingContext,
+      null
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -849,6 +857,10 @@ export default class Purchases {
    * @param {boolean} googleIsPersonalizedPrice Android and Google only. Optional boolean indicates personalized pricing on products available for purchase in the EU.
    * For compliance with EU regulations. User will see "This price has been customized for you" in the purchase dialog when true.
    * See https://developer.android.com/google/play/billing/integrate#personalized-price for more info.
+   * @param {number} quantity iOS only. Optional number of items to purchase, for consumable / one-time products.
+   * Must be between 1 and 10 (inclusive); defaults to the App Store's default quantity (typically 1) when omitted.
+   * Has no effect on Android — Google Play does not accept a purchase quantity ahead of time (for multi-quantity
+   * products the user selects the quantity in Google Play's purchase UI) — and it is ignored on web.
    * @returns {Promise<{ productIdentifier: string, customerInfo: CustomerInfo }>} A promise of an object containing
    * a customer info object and a product identifier. Rejections return an error code, a boolean indicating if the
    * user cancelled the purchase, and an object with more information. The promise will be also be rejected if configure
@@ -858,7 +870,8 @@ export default class Purchases {
     aPackage: PurchasesPackage,
     upgradeInfo?: UpgradeInfo | null,
     productChangeInfo?: GoogleProductChangeInfo | StoreProductChangeInfo | null,
-    googleIsPersonalizedPrice?: boolean | null
+    googleIsPersonalizedPrice?: boolean | null,
+    quantity?: number | null
   ): Promise<MakePurchaseResult> {
     await throwIfNotConfigured();
     return RNPurchases.purchasePackage(
@@ -868,7 +881,8 @@ export default class Purchases {
       null,
       googleIsPersonalizedPrice == null
         ? null
-        : { isPersonalizedPrice: googleIsPersonalizedPrice }
+        : { isPersonalizedPrice: googleIsPersonalizedPrice },
+      quantity == null ? null : quantity
     ).catch((error: PurchasesError) => {
       error.userCancelled =
         error.code === PURCHASES_ERROR_CODE.PURCHASE_CANCELLED_ERROR;
@@ -936,6 +950,7 @@ export default class Purchases {
       aPackage.presentedOfferingContext,
       null,
       discount.timestamp.toString(),
+      null,
       null
     ).catch((error: PurchasesError) => {
       error.userCancelled =


### PR DESCRIPTION
## Description

Adds an optional, iOS-only `quantity` parameter to `Purchases.purchasePackage` and `Purchases.purchaseStoreProduct`, for purchasing multiple of an App Store consumable (range 1–10). Maps to `PurchaseParams.Builder.with(quantity:)` via PurchasesHybridCommon.

### Platform support
**iOS only.** Google Play Billing has no API to set a purchase quantity ahead of time — for multi-quantity products the user picks the quantity in Google Play's purchase UI and the app reads it back after purchase — so the Android module accepts and ignores the parameter, and it's a no-op on web.

### Changes
- `src/purchases.ts`: new optional `quantity?` on `purchasePackage` and `purchaseStoreProduct`. The other callers of the shared native `purchaseProduct`/`purchasePackage` methods (`purchaseProduct`, `purchaseDiscountedProduct`, `purchaseDiscountedPackage`) pass a trailing `null` so the bridge argument counts stay consistent.
- iOS (`RNPurchases.m`): forwards `quantity` to PHC's new `…:quantity:…` selectors.
- Android (`RNPurchasesModule.java`): accepts the arg (`Dynamic`) and ignores it.
- Browser (`src/browser/nativeModule.ts`): accepts and no-ops.
- Tests: existing native-call assertions updated for the trailing arg; new `purchasePackage`/`purchaseStoreProduct` quantity tests. All 234 pass.

### ⚠️ Draft — depends on PurchasesHybridCommon
The native iOS code calls new PHC selectors, so this needs:
1. RevenueCat/purchases-hybrid-common#1721 merged and released.
2. Bumping the PHC pins here (`RNPurchases.podspec`, `android/build.gradle`, `@revenuecat/purchases-js-hybrid-mappings`, and the vendored `ios/PurchasesHybridCommon.framework`) to that release.

The TypeScript layer and Jest tests are independent and pass today; the iOS/Android native build resolves the new selectors once the PHC bump lands.

> Note: please add the `pr:feat` label — I don't have write access to set it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)