### PR TITLE
feat(ads): ad reward tracking support

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -2252,7 +2252,7 @@ describe("Purchases", () => {
       const result = await Purchases.pollRewardVerification("client_transaction_1");
 
       expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledTimes(1);
-      expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledWith("client_transaction_1");
+      expect(NativeModules.RNPurchases.pollRewardVerification).toBeCalledWith("client_transaction_1", undefined);
       expect(result).toEqual(verificationResult);
     });
 

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -666,8 +666,11 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     }
 
     @ReactMethod
-    public void pollRewardVerification(String clientTransactionId, final Promise promise) {
-        CommonKt.pollRewardVerification(clientTransactionId, getOnResult(promise));
+    public void pollRewardVerification(String clientTransactionId,
+                                       @Nullable ReadableMap trackingMetadata,
+                                       final Promise promise) {
+        Map<String, Object> mapTrackingMetadata = trackingMetadata != null ? trackingMetadata.toHashMap() : null;
+        CommonKt.pollRewardVerification(clientTransactionId, getOnResult(promise), mapTrackingMetadata);
     }
 
     // endregion

--- a/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
+++ b/android/src/main/java/com/revenuecat/purchases/react/RNPurchasesModule.java
@@ -669,7 +669,7 @@ public class RNPurchasesModule extends ReactContextBaseJavaModule implements Upd
     public void pollRewardVerification(String clientTransactionId,
                                        @Nullable ReadableMap trackingMetadata,
                                        final Promise promise) {
-        Map<String, Object> mapTrackingMetadata = trackingMetadata != null ? trackingMetadata.toHashMap() : null;
+        Map<String, Object> mapTrackingMetadata = trackingMetadata != null ? mapWithoutNullValues(trackingMetadata) : null;
         CommonKt.pollRewardVerification(clientTransactionId, getOnResult(promise), mapTrackingMetadata);
     }
 

--- a/apitesters/rewardVerification.ts
+++ b/apitesters/rewardVerification.ts
@@ -1,11 +1,14 @@
 import Purchases, {
   RewardVerificationToken,
   RewardVerificationResult,
+  RewardedAdTrackingMetadata,
   VerifiedReward,
   VerifiedVirtualCurrencyReward,
   VerifiedEntitlementReward,
   VerifiedNoReward,
   VerifiedUnsupportedReward,
+  AdMediatorName,
+  AdFormat,
 } from "../src";
 
 async function checkGenerateRewardVerificationToken() {
@@ -22,6 +25,22 @@ async function checkPollRewardVerification() {
   const _failed: boolean = result.failed;
   const _reward: VerifiedReward | undefined = result.reward;
   const _moreRewards: VerifiedReward[] = result.moreRewards;
+}
+
+async function checkPollRewardVerificationWithTrackingMetadata() {
+  const trackingMetadata: RewardedAdTrackingMetadata = {
+    mediatorName: AdMediatorName.adMob,
+    adFormat: AdFormat.rewarded,
+    adUnitId: "unit-1",
+    impressionId: "imp-1",
+    networkName: "AdNetwork",
+    placement: "home",
+  };
+  const result: RewardVerificationResult =
+    await Purchases.pollRewardVerification(
+      "client-transaction-id",
+      trackingMetadata
+    );
 }
 
 function checkVerifiedRewardTypes(reward: VerifiedReward) {

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -718,7 +718,7 @@ RCT_EXPORT_METHOD(pollRewardVerification:(NSString *)clientTransactionId
                                  resolve:(RCTPromiseResolveBlock)resolve
                                   reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
-                                                        trackingMetadata:trackingMetadata
+                                                        trackingMetadata:trackingMetadata.mappingNSNullToNil
                                                              completion:[self getResponseCompletionBlockWithResolve:resolve
                                                                                                              reject:reject]];
 }

--- a/ios/RNPurchases.m
+++ b/ios/RNPurchases.m
@@ -714,9 +714,11 @@ RCT_EXPORT_METHOD(generateRewardVerificationToken:(NSString *)impressionId
 }
 
 RCT_EXPORT_METHOD(pollRewardVerification:(NSString *)clientTransactionId
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject) {
+                        trackingMetadata:(nullable NSDictionary *)trackingMetadata
+                                 resolve:(RCTPromiseResolveBlock)resolve
+                                  reject:(RCTPromiseRejectBlock)reject) {
     [RCCommonFunctionality pollRewardVerificationWithClientTransactionId:clientTransactionId
+                                                        trackingMetadata:trackingMetadata
                                                              completion:[self getResponseCompletionBlockWithResolve:resolve
                                                                                                              reject:reject]];
 }

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -7,6 +7,7 @@ import { validateAndTransform, isCustomerInfo, isPurchasesOfferings, isPurchases
 import { isExpoGo, isRorkSandbox } from '../utils/environment';
 import { ensurePurchasesConfigured, methodNotSupportedOnWeb } from './utils';
 import { purchaseSimulatedPackage } from './simulatedstore/purchaseSimulatedPackageHelper';
+import type { RewardedAdTrackingMetadata } from '../purchases';
 
 
 const packageVersion = '10.7.2';
@@ -366,7 +367,7 @@ export const browserNativeModuleRNPurchases = {
   generateRewardVerificationToken: async (_impressionId: string) => {
     methodNotSupportedOnWeb('generateRewardVerificationToken');
   },
-  pollRewardVerification: async (_clientTransactionId: string, _trackingMetadata?: any) => {
+  pollRewardVerification: async (_clientTransactionId: string, _trackingMetadata?: RewardedAdTrackingMetadata) => {
     methodNotSupportedOnWeb('pollRewardVerification');
   },
 };

--- a/src/browser/nativeModule.ts
+++ b/src/browser/nativeModule.ts
@@ -366,7 +366,7 @@ export const browserNativeModuleRNPurchases = {
   generateRewardVerificationToken: async (_impressionId: string) => {
     methodNotSupportedOnWeb('generateRewardVerificationToken');
   },
-  pollRewardVerification: async (_clientTransactionId: string) => {
+  pollRewardVerification: async (_clientTransactionId: string, _trackingMetadata?: any) => {
     methodNotSupportedOnWeb('pollRewardVerification');
   },
 };

--- a/src/purchases.ts
+++ b/src/purchases.ts
@@ -340,6 +340,20 @@ export interface RewardVerificationResult {
   failed: boolean;
 }
 
+/**
+ * Ad metadata for a rewarded ad, passed to {@link Purchases.pollRewardVerification}
+ * to have the SDK automatically track reward-verification events for it.
+ * @beta
+ */
+export interface RewardedAdTrackingMetadata {
+  mediatorName: AdMediatorName;
+  adFormat: AdFormat;
+  adUnitId: string;
+  impressionId: string;
+  networkName?: string | null;
+  placement?: string | null;
+}
+
 let debugEventListeners: DebugEventListener[] = [];
 
 eventEmitter?.addListener(
@@ -2167,14 +2181,21 @@ export default class Purchases {
    *
    * @param clientTransactionId - The `clientTransactionId` from
    *   {@link Purchases.generateRewardVerificationToken}.
+   * @param trackingMetadata - Pass to have the SDK automatically track
+   *   reward-verification events for the ad it belongs to; omit to poll
+   *   without tracking.
    * @returns {Promise<RewardVerificationResult>} promise with the verification result.
    * @beta
    */
   public static async pollRewardVerification(
-    clientTransactionId: string
+    clientTransactionId: string,
+    trackingMetadata?: RewardedAdTrackingMetadata
   ): Promise<RewardVerificationResult> {
     await throwIfNotConfigured();
-    return RNPurchases.pollRewardVerification(clientTransactionId);
+    return RNPurchases.pollRewardVerification(
+      clientTransactionId,
+      trackingMetadata
+    );
   }
 
   private static async throwIfAndroidPlatform() {


### PR DESCRIPTION
This change exposes the ad reward tracking functionality - which is just a new parameter for the polling function.

**Do** **not** **merge** until android and ios sdks are released with the feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native iOS/Android method signatures that depend on unreleased SDK support; a mismatch could break reward verification polling. Optional param is backward-compatible at the JS layer.
> 
> **Overview**
> Lets callers attach rewarded-ad metadata when polling reward verification so the SDK can auto-track those events.
> 
> Adds optional `trackingMetadata` (`RewardedAdTrackingMetadata`) to `Purchases.pollRewardVerification` and forwards it through iOS and Android native bridges (null-stripped on Android). Omitting it keeps the previous poll-only behavior. Web still reports the method as unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1d529ad43b80b60c41902cb263ce8199c0e658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->