### PR TITLE
chore(ios): drop dead Swift stubs and namespace React header imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,9 @@ react-native-purchases/
 │       ├── RNPurchasesConverters.kt
 │       ├── RNPurchasesPackage.java
 │       └── GoogleUpgradeInfo.java
-├── ios/                      # iOS native module (Obj-C/Swift)
-│   ├── RNPurchases.m
-│   └── PurchasesPlugin.swift
+├── ios/                      # iOS native module (Obj-C)
+│   ├── RNPurchases.h
+│   └── RNPurchases.m
 ├── __tests__/                # Jest test suites
 ├── examples/
 │   ├── MagicWeather/         # Complete example app
@@ -105,7 +105,7 @@ yarn prepare-expo
 1. **TypeScript Wrapper** (`src/purchases.ts`) — Type-safe public API
 2. **Native Bridge** (`PurchasesHybridCommon`) — iOS/Android hybrid mappings come from the corresponding PHC libraries
 3. **Native Modules**:
-   - iOS: `ios/RNPurchases.m`, `ios/PurchasesPlugin.swift`
+   - iOS: `ios/RNPurchases.m`
    - Android: `android/.../RNPurchasesModule.java`
 4. **Browser Fallback** (`src/browser/`) — For web/Expo Go/Rork Sandbox environments
 

--- a/ios/RNPurchases-Bridging-Header.h
+++ b/ios/RNPurchases-Bridging-Header.h
@@ -1,4 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-

--- a/ios/RNPurchases.xcodeproj/project.pbxproj
+++ b/ios/RNPurchases.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3552B97D252CF5900098008A /* PurchasesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3552B97C252CF5900098008A /* PurchasesPlugin.swift */; };
 		B3E7B58A1CC2AC0600A0062D /* RNPurchases.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNPurchases.m */; };
 /* End PBXBuildFile section */
 
@@ -25,8 +24,6 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNPurchases.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPurchases.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3552B97B252CF5900098008A /* RNPurchases-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNPurchases-Bridging-Header.h"; sourceTree = "<group>"; };
-		3552B97C252CF5900098008A /* PurchasesPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesPlugin.swift; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNPurchases.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPurchases.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNPurchases.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPurchases.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -60,12 +57,10 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-				3552B97C252CF5900098008A /* PurchasesPlugin.swift */,
 				B3E7B5881CC2AC0600A0062D /* RNPurchases.h */,
 				B3E7B5891CC2AC0600A0062D /* RNPurchases.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 				35493AC8202D4BCD004DFA39 /* Frameworks */,
-				3552B97B252CF5900098008A /* RNPurchases-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -129,7 +124,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* RNPurchases.m in Sources */,
-				3552B97D252CF5900098008A /* PurchasesPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,7 +230,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPurchases;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "RNPurchases-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
@@ -261,7 +254,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPurchases;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "RNPurchases-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/react-native-purchases-ui/ios/CustomerCenterViewWrapper.m
+++ b/react-native-purchases-ui/ios/CustomerCenterViewWrapper.m
@@ -6,7 +6,7 @@
 
 #import "CustomerCenterViewWrapper.h"
 #import "UIView+Extensions.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 @import RevenueCatUI;
 

--- a/react-native-purchases-ui/ios/PaywallViewWrapper.m
+++ b/react-native-purchases-ui/ios/PaywallViewWrapper.m
@@ -7,7 +7,7 @@
 
 #import "PaywallViewWrapper.h"
 #import "UIView+Extensions.h"
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 
 @import PurchasesHybridCommonUI;
 @import RevenueCat;

--- a/react-native-purchases-ui/ios/PurchasesPlugin.swift
+++ b/react-native-purchases-ui/ios/PurchasesPlugin.swift
@@ -1,9 +1,0 @@
-//
-//  PurchasesPlugin.swift
-//  RNPurchases
-//
-//  Created by César de la Vega  on 10/6/20.
-//  Copyright © 2020 Facebook. All rights reserved.
-//
-
-import Foundation

--- a/react-native-purchases-ui/ios/RNPaywalls-Bridging-Header.h
+++ b/react-native-purchases-ui/ios/RNPaywalls-Bridging-Header.h
@@ -1,4 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-

--- a/react-native-purchases-ui/ios/RNPaywalls.xcodeproj/project.pbxproj
+++ b/react-native-purchases-ui/ios/RNPaywalls.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		354FF7CD2B6423CB0050DDFD /* RNPaywalls.m in Sources */ = {isa = PBXBuildFile; fileRef = 354FF7C22B6423CB0050DDFD /* RNPaywalls.m */; };
 		354FF7CE2B6423CB0050DDFD /* RCPaywallFooterViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 354FF7C62B6423CB0050DDFD /* RCPaywallFooterViewManager.m */; };
 		354FF7CF2B6423CB0050DDFD /* PaywallViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 354FF7C72B6423CB0050DDFD /* PaywallViewManager.m */; };
-		354FF7D02B6423CB0050DDFD /* PurchasesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354FF7C92B6423CB0050DDFD /* PurchasesPlugin.swift */; };
 		354FF7D12B6423CB0050DDFD /* UIView+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 354FF7CA2B6423CB0050DDFD /* UIView+Extensions.m */; };
 /* End PBXBuildFile section */
 
