### PR TITLE
Add onWebCheckoutOpened and onUrlOpened to the paywall listener

### DIFF
--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -167,6 +167,8 @@ const onRestoreError = ({ error }: { error: PurchasesError }) => {};
 
 const onDismiss = () => {};
 
+const onWebCheckoutOpened = () => {};
+
 const PaywallScreen = () => {
   return (
     <RevenueCatUI.Paywall
@@ -220,6 +222,7 @@ const PaywallScreenWithOfferingAndEvents = (
       onRestoreError={onRestoreError}
       onDismiss={onDismiss}
       onPurchasePackageInitiated={onPurchasePackageInitiated}
+      onWebCheckoutOpened={onWebCheckoutOpened}
     />
   );
 };

--- a/apitesters/paywalls.tsx
+++ b/apitesters/paywalls.tsx
@@ -168,6 +168,7 @@ const onRestoreError = ({ error }: { error: PurchasesError }) => {};
 const onDismiss = () => {};
 
 const onWebCheckoutOpened = () => {};
+const onUrlOpened = (url: string) => {};
 
 const PaywallScreen = () => {
   return (
@@ -223,6 +224,7 @@ const PaywallScreenWithOfferingAndEvents = (
       onDismiss={onDismiss}
       onPurchasePackageInitiated={onPurchasePackageInitiated}
       onWebCheckoutOpened={onWebCheckoutOpened}
+      onUrlOpened={onUrlOpened}
     />
   );
 };

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.react.ui.events.OnPurchaseStartedEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreCompletedEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreErrorEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreStartedEvent
+import com.revenuecat.purchases.react.ui.events.OnWebCheckoutOpenedEvent
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 import java.util.concurrent.ConcurrentHashMap
@@ -70,6 +71,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
             .putEvent(PaywallEventName.ON_PURCHASE_PACKAGE_INITIATED)
             .putEvent(PaywallEventName.ON_PERFORM_PURCHASE)
             .putEvent(PaywallEventName.ON_PERFORM_RESTORE)
+            .putEvent(PaywallEventName.ON_WEB_CHECKOUT_OPENED)
             .build()
     }
 
@@ -280,6 +282,14 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
                 viewTag = view.id,
                 rcPackage,
                 requestId,
+            )
+            emitEvent(themedReactContext, view.id, event)
+        }
+
+        override fun onWebCheckoutOpened() {
+            val event = OnWebCheckoutOpenedEvent(
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
             )
             emitEvent(themedReactContext, view.id, event)
         }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/BasePaywallViewManager.kt
@@ -26,6 +26,7 @@ import com.revenuecat.purchases.react.ui.events.OnPurchaseStartedEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreCompletedEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreErrorEvent
 import com.revenuecat.purchases.react.ui.events.OnRestoreStartedEvent
+import com.revenuecat.purchases.react.ui.events.OnUrlOpenedEvent
 import com.revenuecat.purchases.react.ui.events.OnWebCheckoutOpenedEvent
 import com.revenuecat.purchases.ui.revenuecatui.CustomVariableValue
 import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
@@ -72,6 +73,7 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
             .putEvent(PaywallEventName.ON_PERFORM_PURCHASE)
             .putEvent(PaywallEventName.ON_PERFORM_RESTORE)
             .putEvent(PaywallEventName.ON_WEB_CHECKOUT_OPENED)
+            .putEvent(PaywallEventName.ON_URL_OPENED)
             .build()
     }
 
@@ -290,6 +292,15 @@ internal abstract class BasePaywallViewManager<T : View> : SimpleViewManager<T>(
             val event = OnWebCheckoutOpenedEvent(
                 surfaceId = view.surfaceId,
                 viewTag = view.id,
+            )
+            emitEvent(themedReactContext, view.id, event)
+        }
+
+        override fun onUrlOpened(url: String) {
+            val event = OnUrlOpenedEvent(
+                surfaceId = view.surfaceId,
+                viewTag = view.id,
+                url = url,
             )
             emitEvent(themedReactContext, view.id, event)
         }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
