### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that delegates to a pinned reusable workflow with no checkout of PR code and empty workflow permissions; main consideration is ensuring the shared workflow does not execute untrusted content.
> 
> **Overview**
> Adds a new GitHub Actions workflow **External PR Notifications** that runs when a pull request is **opened**, using **`pull_request_target`** so forked PRs can use repo secrets without running untrusted code from the PR branch.
> 
> The job is a thin wrapper around the shared **`revenuecat/sdk-github-workflows`** reusable workflow (pinned at **v7**), passing **`EXTERNAL_PR_SLACK_WEBHOOK_URL`** so opens from outside the org can post to an internal Slack feed. Workflow-level **`permissions: {}`** keeps the default **`GITHUB_TOKEN`** scoped down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03185000da0e62cf5781c5e0778464e3e991beea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->