### PR TITLE
[EXTERNAL] Fix RN interop mode crash for Paywalls (#1916) via @TheRogue76

### DIFF
--- a/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
+++ b/react-native-purchases-ui/android/src/main/java/com/revenuecat/purchases/react/ui/PaywallViewManager.kt
@@ -11,7 +11,7 @@ import com.revenuecat.purchases.ui.revenuecatui.fonts.CustomFontProvider
 internal class PaywallViewManager : BasePaywallViewManager<WrappedPaywallComposeView>() {
 
     companion object {
-        const val REACT_CLASS = "Paywall"
+        const val REACT_CLASS = "PaywallView"
     }
 
     override fun getName(): String {

--- a/react-native-purchases-ui/ios/PaywallViewManager.m
+++ b/react-native-purchases-ui/ios/PaywallViewManager.m
@@ -36,7 +36,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPerformRestore, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onWebCheckoutOpened, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onUrlOpened, RCTDirectEventBlock)
 
-RCT_EXPORT_MODULE(Paywall)
+RCT_EXPORT_MODULE(PaywallView)
 
 - (instancetype)init {
     if ((self = [super init])) {

--- a/react-native-purchases-ui/src/index.tsx
+++ b/react-native-purchases-ui/src/index.tsx
@@ -117,11 +117,11 @@ type NativeFooterPaywallViewProps = Omit<InternalFooterPaywallViewProps, 'option
   options?: WithNativeCustomVariables<FooterPaywallViewOptions>;
 };
 
-const NativePaywall = !usingPreviewAPIMode && UIManager.getViewManagerConfig('Paywall') != null
-  ? requireNativeComponent<NativeFullScreenPaywallViewProps>('Paywall')
+const NativePaywall = !usingPreviewAPIMode && UIManager.getViewManagerConfig('PaywallView') != null
+  ? requireNativeComponent<NativeFullScreenPaywallViewProps>('PaywallView')
   : null;
 
-const NativePaywallFooter = !usingPreviewAPIMode && UIManager.getViewManagerConfig('Paywall') != null
+const NativePaywallFooter = !usingPreviewAPIMode && UIManager.getViewManagerConfig('RCPaywallFooterView') != null
   ? requireNativeComponent<NativeFooterPaywallViewProps>('RCPaywallFooterView')
   : null;
 
@@ -410,7 +410,7 @@ type FullScreenPaywallViewProps = {
   onRestoreError?: ({error}: { error: PurchasesError }) => void;
   onDismiss?: () => void;
   onPurchasePackageInitiated?: ({
-    packageBeingPurchased, 
+    packageBeingPurchased,
     resume
   }: { packageBeingPurchased: PurchasesPackage, resume: (shouldResume: boolean) => void}) => void;
   onWebCheckoutOpened?: () => void;


### PR DESCRIPTION
Rename the export for Paywall so it also works for Fabric interop RN by standardizing the name, also fix paywall footer checking for wrong module before requiring (Was checking Paywall instead of it's own module's existance)
  
Fixes https://github.com/RevenueCat/react-native-purchases/issues/1886

It looks like React looks for the module name + "Manager". Our class is named "PaywallViewManager" but the module is "Paywall". So it's looking for "PaywallManager".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Native view manager name change can break apps that still look up
`Paywall`; otherwise a small interop/crash fix with no auth or data-handling impact.
> 
> **Overview**
> Fixes React Native Fabric interop crashes by renaming the native
paywall view manager from `Paywall` to `PaywallView` on Android and iOS, and matching that name in `requireNativeComponent`.
> 
> Also stops gating the footer native component on the full-screen
`Paywall` manager. It now checks `RCPaywallFooterView` before requiring it, so the footer can load independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit
c24247a498723ffc2fab2f2ea8bed6e491e3f8a1. Bugbot is set up for automated code reviews on this repo. Configure
[here](https://www.cursor.com/dashboard/bugbot).</sup> <!-- /CURSOR_SUMMARY -->