### PR TITLE
Update sdks-common-config orb to v4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   rn: react-native-community/react-native@8.0.1
   android: circleci/android@3.1.0
-  revenuecat: revenuecat/sdks-common-config@4.6.0
+  revenuecat: revenuecat/sdks-common-config@4.6.1
 
 aliases:
   release-tags: &release-tags


### PR DESCRIPTION
### Motivation

Keep CI on the latest shared orb release: [v4.6.1](https://github.com/RevenueCat/sdks-circleci-orb/releases/tag/v4.6.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration version pin only; no runtime or library behavior changes in the React Native SDK itself.
> 
> **Overview**
> Bumps the shared **RevenueCat CircleCI orb** `revenuecat/sdks-common-config` from **4.6.0** to **4.6.1** in `.circleci/config.yml`.
> 
> No job definitions, workflows, or application code change—only the orb pin used by existing `revenuecat/*` steps (mise, gems, release automation, Danger, Maestro, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08cd968a42d62bca62a783ba001a946738dc2d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->