@@ -13,7 +13,8 @@ internal enum class PaywallEventName(val eventName: String) {
     ON_PURCHASE_PACKAGE_INITIATED("onPurchasePackageInitiated"),
     ON_PERFORM_PURCHASE("onPerformPurchase"),
     ON_PERFORM_RESTORE("onPerformRestore"),
-    ON_WEB_CHECKOUT_OPENED("onWebCheckoutOpened");
+    ON_WEB_CHECKOUT_OPENED("onWebCheckoutOpened"),
+    ON_URL_OPENED("onUrlOpened");
 }
 
 internal enum class PaywallEventKey(val key: String) {
@@ -24,4 +25,5 @@ internal enum class PaywallEventKey(val key: String) {
     ERROR("error"),
     MEASUREMENTS("measurements"),
     HEIGHT("height"),
+    URL("url"),
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallEventName.kt
@@ -12,7 +12,8 @@ internal enum class PaywallEventName(val eventName: String) {
     ON_MEASURE("onMeasure"),
     ON_PURCHASE_PACKAGE_INITIATED("onPurchasePackageInitiated"),
     ON_PERFORM_PURCHASE("onPerformPurchase"),
-    ON_PERFORM_RESTORE("onPerformRestore");
+    ON_PERFORM_RESTORE("onPerformRestore"),
+    ON_WEB_CHECKOUT_OPENED("onWebCheckoutOpened");
 }
 
 internal enum class PaywallEventKey(val key: String) {

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnUrlOpenedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnUrlOpenedEvent.kt
@@ -1,0 +1,15 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+internal class OnUrlOpenedEvent(
+    surfaceId: Int,
+    viewTag: Int,
+    private val url: String,
+) : PaywallEvent<OnUrlOpenedEvent>(surfaceId, viewTag) {
+    override fun getPaywallEventName() = PaywallEventName.ON_URL_OPENED
+
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> =
+        mapOf(PaywallEventKey.URL to mapOf(PaywallEventKey.URL.key to url))
+}

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnUrlOpenedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnUrlOpenedEvent.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.react.ui.events
 
+import com.facebook.react.bridge.WritableMap
 import com.revenuecat.purchases.react.ui.PaywallEventKey
 import com.revenuecat.purchases.react.ui.PaywallEventName
 
@@ -10,6 +11,11 @@ internal class OnUrlOpenedEvent(
 ) : PaywallEvent<OnUrlOpenedEvent>(surfaceId, viewTag) {
     override fun getPaywallEventName() = PaywallEventName.ON_URL_OPENED
 
-    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> =
-        mapOf(PaywallEventKey.URL to mapOf(PaywallEventKey.URL.key to url))
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> = emptyMap()
+
+    override fun getEventData(): WritableMap {
+        return super.getEventData().apply {
+            putString(PaywallEventKey.URL.key, url)
+        }
+    }
 }

--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnWebCheckoutOpenedEvent.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/events/OnWebCheckoutOpenedEvent.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.react.ui.events
+
+import com.revenuecat.purchases.react.ui.PaywallEventKey
+import com.revenuecat.purchases.react.ui.PaywallEventName
+
+internal class OnWebCheckoutOpenedEvent(
+    surfaceId: Int,
+    viewTag: Int,
+) : PaywallEvent<OnWebCheckoutOpenedEvent>(surfaceId, viewTag) {
+    override fun getPaywallEventName() = PaywallEventName.ON_WEB_CHECKOUT_OPENED
+
+    override fun getPayload(): Map<PaywallEventKey, Map<String, Any?>> = emptyMap()
+}

--- a/react-native-purchases-ui/apitesters/paywalls.tsx
+++ b/react-native-purchases-ui/apitesters/paywalls.tsx
@@ -59,6 +59,7 @@ const paywallComponentProps: PaywallComponentProps = {
     void purchasesError;
   },
   onDismiss: () => {},
+  onWebCheckoutOpened: () => {},
 };
 
 void paywallComponentProps;
@@ -316,6 +317,8 @@ const onRestoreError = ({ error }: { error: PurchasesError }) => {
 
 const onDismiss = () => {};
 
+const onWebCheckoutOpened = () => {};
+
 const PaywallScreen = () => {
   return (
     <RevenueCatUI.Paywall
@@ -368,6 +371,7 @@ const PaywallScreenWithOfferingAndEvents = (
       onRestoreCompleted={onRestoreCompleted}
       onRestoreError={onRestoreError}
       onDismiss={onDismiss}
+      onWebCheckoutOpened={onWebCheckoutOpened}
     />
   );
 };

--- a/react-native-purchases-ui/apitesters/paywalls.tsx
+++ b/react-native-purchases-ui/apitesters/paywalls.tsx
@@ -60,6 +60,7 @@ const paywallComponentProps: PaywallComponentProps = {
   },
   onDismiss: () => {},
   onWebCheckoutOpened: () => {},
+  onUrlOpened: (url: string) => {},
 };
 
 void paywallComponentProps;
@@ -318,6 +319,7 @@ const onRestoreError = ({ error }: { error: PurchasesError }) => {
 const onDismiss = () => {};
 
 const onWebCheckoutOpened = () => {};
+const onUrlOpened = (url: string) => {};
 
 const PaywallScreen = () => {
   return (
@@ -372,6 +374,7 @@ const PaywallScreenWithOfferingAndEvents = (
       onRestoreError={onRestoreError}
       onDismiss={onDismiss}
       onWebCheckoutOpened={onWebCheckoutOpened}
+      onUrlOpened={onUrlOpened}
     />
   );
 };

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -33,6 +33,7 @@ RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPurchasePackageInitiated, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPerformPurchase, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPerformRestore, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onWebCheckoutOpened, RCTDirectEventBlock)
 
 RCT_EXPORT_MODULE(Paywall)
 

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPurchasePackageInitiated, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPerformPurchase, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPerformRestore, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onWebCheckoutOpened, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onUrlOpened, RCTDirectEventBlock)
 
 RCT_EXPORT_MODULE(Paywall)
 

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.h
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onPerformPurchase;
 @property (nonatomic, copy) RCTDirectEventBlock onPerformRestore;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onWebCheckoutOpened;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onUrlOpened;
 
 @property (nonatomic, strong, nullable) HybridPurchaseLogicBridge *purchaseLogicBridge;
 @property (nonatomic, copy, nullable) UIViewController * _Nullable (^createViewController)(HybridPurchaseLogicBridge * _Nonnull);

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.h
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onPurchasePackageInitiated;
 @property (nonatomic, copy) RCTDirectEventBlock onPerformPurchase;
 @property (nonatomic, copy) RCTDirectEventBlock onPerformRestore;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onWebCheckoutOpened;
 
 @property (nonatomic, strong, nullable) HybridPurchaseLogicBridge *purchaseLogicBridge;
 @property (nonatomic, copy, nullable) UIViewController * _Nullable (^createViewController)(HybridPurchaseLogicBridge * _Nonnull);

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -301,7 +301,7 @@ didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
 
 - (void)paywallViewController:(RCPaywallViewController *)controller didOpenURL:(NSString *)url API_AVAILABLE(ios(15.0)) {
     if (self.onUrlOpened) {
-        self.onUrlOpened(@{KeyUrl: @{KeyUrl: url ?: @""}});
+        self.onUrlOpened(@{KeyUrl: url ?: @""});
     }
 }
 

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -298,4 +298,10 @@ didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
     }
 }
 
+- (void)paywallViewController:(RCPaywallViewController *)controller didOpenURL:(NSURL *)url API_AVAILABLE(ios(15.0)) {
+    if (self.onUrlOpened) {
+        self.onUrlOpened(@{@"url": @{@"url": url.absoluteString ?: @""}});
+    }
+}
+
 @end

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -17,6 +17,7 @@ static NSString *const KeyCustomerInfo = @"customerInfo";
 static NSString *const KeyStoreTransaction = @"storeTransaction";
 static NSString *const KeyError = @"error";
 static NSString *const KeyPackage = @"packageBeingPurchased";
+static NSString *const KeyUrl = @"url";
 
 API_AVAILABLE(ios(15.0))
 @interface PaywallViewWrapper ()
@@ -300,7 +301,7 @@ didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
 
 - (void)paywallViewController:(RCPaywallViewController *)controller didOpenURL:(NSString *)url API_AVAILABLE(ios(15.0)) {
     if (self.onUrlOpened) {
-        self.onUrlOpened(@{@"url": @{@"url": url ?: @""}});
+        self.onUrlOpened(@{KeyUrl: @{KeyUrl: url ?: @""}});
     }
 }
 

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -298,9 +298,9 @@ didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
     }
 }
 
