### PR TITLE
[EXTERNAL] Fix build on AGP 9 by skipping kotlin-android when AGP registers the kotlin extension (#1934) via @gabrieldonadel

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,13 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying kotlin-android on top of it fails with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing
+// has registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: 'kotlin-android'
+}
 
 def getExtOrDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['Purchases_' + name]

--- a/react-native-purchases-ui/android/build.gradle
+++ b/react-native-purchases-ui/android/build.gradle
@@ -19,7 +19,13 @@ def isNewArchitectureEnabled() {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+// AGP 9 ships built-in Kotlin support and registers the `kotlin` extension
+// itself. Applying kotlin-android on top of it fails with
+// "Cannot add extension with name 'kotlin'". Only apply it when nothing
+// has registered that extension yet.
+if (project.extensions.findByName('kotlin') == null) {
+    apply plugin: "kotlin-android"
+}
 
 if (isNewArchitectureEnabled()) {
   apply plugin: "com.facebook.react"


### PR DESCRIPTION
External contribution from @gabrieldonadel, merged into this branch to run CI. Original PR: #1934

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gradle plugin wiring only; no runtime or security impact, with behavior unchanged on pre-AGP-9 toolchains.
> 
> **Overview**
> Fixes Android Gradle Plugin 9 builds that fail with **"Cannot add extension with name 'kotlin'"** when both AGP’s built-in Kotlin support and the `kotlin-android` plugin run together.
> 
> In **`android/build.gradle`** and **`react-native-purchases-ui/android/build.gradle`**, `kotlin-android` is no longer applied unconditionally. It is applied only when `project.extensions.findByName('kotlin')` is null, so older AGP setups still get the plugin while AGP 9 can rely on its own `kotlin` extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22131fce238493ac861d1243eff91541c9a9fae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->