### PR TITLE
ci: bump sdks-common-config orb to 4.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   rn: react-native-community/react-native@8.0.1
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@4.4.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
 
 aliases:
   release-tags: &release-tags


### PR DESCRIPTION
### Motivation

`danger` and `automatic-bump` relied on the orb's old default Ruby `3.1.2`, which no longer satisfies gems requiring Ruby >= 3.2 — `bundle install` fails as Bundler backtracks to an unbuildable `nokogiri`.

### Summary

- Bump `revenuecat/sdks-common-config` to `4.5.0`, whose `danger`/`automatic-bump` default to Ruby 3.2.0 (sdks-circleci-orb#81).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI orb version pin with no application or runtime code changes; risk is limited to CircleCI job behavior for shared RevenueCat workflows.
> 
> **Overview**
> Bumps the CircleCI **`revenuecat/sdks-common-config`** orb from **4.4.0** to **4.5.0** so shared jobs (notably **`revenuecat/danger`** and **`revenuecat/automatic-bump`**) run on the orb’s updated Ruby **3.2.0** default instead of **3.1.2**.
> 
> This unblocks **`bundle install`** when gems require Ruby ≥ 3.2, which previously caused Bundler to backtrack to an unbuildable **`nokogiri`** resolution on the old orb.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a20157b034138e6ee0b488ae41fefacc6aa62c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->