### PR TITLE
chore: bump fastlane-plugin-revenuecat_internal to unblock hybrid bumps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 9e334ffd854233f1b11da13d6f90fb8e6c30e36f
+  revision: 9b928b6ca92e965ecb7d63edb810e9343975f3de
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Motivation
Hybrid version bumps crash in `update_hybrids_versions_file` with `undefined method 'captures' for nil:NilClass`, because the plugin looked up a removed `bc8` key in purchases-android's `libs.versions.toml`.

### Summary
- Bump the pinned `fastlane-plugin-revenuecat_internal` revision to `main` HEAD, which includes the fix (RevenueCat/fastlane-plugin-revenuecat_internal#145).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency pin for internal Fastlane tooling; no runtime app or security surface changes.
> 
> **Overview**
> Pins **`fastlane-plugin-revenuecat_internal`** in `Gemfile.lock` to a newer git revision (`9b928b6…`) so hybrid version-bump automation picks up upstream fix **#145**.
> 
> That change stops `update_hybrids_versions_file` from crashing with `undefined method 'captures' for nil:NilClass` when the plugin still expected a removed `bc8` entry in purchases-android’s `libs.versions.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca29da8ffbb3220a103287d91417c7b8e2540fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->