### PR TITLE
[HOLD] chore: bump sample app to Android target SDK 36

### DIFF
--- a/examples/purchaseTesterTypescript/android/build.gradle
+++ b/examples/purchaseTesterTypescript/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.11.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }


### PR DESCRIPTION
Bumps the `purchaseTesterTypescript` sample app to Android target SDK 36 (Android 16), so it runs with predictive back and edge-to-edge enabled by default.

- `compileSdk` / `targetSdk` / `buildTools`: 35 → 36
- AGP: 8.8.0 → 8.11.1 (8.8.0 predates compileSdk 36)

`purchaseTesterExpo` already targets 36 via Expo SDK 54, so it needs no change.

Holding until we make sure #1854 is not needed, so it's easier to test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-app-only Gradle version bumps with no library, auth, or production runtime changes.
> 
> **Overview**
> Updates the **`purchaseTesterTypescript`** sample’s root `android/build.gradle` so it builds and targets **Android API 36** (Android 16), aligning the sample with newer platform defaults (e.g. predictive back and edge-to-edge).
> 
> **SDK / tools:** `buildToolsVersion` **35.0.0 → 36.0.0**, `compileSdkVersion` and `targetSdkVersion` **35 → 36**. `minSdkVersion` stays **24**.
> 
> **Build:** Pins **Android Gradle Plugin** to **8.11.1** (classpath was previously unpinned) so the toolchain supports `compileSdk` 36.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25663d5d27cc0838fbca751e91a0f3a734b97ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->