### PR TITLE
Add multipage to CHANGELOG

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,7 @@
 ## RevenueCat SDK
+### ✨ New Features
+* Enables support for multipage paywalls
+
 ### 📦 Dependency Updates
 * [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.28.0 (#1879) via RevenueCat Git Bot (@RCGitBot)
   * [Android 10.16.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.16.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 10.6.0
 ## RevenueCat SDK
+### ✨ New Features
+* Enables support for multipage paywalls
+
 ### 📦 Dependency Updates
 * [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.28.0 (#1879) via RevenueCat Git Bot (@RCGitBot)
   * [Android 10.16.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.16.0)
@@ -599,6 +602,8 @@ This release updates to Billing Library 8.3.0 with min SDK supported of Android 
 * Fix issue in iOS with incorrectly configured event (#1566) via Toni Rico (@tonidero)
 
 ## 9.7.4
+> [!CAUTION]
+> This release can cause crashes on app startup on iOS releases. We ask to update to 9.7.5+ instead
 ## RevenueCat SDK
 ### 📦 Dependency Updates
 * [AUTOMATIC BUMP] Updates purchases-hybrid-common to 17.30.1 (#1560) via RevenueCat Git Bot (@RCGitBot)


### PR DESCRIPTION
Adds the multipage paywall support entry under New Features in 10.6.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edits with no runtime or SDK behavior changes.
> 
> **Overview**
> Updates release notes so **10.6.0** documents multipage paywall support under **New Features** in both `CHANGELOG.latest.md` and `CHANGELOG.md`.
> 
> Also adds a **CAUTION** callout on the **9.7.4** section in `CHANGELOG.md` warning that that release can crash on iOS startup and recommending **9.7.5+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8d2c4a816e18e29e61bd6c3961b1060e343118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->