### PR TITLE
[EXTERNAL] fix: prefix browser-mode detection logs with [RevenueCat]

### DIFF
--- a/__tests__/environment.test.ts
+++ b/__tests__/environment.test.ts
@@ -1,0 +1,72 @@
+import { NativeModules, Platform } from 'react-native';
+import { shouldUseBrowserMode } from '../src/utils/environment';
+
+describe('shouldUseBrowserMode logging', () => {
+  const originalOS = Platform.OS;
+  const originalRNPurchases = NativeModules.RNPurchases;
+  const originalRorkSandbox = NativeModules.RorkSandbox;
+  const originalExpo = globalThis.expo;
+
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    Platform.OS = originalOS;
+    NativeModules.RNPurchases = originalRNPurchases;
+    NativeModules.RorkSandbox = originalRorkSandbox;
+    globalThis.expo = originalExpo;
+  });
+
+  it('prefixes the web platform detection message with [RevenueCat]', () => {
+    Platform.OS = 'web';
+    NativeModules.RNPurchases = originalRNPurchases;
+    NativeModules.RorkSandbox = undefined;
+
+    const result = shouldUseBrowserMode();
+
+    expect(result).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[RevenueCat] Web platform detected. Using RevenueCat in Browser Mode.'
+    );
+  });
+
+  it('prefixes the Expo Go detection message with [RevenueCat]', () => {
+    NativeModules.RNPurchases = null;
+    NativeModules.RorkSandbox = undefined;
+    globalThis.expo = { modules: { ExpoGo: true } };
+
+    const result = shouldUseBrowserMode();
+
+    expect(result).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[RevenueCat] Expo Go app detected. Using RevenueCat in Browser Mode.'
+    );
+  });
+
+  it('prefixes the Rork sandbox detection message with [RevenueCat]', () => {
+    NativeModules.RorkSandbox = {};
+
+    const result = shouldUseBrowserMode();
+
+    expect(result).toBe(true);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[RevenueCat] Rork app detected. Using RevenueCat in Preview API Mode.'
+    );
+  });
+
+  it('does not log a browser-mode detection message on native platforms', () => {
+    Platform.OS = 'ios';
+    NativeModules.RNPurchases = originalRNPurchases;
+    NativeModules.RorkSandbox = undefined;
+    globalThis.expo = undefined;
+
+    const result = shouldUseBrowserMode();
+
+    expect(result).toBe(false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -9,13 +9,13 @@ import { NativeModules, Platform } from "react-native";
  */
 export function shouldUseBrowserMode(): boolean {
   if (isExpoGo()) {
-    console.log('Expo Go app detected. Using RevenueCat in Browser Mode.');
+    console.log('[RevenueCat] Expo Go app detected. Using RevenueCat in Browser Mode.');
     return true;
   } else if (isRorkSandbox()) {
-    console.log('Rork app detected. Using RevenueCat in Preview API Mode.');
+    console.log('[RevenueCat] Rork app detected. Using RevenueCat in Preview API Mode.');
     return true;
   } else if (isWebPlatform()) {
-    console.log('Web platform detected. Using RevenueCat in Browser Mode.');
+    console.log('[RevenueCat] Web platform detected. Using RevenueCat in Browser Mode.');
     return true;
   } else {
     return false;


### PR DESCRIPTION
Thank you for contributing to react-native-purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

Prefixes the three existing `console.log` calls in `shouldUseBrowserMode()` with `[RevenueCat]`. Other TypeScript logs from this package's default handler are tagged `[RevenueCat]`, so the unprefixed web / Expo Go / Rork detection line is hard to filter in a busy console. Detection is unchanged: the log still runs at module import, before `configure()`.

Prefix is `[RevenueCat]`, not `[purchases]`. The issue asked for `[purchases]` "as other messages." Native iOS `NSLog` and purchases-js use `[Purchases]` / `[purchases]`. `[RevenueCat]` is already the TypeScript log tag in this package (default log handler, `isConfigured()`, etc.).

The detection logs are not gated on `setLogLevel`. The issue asked whether this line should respect log level. Deferring until `configure()` / `setLogLevel()`, or dropping the log, would be a larger behavior change: the log runs at module import, before any log level exists.

Can switch the prefix, or defer or silence the log.

Unit tests in `__tests__/environment.test.ts` assert the prefixed strings for web, Expo Go, and Rork, and that native iOS does not log.

Fixes #1709.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic log-prefix change only; no change to environment detection or purchase flow.
> 
> **Overview**
> Prefixes the three **browser-mode detection** `console.log` lines in `shouldUseBrowserMode()` with **`[RevenueCat]`**, matching the rest of this package’s TypeScript logging so those messages are easier to filter in the console.
> 
> **Detection behavior is unchanged** (web, Expo Go, Rork, native); only log text changes. Adds **`__tests__/environment.test.ts`** to assert the prefixed messages and that native iOS does not log.
> 
> Fixes #1709.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f962274a8cac44907250255f61465a83db8ee20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->