@@ -29,17 +28,14 @@
 
 /* Begin PBXFileReference section */
 		354FF7B52B6422970050DDFD /* libRNPaywalls.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNPaywalls.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		354FF7BF2B6423CA0050DDFD /* RNPaywalls-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNPaywalls-Bridging-Header.h"; sourceTree = "<group>"; };
 		354FF7C02B6423CB0050DDFD /* RNPaywalls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPaywalls.h; sourceTree = "<group>"; };
 		354FF7C12B6423CB0050DDFD /* PaywallViewWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PaywallViewWrapper.m; sourceTree = "<group>"; };
 		354FF7C22B6423CB0050DDFD /* RNPaywalls.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPaywalls.m; sourceTree = "<group>"; };
-		354FF7C32B6423CB0050DDFD /* RNPaywalls-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RNPaywalls-Bridging-Header.h"; sourceTree = "<group>"; };
 		354FF7C42B6423CB0050DDFD /* PaywallViewWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaywallViewWrapper.h; sourceTree = "<group>"; };
 		354FF7C52B6423CB0050DDFD /* RCPaywallFooterViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCPaywallFooterViewManager.h; sourceTree = "<group>"; };
 		354FF7C62B6423CB0050DDFD /* RCPaywallFooterViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCPaywallFooterViewManager.m; sourceTree = "<group>"; };
 		354FF7C72B6423CB0050DDFD /* PaywallViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PaywallViewManager.m; sourceTree = "<group>"; };
 		354FF7C82B6423CB0050DDFD /* UIView+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Extensions.h"; sourceTree = "<group>"; };
-		354FF7C92B6423CB0050DDFD /* PurchasesPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesPlugin.swift; sourceTree = "<group>"; };
 		354FF7CA2B6423CB0050DDFD /* UIView+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Extensions.m"; sourceTree = "<group>"; };
 		354FF7CB2B6423CB0050DDFD /* PaywallViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaywallViewManager.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -62,16 +58,13 @@
 				354FF7C72B6423CB0050DDFD /* PaywallViewManager.m */,
 				354FF7C42B6423CB0050DDFD /* PaywallViewWrapper.h */,
 				354FF7C12B6423CB0050DDFD /* PaywallViewWrapper.m */,
-				354FF7C92B6423CB0050DDFD /* PurchasesPlugin.swift */,
 				354FF7C52B6423CB0050DDFD /* RCPaywallFooterViewManager.h */,
 				354FF7C62B6423CB0050DDFD /* RCPaywallFooterViewManager.m */,
-				354FF7C32B6423CB0050DDFD /* RNPaywalls-Bridging-Header.h */,
 				354FF7C02B6423CB0050DDFD /* RNPaywalls.h */,
 				354FF7C22B6423CB0050DDFD /* RNPaywalls.m */,
 				354FF7C82B6423CB0050DDFD /* UIView+Extensions.h */,
 				354FF7CA2B6423CB0050DDFD /* UIView+Extensions.m */,
 				354FF7B62B6422970050DDFD /* Products */,
-				354FF7BF2B6423CA0050DDFD /* RNPaywalls-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -145,7 +138,6 @@
 				354FF7CE2B6423CB0050DDFD /* RCPaywallFooterViewManager.m in Sources */,
 				354FF7CD2B6423CB0050DDFD /* RNPaywalls.m in Sources */,
 				354FF7CC2B6423CB0050DDFD /* PaywallViewWrapper.m in Sources */,
-				354FF7D02B6423CB0050DDFD /* PurchasesPlugin.swift in Sources */,
 				354FF7D12B6423CB0050DDFD /* UIView+Extensions.m in Sources */,
 				354FF7CF2B6423CB0050DDFD /* PaywallViewManager.m in Sources */,
 			);
@@ -281,7 +273,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "RNPaywalls-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -296,7 +287,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "RNPaywalls-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};


### PR DESCRIPTION
### Motivation
Small cleanup PR in preparation for adding SwiftPM support in #1907.

React Native 0.87 added experimental SwiftPM support for iOS. Its tooling refuses `react-native-purchases-ui` outright ("mixed Swift + Objective-C/C++ sources") solely because of an empty `PurchasesPlugin.swift` stub, and `#import "UIView+React.h"` only resolves through CocoaPods' header map.

### Summary

- The deleted Swift stubs and bridging headers are empty and nothing references them.
- `<React/UIView+React.h>` is the canonical spelling. `React-Core.podspec` sets `header_dir = "React"`, so CocoaPods resolves it identically.

### Notes

No behavior change, and no test changes: the affected code is Obj-C glue with no unit test coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and import-path cleanup with no purchase, auth, or JS API changes; intended behavior is unchanged under CocoaPods.
> 
> **Overview**
> Prepares the iOS native targets for upcoming SwiftPM work by removing unused Swift scaffolding and aligning React header imports with the canonical CocoaPods/SwiftPM spelling.
> 
> **Empty Swift removed:** Deletes stub `PurchasesPlugin.swift`, bridging headers, and Xcode references from `RNPurchases` and `react-native-purchases-ui` so the UI package is no longer classified as mixed Swift + Obj-C for RN 0.87’s experimental SwiftPM tooling. `AGENTS.md` now documents iOS as Obj-C only (`RNPurchases.h` / `RNPurchases.m`).
> 
> **React imports:** `CustomerCenterViewWrapper.m` and `PaywallViewWrapper.m` switch from `#import "UIView+React.h"` to `#import <React/UIView+React.h>`, matching `React-Core`’s `header_dir` and avoiding header-map-only resolution.
> 
> No runtime or public API changes; Obj-C glue only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e70858555514771eeeacdebc88466ff0a5e8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->