-- (void)paywallViewController:(RCPaywallViewController *)controller didOpenURL:(NSURL *)url API_AVAILABLE(ios(15.0)) {
+- (void)paywallViewController:(RCPaywallViewController *)controller didOpenURL:(NSString *)url API_AVAILABLE(ios(15.0)) {
     if (self.onUrlOpened) {
-        self.onUrlOpened(@{@"url": @{@"url": url.absoluteString ?: @""}});
+        self.onUrlOpened(@{@"url": @{@"url": url ?: @""}});
     }
 }
 

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -292,4 +292,10 @@ didInitiatePurchaseWithPackageDictionary:(NSDictionary *)packageDictionary
     }
 }
 
+- (void)paywallViewControllerDidOpenWebCheckout:(RCPaywallViewController *)controller API_AVAILABLE(ios(15.0)) {
+    if (self.onWebCheckoutOpened) {
+        self.onWebCheckoutOpened(nil);
+    }
+}
+
 @end

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -181,6 +181,7 @@ const InternalPaywall: React.FC<FullScreenPaywallViewProps> = ({
   onDismiss,
   onPurchasePackageInitiated,
   onWebCheckoutOpened,
+  onUrlOpened,
 }) => {
   const { nativeOptions, handlePerformPurchase, handlePerformRestore } = createPurchaseLogicHandlers(purchaseLogic);
 
@@ -230,6 +231,7 @@ const InternalPaywall: React.FC<FullScreenPaywallViewProps> = ({
         onPerformPurchase={handlePerformPurchase}
         onPerformRestore={handlePerformRestore}
         onWebCheckoutOpened={() => onWebCheckoutOpened && onWebCheckoutOpened()}
+        onUrlOpened={(event: any) => onUrlOpened && onUrlOpened(event.nativeEvent.url.url)}
       />
     );
   }
@@ -412,6 +414,7 @@ type FullScreenPaywallViewProps = {
     resume
   }: { packageBeingPurchased: PurchasesPackage, resume: (shouldResume: boolean) => void}) => void;
   onWebCheckoutOpened?: () => void;
