### PR TITLE
chore: don't run danger on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,6 +530,9 @@ workflows:
     jobs:
       - revenuecat/danger:
           ruby_version: "3.3.0"
+          filters:
+            branches:
+              ignore: main
 
   weekly-run-workflow:
     when:


### PR DESCRIPTION
Danger runs on every push to `main`, but there's no PR there for it to comment on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only branch filter change with no runtime or security impact.
> 
> **Overview**
> Stops the CircleCI **danger** workflow from running on pushes to **`main`**, while keeping it on feature and release branches.
> 
> Branch filters (`ignore: main`) are added on the `revenuecat/danger` job so CI no longer spends time on Danger when there is no open PR to comment on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52df4e4c1928e9e23ed14d804afa4015780a6383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->