+  onUrlOpened?: (url: string) => void;
 };
 
 type FooterPaywallViewProps = {
@@ -627,6 +630,7 @@ export default class RevenueCatUI {
                                                                    onDismiss,
                                                                    onPurchasePackageInitiated,
                                                                    onWebCheckoutOpened,
+                                                                   onUrlOpened,
                                                                  }) => {
     return (
       <InternalPaywall
@@ -643,6 +647,7 @@ export default class RevenueCatUI {
         onDismiss={onDismiss}
         onPurchasePackageInitiated={onPurchasePackageInitiated}
         onWebCheckoutOpened={onWebCheckoutOpened}
+        onUrlOpened={onUrlOpened}
         style={[{flex: 1}, style]}
       />
     );

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -180,6 +180,7 @@ const InternalPaywall: React.FC<FullScreenPaywallViewProps> = ({
   onRestoreError,
   onDismiss,
   onPurchasePackageInitiated,
+  onWebCheckoutOpened,
 }) => {
   const { nativeOptions, handlePerformPurchase, handlePerformRestore } = createPurchaseLogicHandlers(purchaseLogic);
 
@@ -228,6 +229,7 @@ const InternalPaywall: React.FC<FullScreenPaywallViewProps> = ({
         }}
         onPerformPurchase={handlePerformPurchase}
         onPerformRestore={handlePerformRestore}
+        onWebCheckoutOpened={() => onWebCheckoutOpened && onWebCheckoutOpened()}
       />
     );
   }
@@ -409,6 +411,7 @@ type FullScreenPaywallViewProps = {
     packageBeingPurchased, 
     resume
   }: { packageBeingPurchased: PurchasesPackage, resume: (shouldResume: boolean) => void}) => void;
+  onWebCheckoutOpened?: () => void;
 };
 
 type FooterPaywallViewProps = {
@@ -623,6 +626,7 @@ export default class RevenueCatUI {
                                                                    onRestoreError,
                                                                    onDismiss,
                                                                    onPurchasePackageInitiated,
+                                                                   onWebCheckoutOpened,
                                                                  }) => {
     return (
       <InternalPaywall
@@ -638,6 +642,7 @@ export default class RevenueCatUI {
         onRestoreError={onRestoreError}
         onDismiss={onDismiss}
         onPurchasePackageInitiated={onPurchasePackageInitiated}
+        onWebCheckoutOpened={onWebCheckoutOpened}
         style={[{flex: 1}, style]}
       />
     );

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -231,7 +231,7 @@ const InternalPaywall: React.FC<FullScreenPaywallViewProps> = ({
         onPerformPurchase={handlePerformPurchase}
         onPerformRestore={handlePerformRestore}
         onWebCheckoutOpened={() => onWebCheckoutOpened && onWebCheckoutOpened()}
-        onUrlOpened={(event: any) => onUrlOpened && onUrlOpened(event.nativeEvent.url.url)}
+        onUrlOpened={(event: any) => onUrlOpened && onUrlOpened(event.nativeEvent.url)}
       />
     );
   }


### PR DESCRIPTION
Adds `onWebCheckoutOpened` and `onUrlOpened` callbacks to the paywall listener, forwarding the native paywall listener events (available in PHC 18.29.0).

- `onWebCheckoutOpened`: the user tapped a web checkout CTA and left the app to pay externally.
- `onUrlOpened(url)`: the paywall opened a URL from a button URL destination or a text-component link. Not called for web checkout.

Exposes RevenueCat/purchases-hybrid-common#1776

Closes SDK-4398 (last one)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional listener props with no changes to purchase, restore, or auth flows; behavior only when apps opt in to the new callbacks.
> 
> **Overview**
> Adds optional **`onWebCheckoutOpened`** and **`onUrlOpened(url)`** props on **`RevenueCatUI.Paywall`**, wiring PHC paywall listener events through React Native on iOS and Android.
> 
> **`onWebCheckoutOpened`** runs when the user leaves the app via a web checkout CTA. **`onUrlOpened`** runs when the paywall opens a URL from a button destination or text link (not web checkout).
> 
> Native bridges register the new direct events (`OnWebCheckoutOpenedEvent`, `OnUrlOpenedEvent` with a `url` field). TypeScript types and apitesters are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d9f6bcfaf7d030015835b9f7cd489e207fde62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->